### PR TITLE
[feat] 스테이지: 노래 재생 기능 추가HH-168)

### DIFF
--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,0 +1,63 @@
+import 'package:audio_session/audio_session.dart';
+import 'package:just_audio/just_audio.dart' as ja;
+
+class AudioPlayerUtil {
+  late AudioSession audioSession;
+  ja.AudioPlayer player = ja.AudioPlayer(
+      handleInterruptions: false,
+      androidApplyAudioAttributes: false,
+      handleAudioSessionActivation: false);
+
+  static final AudioPlayerUtil _instance = AudioPlayerUtil._internal();
+
+  factory AudioPlayerUtil() => _instance;
+
+  AudioPlayerUtil._internal() {
+    _audioSessionConfigure();
+  }
+
+  getPlaybackRn(String url) async {
+    await player.setUrl(url);
+    _handleInterruptions();
+  }
+
+  play() async {
+    // 내부 음악 실행
+    await player.play();
+    // 외부 음악 종료
+    await audioSession.setActive(true);
+  }
+
+  stop() async {
+    // 내부 음악 종료
+    await player.stop();
+    // 외부 음악 실행
+    await audioSession.setActive(false);
+  }
+
+  _handleInterruptions() async {
+    player.playing ? await player.stop() : await player.play();
+    await audioSession.setActive(player.playing);
+  }
+
+  // 외부 음악 들릴 때 반응 설정
+  _audioSessionConfigure() =>
+      AudioSession.instance.then((audioSession) async => await audioSession
+          .configure(const AudioSessionConfiguration(
+              avAudioSessionCategory: AVAudioSessionCategory.playback,
+              avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
+              avAudioSessionMode: AVAudioSessionMode.defaultMode,
+              avAudioSessionRouteSharingPolicy:
+                  AVAudioSessionRouteSharingPolicy.defaultPolicy,
+              avAudioSessionSetActiveOptions:
+                  AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
+              androidAudioAttributes: AndroidAudioAttributes(
+                contentType: AndroidAudioContentType.music,
+                flags: AndroidAudioFlags.none,
+                usage: AndroidAudioUsage.media,
+              ),
+              androidAudioFocusGainType:
+                  AndroidAudioFocusGainType.gainTransient,
+              androidWillPauseWhenDucked: true))
+          .then((_) => audioSession = audioSession));
+}

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -9,23 +9,29 @@ class AudioPlayerUtil {
 
   factory AudioPlayerUtil() => _instance;
 
-  var _musicUrl = "https://ccrma.stanford.edu/~jos/mp3/harpsi-cs.mp3";
-
   AudioPlayerUtil._internal() {
     _audioSessionConfigure();
+  }
+
+  // 노래 종료 후 실행할 함수 설정
+  setPlayerCompletion(
+      Function setIsSkeletonDetectStart, Function setIsMusicStart) {
     player.onPlayerCompletion.listen((event) {
-      print("mmm:노래 끝");
+      // 스켈레톤 추출 종료
+      setIsSkeletonDetectStart(false);
+      // 시작 버튼 검정색 텍스트로
+      setIsMusicStart(false);
     });
   }
 
-  setMusicUrl(String url) async {
-    await player.setUrl(url);
-    _musicUrl = url;
-  }
-
-  play() async {
+  play(String musicUrl, Function setIsSkeletonDetectStart,
+      Function setIsMusicStart) async {
     // 내부 음악 실행
-    await player.play(_musicUrl);
+    await player.play(musicUrl);
+    // 스켈레톤 추출 시작
+    setIsSkeletonDetectStart(true);
+    // 시작 버튼 빨간 텍스트로
+    setIsMusicStart(true);
     // 외부 음악 종료
     await audioSession.setActive(false);
   }

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -9,7 +9,7 @@ class AudioPlayerUtil {
 
   factory AudioPlayerUtil() => _instance;
 
-  var _musicUrl = "https://youtube.com/shorts/eTL30G_dbCE?feature=share";
+  var _musicUrl = "https://ccrma.stanford.edu/~jos/mp3/harpsi-cs.mp3";
 
   AudioPlayerUtil._internal() {
     _audioSessionConfigure();

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,43 +1,40 @@
 import 'package:audio_session/audio_session.dart';
-import 'package:just_audio/just_audio.dart' as ja;
+import 'package:audioplayers/audioplayers.dart';
 
 class AudioPlayerUtil {
   late AudioSession audioSession;
-  ja.AudioPlayer player = ja.AudioPlayer(
-      handleInterruptions: false,
-      androidApplyAudioAttributes: false,
-      handleAudioSessionActivation: false);
+  AudioPlayer player = AudioPlayer();
 
   static final AudioPlayerUtil _instance = AudioPlayerUtil._internal();
 
   factory AudioPlayerUtil() => _instance;
 
+  var _musicUrl = "https://youtube.com/shorts/eTL30G_dbCE?feature=share";
+
   AudioPlayerUtil._internal() {
     _audioSessionConfigure();
+    player.onPlayerCompletion.listen((event) {
+      print("mmm:노래 끝");
+    });
   }
 
-  getPlaybackRn(String url) async {
+  setMusicUrl(String url) async {
     await player.setUrl(url);
-    _handleInterruptions();
+    _musicUrl = url;
   }
 
   play() async {
     // 내부 음악 실행
-    await player.play();
+    await player.play(_musicUrl);
     // 외부 음악 종료
-    await audioSession.setActive(true);
+    await audioSession.setActive(false);
   }
 
   stop() async {
     // 내부 음악 종료
     await player.stop();
     // 외부 음악 실행
-    await audioSession.setActive(false);
-  }
-
-  _handleInterruptions() async {
-    player.playing ? await player.stop() : await player.play();
-    await audioSession.setActive(player.playing);
+    await audioSession.setActive(true);
   }
 
   // 외부 음악 들릴 때 반응 설정

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -5,6 +5,7 @@ import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_commons/google_mlkit_commons.dart';
+import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
 import 'package:pocket_pose/main.dart';
 
 class CameraView extends StatefulWidget {
@@ -40,6 +41,9 @@ class _CameraViewState extends State<CameraView> {
   // 버튼 텍스트 색깔
   Color startColor = Colors.black;
   Color endColor = Colors.black;
+  // 음악 텍스트 색깔
+  Color musicStartColor = Colors.black;
+  Color musicEndColor = Colors.black;
 
   @override
   void initState() {
@@ -69,6 +73,10 @@ class _CameraViewState extends State<CameraView> {
     if (_cameraIndex != -1) {
       _startLiveFeed();
     }
+
+    // 음악 초기화
+    AudioPlayerUtil()
+        .setMusicUrl('https://ccrma.stanford.edu/~jos/mp3/harpsi-cs.mp3');
   }
 
   @override
@@ -156,34 +164,64 @@ class _CameraViewState extends State<CameraView> {
                   : (maxZoomLevel - 1).toInt(),
             ),
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
+          Column(
             children: [
-              TextButton(
-                onPressed: () {
-                  debugPrint("start");
-                  setState(() {
-                    startColor = Colors.blue;
-                    endColor = Colors.black;
-                  });
-                  widget.setIsStarted(true);
-                },
-                child: Text("Start", style: TextStyle(color: startColor)),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        startColor = Colors.blue;
+                        endColor = Colors.black;
+                      });
+                      widget.setIsStarted(true);
+                    },
+                    child: Text("Start", style: TextStyle(color: startColor)),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      widget.setIsStarted(false);
+                      setState(() {
+                        startColor = Colors.black;
+                        endColor = Colors.blue;
+                      });
+                    },
+                    child: Text("End", style: TextStyle(color: endColor)),
+                  ),
+                ],
               ),
-              TextButton(
-                onPressed: () {
-                  debugPrint("end");
-                  widget.setIsStarted(false);
-                  setState(() {
-                    startColor = Colors.black;
-                    endColor = Colors.blue;
-                  });
-                },
-                child: Text("End", style: TextStyle(color: endColor)),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        musicStartColor = Colors.red;
+                        musicEndColor = Colors.black;
+                      });
+                      AudioPlayerUtil().play();
+                    },
+                    child: Text("MusicStart",
+                        style: TextStyle(color: musicStartColor)),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        musicStartColor = Colors.black;
+                        musicEndColor = Colors.red;
+                      });
+                      AudioPlayerUtil().stop();
+                    },
+                    child: Text("MusicEnd",
+                        style: TextStyle(color: musicEndColor)),
+                  ),
+                ],
               ),
             ],
-          ),
+          )
         ],
       ),
     );

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -113,10 +113,6 @@ class _CameraViewState extends State<CameraView> {
 
     final size = MediaQuery.of(context).size;
     // 화면 및 카메라 비율에 따른 스케일 계산
-    // 원문: calculate scale depending on screen and camera ratios
-    // this is actually size.aspectRatio / (1 / camera.aspectRatio)
-    // because camera preview size is received as landscape
-    // but we're calculating for portrait orientation
     var scale = size.aspectRatio * _controller!.value.aspectRatio;
 
     // to prevent scaling down, invert the value
@@ -183,19 +179,11 @@ class _CameraViewState extends State<CameraView> {
                     startColor = Colors.black;
                     endColor = Colors.blue;
                   });
-                  //debugPrint("mmm result: $inputMap");
                 },
                 child: Text("End", style: TextStyle(color: endColor)),
               ),
-              // if (_byteImage != null)
-              //   Image.memory(_byteImage!,
-              //       width: 100, height: 100, fit: BoxFit.fill),
             ],
           ),
-          // if (_byteImage != null)
-          //   Image.memory(_byteImage!, width: 100, height: 100),
-          // if (_byteImage != null)
-          //   Image(image: MemoryImage(_byteImage!), width: 100, height: 100),
         ],
       ),
     );

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -11,13 +11,13 @@ import 'package:pocket_pose/main.dart';
 class CameraView extends StatefulWidget {
   CameraView(
       {Key? key,
-      required this.setIsStarted,
+      required this.setIsSkeletonDetectStart,
       required this.customPaint,
       required this.onImage,
       this.initialDirection = CameraLensDirection.back})
       : super(key: key);
-  // start, end  버튼 트리거
-  Function setIsStarted;
+  // skeleton 트리거
+  Function setIsSkeletonDetectStart;
   // 스켈레톤을 그려주는 객체
   final CustomPaint? customPaint;
   // 이미지 받을 때마다 실행하는 함수
@@ -38,12 +38,8 @@ class _CameraViewState extends State<CameraView> {
   double zoomLevel = 0.0, minZoomLevel = 0.0, maxZoomLevel = 0.0;
   // 카메라 렌즈 변경 변수
   bool _changingCameraLens = false;
-  // 버튼 텍스트 색깔
-  Color startColor = Colors.black;
-  Color endColor = Colors.black;
-  // 음악 텍스트 색깔
-  Color musicStartColor = Colors.black;
-  Color musicEndColor = Colors.black;
+  // 음악 버튼 텍스트
+  bool isMusicStart = false;
 
   @override
   void initState() {
@@ -73,20 +69,21 @@ class _CameraViewState extends State<CameraView> {
     if (_cameraIndex != -1) {
       _startLiveFeed();
     }
-
-    // 음악 초기화
-    AudioPlayerUtil()
-        .setMusicUrl('https://ccrma.stanford.edu/~jos/mp3/harpsi-cs.mp3');
   }
 
   @override
   void dispose() {
     _stopLiveFeed();
+    AudioPlayerUtil().stop();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    // AudioPlayer 초기화
+    AudioPlayerUtil()
+        .setPlayerCompletion(widget.setIsSkeletonDetectStart, setIsMusicStart);
+
     return Scaffold(
       // 카메라 화면 보여주기 + 화면에서 실시간으로 포즈 추출
       body: _liveFeedBody(),
@@ -172,51 +169,18 @@ class _CameraViewState extends State<CameraView> {
                 children: [
                   TextButton(
                     onPressed: () {
-                      setState(() {
-                        startColor = Colors.blue;
-                        endColor = Colors.black;
-                      });
-                      widget.setIsStarted(true);
+                      if (!isMusicStart) {
+                        AudioPlayerUtil().play(
+                            "https://ccrma.stanford.edu/~jos/mp3/harpsi-cs.mp3",
+                            widget.setIsSkeletonDetectStart,
+                            setIsMusicStart);
+                      }
                     },
-                    child: Text("Start", style: TextStyle(color: startColor)),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      widget.setIsStarted(false);
-                      setState(() {
-                        startColor = Colors.black;
-                        endColor = Colors.blue;
-                      });
-                    },
-                    child: Text("End", style: TextStyle(color: endColor)),
-                  ),
-                ],
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TextButton(
-                    onPressed: () {
-                      setState(() {
-                        musicStartColor = Colors.red;
-                        musicEndColor = Colors.black;
-                      });
-                      AudioPlayerUtil().play();
-                    },
-                    child: Text("MusicStart",
-                        style: TextStyle(color: musicStartColor)),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      setState(() {
-                        musicStartColor = Colors.black;
-                        musicEndColor = Colors.red;
-                      });
-                      AudioPlayerUtil().stop();
-                    },
-                    child: Text("MusicEnd",
-                        style: TextStyle(color: musicEndColor)),
+                    child: Text(
+                      isMusicStart ? "~🎵~" : "▶️",
+                      style: TextStyle(
+                          color: isMusicStart ? Colors.red : Colors.black),
+                    ),
                   ),
                 ],
               ),
@@ -225,6 +189,12 @@ class _CameraViewState extends State<CameraView> {
         ],
       ),
     );
+  }
+
+  setIsMusicStart(bool value) {
+    setState(() {
+      isMusicStart = value;
+    });
   }
 
   // 실시간으로 카메라에서 이미지 받기(비동기적)

--- a/lib/ui/view/ml_kit_pose_detector_view.dart
+++ b/lib/ui/view/ml_kit_pose_detector_view.dart
@@ -38,7 +38,7 @@ class _PoseDetectorViewState extends State<PoseDetectorView> {
   Widget build(BuildContext context) {
     // 카메라뷰 보이기
     return CameraView(
-      setIsStarted: setIsStarted,
+      setIsSkeletonDetectStart: setIsStarted,
       // 스켈레톤 그려주는 객체 전달
       customPaint: _customPaint,
       // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,13 @@ import FlutterMacOS
 import Foundation
 
 import audio_session
+import audioplayers
 import just_audio
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  AudioplayersPlugin.register(with: registry.registrar(forPlugin: "AudioplayersPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import audio_session
+import just_audio
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,10 @@ import Foundation
 
 import audio_session
 import audioplayers
-import just_audio
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersPlugin.register(with: registry.registrar(forPlugin: "AudioplayersPlugin"))
-  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -256,30 +256,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
-  just_audio:
-    dependency: "direct main"
-    description:
-      name: just_audio
-      sha256: "890cd0fc41a1a4530c171e375a2a3fb6a09d84e9d508c5195f40bcff54330327"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.34"
-  just_audio_platform_interface:
-    dependency: transitive
-    description:
-      name: just_audio_platform_interface
-      sha256: d8409da198bbc59426cd45d4c92fca522a2ec269b576ce29459d6d6fcaeb44df
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.1"
-  just_audio_web:
-    dependency: transitive
-    description:
-      name: just_audio_web
-      sha256: ff62f733f437b25a0ff590f0e295fa5441dcb465f1edbdb33b3dea264705bc13
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.8"
   lints:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.15"
+  audioplayers:
+    dependency: "direct main"
+    description:
+      name: audioplayers
+      sha256: a565e7e3e8a21a823b8cd7fed0bde1eb3796a96b373374be557adecfb511fa6b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.10.0"
+  audio_session:
+    dependency: "direct main"
+    description:
+      name: audio_session
+      sha256: "655343841a723646f74932215c5785ef7156b76d2de4b99bcd3205476f08dc61"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.15"
   boolean_selector:
     dependency: transitive
     description:
@@ -105,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.3+4"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -129,6 +145,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -216,6 +248,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: "890cd0fc41a1a4530c171e375a2a3fb6a09d84e9d508c5195f40bcff54330327"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.34"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: d8409da198bbc59426cd45d4c92fca522a2ec269b576ce29459d6d6fcaeb44df
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: ff62f733f437b25a0ff590f0e295fa5441dcb465f1edbdb33b3dea264705bc13
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.8"
   lints:
     dependency: transitive
     description:
@@ -264,6 +320,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "3087813781ab814e4157b172f1a11c46be20179fcc9bea043e0fba36bc0acaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.15"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.27"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "1995d88ec2948dac43edf8fe58eb434d35d22a2940ecee1a9fefcd62beee6eb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: ffbb8cc9ed2c9ec0e4b7a541e56fd79b138e8f47d2fb86815f15358a349b3b57
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.11"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.6"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: d3f80b32e83ec208ac95253e0cd4d298e104fbc63cb29c5c69edaed43b0c69d6
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
   petitparser:
     dependency: transitive
     description:
@@ -272,6 +376,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -280,6 +392,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.4"
   quiver:
     dependency: transitive
     description:
@@ -288,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -357,6 +485,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   vector_graphics:
     dependency: transitive
     description:
@@ -389,6 +525,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.4"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   dio: ^5.0.3
   audio_session: ^0.1.15
   just_audio: ^0.9.34
+  audioplayers: ^0.20.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   http: ^0.13.5
   dio: ^5.0.3
   audio_session: ^0.1.15
-  just_audio: ^0.9.34
   audioplayers: ^0.20.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   camera: ^0.10.4
   http: ^0.13.5
   dio: ^5.0.3
+  audio_session: ^0.1.15
+  just_audio: ^0.9.34
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/7517f0a0-0b1d-4612-9683-54cb77d20c27" width="30%">
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/69d57b8c-efa7-4207-af47-7d2948fd0b5f" width="30%">

## 💬 작업 설명
1. 포포 스테이지 ▶️ 화면: ▶️버튼을 누르면 노래가 시작되고 스켈레톤 추출을 시작합니다.
2. 포포 스테이지 ~🎵~화면: 노래가 재생중인 화면입니다. 이때 버튼을 눌러도 아무 변화가 없습니다. 노래가 끝나면 몇 초 뒤 정확도 값이 토스트로 보여지고, 자동으로 ▶️로 변경됩니다.

## ✅ 한 일
1. 시작 버튼(▶️) 누르면 노래 시작 + 스켈레톤 추출
2. 노래 재생 중엔 ~🎵~  보임
3. 노래 종료 후 정확도 토스트로 출력 + ▶️버튼으로 변경 

## ☝️ 참고 하세요~
1. 지금 재생되는 노래는 예시 노래로, 길이가 18초인 노래입니다. (https://ccrma.stanford.edu/~jos/mp3/harpsi-cs.mp3)
2. 노래 종료 후 정확도 값 토스트가 띄워지지 않는다면 ai 서버가 실행 중이 맞는지 확인해주세요.

## 🤓 다음에 할 일
1. 시연 때 보일 노래 url로 변경 + 또는 서버에서 노래를 받을 수 있는 api 개발이 된다면 api 연결
2. 스테이지 노래 재생 전에 3초 기다리기
3. ui 꾸미기
