### PR TITLE
[feat] 화면에 보이는 스켈레톤을 커스텀 (HH-171)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -3,4 +3,5 @@ import 'package:flutter/material.dart';
 
 class AppColor {
   static Color mainPurpleColor = const Color(0xFF565CEA);
+  static Color mintNeonColor = const Color.fromARGB(255, 104, 250, 241);
 }

--- a/lib/config/ml_kit/custom_pose_painter.dart
+++ b/lib/config/ml_kit/custom_pose_painter.dart
@@ -2,6 +2,7 @@
 // translateX, translateY를 사용해 추출된 좌표를 휴대폰 화면 크기에 맞게 변형하여 그려줌
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/coordinates_translator.dart';
 
 class CustomPosePainter extends CustomPainter {
@@ -16,36 +17,30 @@ class CustomPosePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // 초록: 33개의 관절 포인트(랜드마크) 색깔
-    final paint = Paint()
+    // Outer 네온 효과
+    final neonOuterPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 8.0
+      ..strokeCap = StrokeCap.round
+      ..color = AppColor.mintNeonColor
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3.0);
+
+    // Inner 네온 효과
+    final neonInnerPaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = 4.0
-      ..color = Colors.green;
+      ..strokeCap = StrokeCap.round
+      ..color = AppColor.mintNeonColor
+      ..maskFilter = const MaskFilter.blur(BlurStyle.inner, 2.0);
 
-    // 노랑: 왼쪽 선 색깔(왼팔~왼다리)
-    final leftPaint = Paint()
+    // 기본 라인
+    final paint = Paint()
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 3.0
-      ..color = Colors.yellow;
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round // 끝을 둥글게
+      ..color = Colors.white;
 
-    // 초록: 오른쪽 선 색깔(오른팔~오른다리)
-    final rightPaint = Paint()
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 3.0
-      ..color = Colors.blueAccent;
-
-    // 추출된 관절 포인트 갯수만큼 점 그리기
     for (final pose in poses) {
-      pose.landmarks.forEach((_, landmark) {
-        canvas.drawCircle(
-            Offset(
-              translateX(landmark.x, rotation, size, absoluteImageSize),
-              translateY(landmark.y, rotation, size, absoluteImageSize),
-            ),
-            1,
-            paint);
-      });
-
       // 점1과 점2를 선으로 이어주는 함수(랜드마크 타입1, 랜드마크 타입2, 선 색깔 타입)
       void paintLine(
           PoseLandmarkType type1, PoseLandmarkType type2, Paint paintType) {
@@ -59,30 +54,107 @@ class CustomPosePainter extends CustomPainter {
             paintType);
       }
 
+      // 점 1과 점 2를 네온 선으로 이어주는 함수(랜드마크 타입1, 랜드마크 타입2, 선 색깔 타입)
+      // 네온은 총 3번 그려야한다.
+      void paintNeonLine(
+          PoseLandmarkType type1, PoseLandmarkType type2, Paint paintType) {
+        paintLine(type1, type2, neonOuterPaint);
+        paintLine(type1, type2, neonInnerPaint);
+        paintLine(type1, type2, paintType);
+      }
+
       //Draw arms
-      paintLine(
-          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftElbow, leftPaint);
-      paintLine(
-          PoseLandmarkType.leftElbow, PoseLandmarkType.leftWrist, leftPaint);
-      paintLine(PoseLandmarkType.rightShoulder, PoseLandmarkType.rightElbow,
-          rightPaint);
-      paintLine(
-          PoseLandmarkType.rightElbow, PoseLandmarkType.rightWrist, rightPaint);
+      paintNeonLine(
+          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftElbow, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftElbow, PoseLandmarkType.leftWrist, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightShoulder, PoseLandmarkType.rightElbow, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightElbow, PoseLandmarkType.rightWrist, paint);
+
+      //Draw hands
+      paintNeonLine(
+          PoseLandmarkType.leftThumb, PoseLandmarkType.leftWrist, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftWrist, PoseLandmarkType.leftPinky, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftPinky, PoseLandmarkType.leftIndex, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftIndex, PoseLandmarkType.leftWrist, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightThumb, PoseLandmarkType.rightWrist, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightWrist, PoseLandmarkType.rightPinky, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightPinky, PoseLandmarkType.rightIndex, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightIndex, PoseLandmarkType.rightWrist, paint);
+
+      //Draw foots
+      paintNeonLine(
+          PoseLandmarkType.leftAnkle, PoseLandmarkType.leftFootIndex, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftFootIndex, PoseLandmarkType.leftHeel, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftHeel, PoseLandmarkType.leftAnkle, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightAnkle, PoseLandmarkType.rightFootIndex, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightFootIndex, PoseLandmarkType.rightHeel, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightHeel, PoseLandmarkType.rightAnkle, paint);
 
       //Draw Body
-      paintLine(
-          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftHip, leftPaint);
-      paintLine(PoseLandmarkType.rightShoulder, PoseLandmarkType.rightHip,
-          rightPaint);
+      paintNeonLine(
+          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftHip, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightShoulder, PoseLandmarkType.rightHip, paint);
 
       //Draw legs
-      paintLine(PoseLandmarkType.leftHip, PoseLandmarkType.leftKnee, leftPaint);
-      paintLine(
-          PoseLandmarkType.leftKnee, PoseLandmarkType.leftAnkle, leftPaint);
-      paintLine(
-          PoseLandmarkType.rightHip, PoseLandmarkType.rightKnee, rightPaint);
-      paintLine(
-          PoseLandmarkType.rightKnee, PoseLandmarkType.rightAnkle, rightPaint);
+      paintNeonLine(PoseLandmarkType.leftHip, PoseLandmarkType.leftKnee, paint);
+      paintNeonLine(
+          PoseLandmarkType.leftKnee, PoseLandmarkType.leftAnkle, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightHip, PoseLandmarkType.rightKnee, paint);
+      paintNeonLine(
+          PoseLandmarkType.rightKnee, PoseLandmarkType.rightAnkle, paint);
+
+      //Draw connect body
+      paintNeonLine(
+          PoseLandmarkType.leftShoulder, PoseLandmarkType.rightShoulder, paint);
+      paintNeonLine(PoseLandmarkType.leftHip, PoseLandmarkType.rightHip, paint);
+
+      // Draw face
+      final noseLandmark = pose.landmarks[PoseLandmarkType.nose];
+      final leftEyeLandmark = pose.landmarks[PoseLandmarkType.leftEye];
+      final rightEyeLandmark = pose.landmarks[PoseLandmarkType.rightEye];
+
+      if (noseLandmark != null &&
+          leftEyeLandmark != null &&
+          rightEyeLandmark != null) {
+        final nosePoint = Offset(
+          translateX(noseLandmark.x, rotation, size, absoluteImageSize),
+          translateY(noseLandmark.y, rotation, size, absoluteImageSize),
+        );
+        final leftEyePoint = Offset(
+          translateX(leftEyeLandmark.x, rotation, size, absoluteImageSize),
+          translateY(leftEyeLandmark.y, rotation, size, absoluteImageSize),
+        );
+        final rightEyePoint = Offset(
+          translateX(rightEyeLandmark.x, rotation, size, absoluteImageSize),
+          translateY(rightEyeLandmark.y, rotation, size, absoluteImageSize),
+        );
+
+        // Calculate face radius
+        final eyeDistance = leftEyePoint.dx - rightEyePoint.dx;
+        final faceRadius = eyeDistance * 1.5;
+
+        // Draw face circle
+        canvas.drawCircle(nosePoint, faceRadius, neonOuterPaint);
+        canvas.drawCircle(nosePoint, faceRadius, neonInnerPaint);
+        canvas.drawCircle(nosePoint, faceRadius, paint);
+      }
     }
   }
 

--- a/lib/config/ml_kit/custom_pose_painter.dart
+++ b/lib/config/ml_kit/custom_pose_painter.dart
@@ -1,0 +1,94 @@
+// 스켈레톤을 화면에 그려주는 클래스(추출된 포즈의 관절 랜드마크 배열, 이미지 크기, 이미지 회전 정보)
+// translateX, translateY를 사용해 추출된 좌표를 휴대폰 화면 크기에 맞게 변형하여 그려줌
+import 'package:flutter/material.dart';
+import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'package:pocket_pose/config/ml_kit/coordinates_translator.dart';
+
+class CustomPosePainter extends CustomPainter {
+  CustomPosePainter(this.poses, this.absoluteImageSize, this.rotation);
+
+  // 추출된 포즈의 랜드마크 리스트
+  final List<Pose> poses;
+  // 이미지 크기
+  final Size absoluteImageSize;
+  // 이미지 회전 정보
+  final InputImageRotation rotation;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // 초록: 33개의 관절 포인트(랜드마크) 색깔
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 4.0
+      ..color = Colors.green;
+
+    // 노랑: 왼쪽 선 색깔(왼팔~왼다리)
+    final leftPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3.0
+      ..color = Colors.yellow;
+
+    // 초록: 오른쪽 선 색깔(오른팔~오른다리)
+    final rightPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3.0
+      ..color = Colors.blueAccent;
+
+    // 추출된 관절 포인트 갯수만큼 점 그리기
+    for (final pose in poses) {
+      pose.landmarks.forEach((_, landmark) {
+        canvas.drawCircle(
+            Offset(
+              translateX(landmark.x, rotation, size, absoluteImageSize),
+              translateY(landmark.y, rotation, size, absoluteImageSize),
+            ),
+            1,
+            paint);
+      });
+
+      // 점1과 점2를 선으로 이어주는 함수(랜드마크 타입1, 랜드마크 타입2, 선 색깔 타입)
+      void paintLine(
+          PoseLandmarkType type1, PoseLandmarkType type2, Paint paintType) {
+        final PoseLandmark joint1 = pose.landmarks[type1]!;
+        final PoseLandmark joint2 = pose.landmarks[type2]!;
+        canvas.drawLine(
+            Offset(translateX(joint1.x, rotation, size, absoluteImageSize),
+                translateY(joint1.y, rotation, size, absoluteImageSize)),
+            Offset(translateX(joint2.x, rotation, size, absoluteImageSize),
+                translateY(joint2.y, rotation, size, absoluteImageSize)),
+            paintType);
+      }
+
+      //Draw arms
+      paintLine(
+          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftElbow, leftPaint);
+      paintLine(
+          PoseLandmarkType.leftElbow, PoseLandmarkType.leftWrist, leftPaint);
+      paintLine(PoseLandmarkType.rightShoulder, PoseLandmarkType.rightElbow,
+          rightPaint);
+      paintLine(
+          PoseLandmarkType.rightElbow, PoseLandmarkType.rightWrist, rightPaint);
+
+      //Draw Body
+      paintLine(
+          PoseLandmarkType.leftShoulder, PoseLandmarkType.leftHip, leftPaint);
+      paintLine(PoseLandmarkType.rightShoulder, PoseLandmarkType.rightHip,
+          rightPaint);
+
+      //Draw legs
+      paintLine(PoseLandmarkType.leftHip, PoseLandmarkType.leftKnee, leftPaint);
+      paintLine(
+          PoseLandmarkType.leftKnee, PoseLandmarkType.leftAnkle, leftPaint);
+      paintLine(
+          PoseLandmarkType.rightHip, PoseLandmarkType.rightKnee, rightPaint);
+      paintLine(
+          PoseLandmarkType.rightKnee, PoseLandmarkType.rightAnkle, rightPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPosePainter oldDelegate) {
+    return oldDelegate.absoluteImageSize != absoluteImageSize ||
+        oldDelegate.poses != poses;
+  }
+}

--- a/lib/ui/screen/profile_screen.dart
+++ b/lib/ui/screen/profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pocket_pose/ui/view/skeleton_custom_view.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -7,10 +8,7 @@ class ProfileScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Scaffold(
       backgroundColor: Colors.lightBlue,
-      body: Text(
-        "profile",
-        style: TextStyle(color: Colors.white, fontSize: 50),
-      ),
+      body: SkeletonCutomView(),
     );
   }
 }

--- a/lib/ui/view/skeleton_custom_view.dart
+++ b/lib/ui/view/skeleton_custom_view.dart
@@ -68,6 +68,7 @@ class _SkeletonCutomViewState extends State<SkeletonCutomView> {
     // 이미지가 정상적이면 포즈에 스켈레톤 그려주기
     if (inputImage.inputImageData?.size != null &&
         inputImage.inputImageData?.imageRotation != null) {
+      // 여기만 2개만 수정 ! PosePainter -> CustomPosePainter
       final painter = CustomPosePainter(poses, inputImage.inputImageData!.size,
           inputImage.inputImageData!.imageRotation);
       _customPaint = CustomPaint(painter: painter);

--- a/lib/ui/view/skeleton_custom_view.dart
+++ b/lib/ui/view/skeleton_custom_view.dart
@@ -1,0 +1,134 @@
+// 카메라에서 스켈레톤 추출하는 화면
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'package:pocket_pose/config/ml_kit/custom_pose_painter.dart';
+import 'package:pocket_pose/data/remote/provider/popo_skeleton_provider_impl.dart';
+import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
+
+class SkeletonCutomView extends StatefulWidget {
+  const SkeletonCutomView({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _SkeletonCutomViewState();
+}
+
+class _SkeletonCutomViewState extends State<SkeletonCutomView> {
+  // 스켈레톤 추출 변수 선언(google_mlkit_pose_detection 라이브러리)
+  final PoseDetector _poseDetector =
+      PoseDetector(options: PoseDetectorOptions());
+  bool _canProcess = true;
+  bool _isBusy = false;
+  // 스켈레톤 모양을 그려주는 변수
+  CustomPaint? _customPaint;
+  // start, end btn trigger
+  bool _isStarted = false;
+  // input Lists
+  final List<List<double>> _inputLists = [];
+  final _provider = PoPoSkeletonProviderImpl();
+
+  @override
+  void dispose() async {
+    _canProcess = false;
+    _poseDetector.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 카메라뷰 보이기
+    return
+        // const Image(image: 'assets/icons/bottom_popo.svg')
+        CameraView(
+      setIsSkeletonDetectStart: setIsStarted,
+      // 스켈레톤 그려주는 객체 전달
+      customPaint: _customPaint,
+      // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
+      onImage: (inputImage) {
+        // start 버튼 눌렀을 때만 스켈레톤 추출
+        if (_isStarted) {
+          processImage(inputImage);
+        }
+      },
+    );
+  }
+
+  // 카메라에서 실시간으로 받아온 이미지 처리: 이미지에 포즈가 추출되었으면 스켈레톤 그려주기
+  Future<void> processImage(InputImage inputImage) async {
+    if (!_canProcess) return;
+    if (_isBusy) return;
+    _isBusy = true;
+    // poseDetector에서 추출된 포즈 가져오기
+    List<Pose> poses = await _poseDetector.processImage(inputImage);
+
+    for (final pose in poses) {
+      _inputLists.add(_poseMapToInputList(pose.landmarks));
+    }
+
+    // 이미지가 정상적이면 포즈에 스켈레톤 그려주기
+    if (inputImage.inputImageData?.size != null &&
+        inputImage.inputImageData?.imageRotation != null) {
+      final painter = CustomPosePainter(poses, inputImage.inputImageData!.size,
+          inputImage.inputImageData!.imageRotation);
+      _customPaint = CustomPaint(painter: painter);
+    } else {
+      // 추출된 포즈 없음
+      _customPaint = null;
+    }
+    _isBusy = false;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void setIsStarted(bool bool) async {
+    setState(() {
+      _isStarted = bool;
+
+      if (!_isStarted) {
+        _provider
+            .postSkeletonList(_inputLists)
+            .then((value) => Fluttertoast.showToast(
+                  msg: value.toString(),
+                  toastLength: Toast.LENGTH_SHORT,
+                  timeInSecForIosWeb: 1,
+                  backgroundColor: Colors.black,
+                  textColor: Colors.white,
+                  fontSize: 16.0,
+                ))
+            .then((value) => _inputLists.clear());
+      }
+    });
+  }
+
+  List<double> _poseMapToInputList(Map<PoseLandmarkType, PoseLandmark> entry) {
+    return [
+      entry[PoseLandmarkType.nose]!.x,
+      entry[PoseLandmarkType.nose]!.y,
+      entry[PoseLandmarkType.rightShoulder]!.x,
+      entry[PoseLandmarkType.rightShoulder]!.y,
+      entry[PoseLandmarkType.rightElbow]!.x,
+      entry[PoseLandmarkType.rightElbow]!.y,
+      entry[PoseLandmarkType.rightWrist]!.x,
+      entry[PoseLandmarkType.rightWrist]!.y,
+      entry[PoseLandmarkType.leftShoulder]!.x,
+      entry[PoseLandmarkType.leftShoulder]!.y,
+      entry[PoseLandmarkType.leftElbow]!.x,
+      entry[PoseLandmarkType.leftElbow]!.y,
+      entry[PoseLandmarkType.leftWrist]!.x,
+      entry[PoseLandmarkType.leftWrist]!.y,
+      entry[PoseLandmarkType.rightHip]!.x,
+      entry[PoseLandmarkType.rightHip]!.y,
+      entry[PoseLandmarkType.rightKnee]!.x,
+      entry[PoseLandmarkType.rightKnee]!.y,
+      entry[PoseLandmarkType.rightAnkle]!.x,
+      entry[PoseLandmarkType.rightAnkle]!.y,
+      entry[PoseLandmarkType.leftHip]!.x,
+      entry[PoseLandmarkType.leftHip]!.y,
+      entry[PoseLandmarkType.leftKnee]!.x,
+      entry[PoseLandmarkType.leftKnee]!.y,
+      entry[PoseLandmarkType.leftAnkle]!.x,
+      entry[PoseLandmarkType.leftAnkle]!.y
+    ];
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   audio_session:
     dependency: "direct main"
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cross_file:
     dependency: transitive
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -284,18 +284,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -457,10 +457,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
@@ -534,5 +534,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.19.5 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ flutter:
   assets:
     - assets/
     - assets/icons/
+    - assets/images/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/4b642356-6bc1-49da-9a55-f4e8b9484160


## 💬 작업 설명
영상 속 사람으로부터 추출한 관절 값으로 그린 스켈레톤 그림을 커스텀 했습니다.


## ✅ 한 일
### 1차 작업본
- 작업 전 원본
<img width="300" alt="1차 스켈레톤" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/ab6871af-a638-40f5-828f-6ad2355656f6">


### 2차 작업본
- 그림 샘플을 참고하여 네온 느낌을 냄
- 라인의 type을 round로 하여 조금 더 부드러운 느낌을 줌
<img width="300" alt="2차 스켈레톤_neon 적용" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/cfdafc51-2f39-4e1d-b043-c18096412808">

<img width="200" alt="네온 샘플1" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/ff56981f-119f-466a-96ac-c6d10852a463">
<img width="200" alt="네온 샘플2" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/2fe66727-bb9b-411e-bdc5-a553a64636c1">



### 3차 작업본
- 미디어 파이프의 관절값을 이용해 그림을 그림
- 각 관절 값의 점은 그리지 않음
<img width="300" alt="3차 스켈레톤_neon 적용" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/4762fbbe-878c-4f5f-80af-a8d6f0ed835b">


### 4차 작업본
- 코와 눈 좌표를 활용해 얼굴 그림

https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/62861c5f-beab-4a38-99fa-a1e638dd7252



## ☝️ 참고 하세요~
1. 민영언니 코드랑 겹칠까봐 바텀 네비 오른쪽에 있는 프로필(profile_screen)에 코드 작성했습니다.
2. 민영언니가 이전에 미리 만들었던 영상 찍는 화면, 스켈레톤 뽑는 코드가 적힌 파일을 활용해야했는데, 마찬가지로 겹칠까봐 건들지 않고 아예 새로 복사붙여넣기 한 파일을 만들어서 수정했습니다.

나중에 하나로 합칩시다~!

[민영]lib\ui\view\ml_kit_pose_detector_view.dart -> [서연]skeleton_custom_view.dart 
[민영]lib\config\ml_kit\pose_painter.dart -> [서연]custom_pose_painter.dart

3. 네온 색은 피그마에서 그렸던 대로 일단 민트로 했는데, 나중에 변경하고 싶으면 이야기 해주세요~!


## 💃 부탁 드립니다~
1. 애뮬레이터로 했을 땐 관절값 추출이 상당히 느린데.. 기기에서 실행했을 땐 어떤지 봐주세요~


## 🤓 다음에 할 일
1. 카카오 로그인
2.  앱 입장 시 화면 봐줄만하게 디자인
