### PR TITLE
[bug] #7 이후 홈 화면 오류 수정 및 비디오 재생 기능 보완(HH-176)

### DIFF
--- a/lib/data/local/provider/info_local_provider.dart
+++ b/lib/data/local/provider/info_local_provider.dart
@@ -1,1 +1,0 @@
-// local service를 사용하는 provider를 정의합니다.

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -52,6 +52,8 @@ class VideoPlayProvider with ChangeNotifier {
     '최애의 완소 퍼펙트 반장❤️ #최애의아이',
   ];
 
+  int currentIndex = 0;
+
   void loadVideo() {
     // 모든 비디오 로드
     controllers = List<VideoPlayerController>.generate(
@@ -61,7 +63,7 @@ class VideoPlayProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  void setVideo(int currentIndex) {
+  void setVideo() {
     // 비디오 기본 값 설정
     controllers[currentIndex].play(); // 재생되는 상태
     controllers[currentIndex].setLooping(true); // 영상 무한 반복
@@ -70,12 +72,25 @@ class VideoPlayProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  void pauseVideo() {
+    controllers[currentIndex].pause();
+    // for (int i = 0; i < videoLinks.length; i++) {
+    //   controllers[i].pause();
+    // }
+  }
+
+  void playVideo() {
+    controllers[currentIndex].play();
+    // for (int i = 0; i < videoLinks.length; i++) {
+    //   controllers[i].pause();
+    // }
+  }
+
   void disposeVideoController() {
     // 자원을 반환하기 위해 VideoPlayerController dispose.
-    for (int i = 0; i < videoLinks.length; i++) {
-      controllers[i].dispose();
-    }
-
+    // for (int i = 0; i < videoLinks.length; i++) {
+    //   controllers[i].dispose();
+    // }
     notifyListeners();
   }
 }

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class VideoPlayProvider with ChangeNotifier {
+  late List<VideoPlayerController> _videoControllers;
+
+  List<String> videoLinks = [
+    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
+    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-4.mp4',
+    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-5.mp4',
+    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-3.mp4',
+    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-1.mp4',
+  ];
+
+  List<String> likes = [
+    '6.6천',
+    '1만',
+    '9.2만',
+    '9.4천',
+    '2.8만',
+  ];
+
+  List<String> chats = [
+    '110',
+    '282',
+    '1.2천',
+    '230',
+    '437',
+  ];
+
+  List<String> profiles = [
+    'assets/images/home_profile_1.jpg',
+    'assets/images/home_profile_2.jpg',
+    'assets/images/home_profile_3.jpg',
+    'assets/images/home_profile_4.jpg',
+    'assets/images/home_profile_5.jpg',
+  ];
+
+  List<String> nicknames = [
+    '@okoi2202',
+    '@ONEUS',
+    '@joyseoworld',
+    '@yunamong_',
+    '@hyezz',
+  ];
+
+  List<String> contents = [
+    '나이트댄서 춤 댄스챌린지 🌸🤍 | 가사 발음 포함 버전',
+    '늦었지만 토카토카 댄스!! (난 추고 본적 없음) #원어스 #ONEUS #서호',
+    '띵띵땅땅 이 노래 가사가 이런 뜻이었어...',
+    '요즘 난리난 챌린지 #아디아디챌린지 #아디아디아디 #dance #dancevideo #tiktok #reels #chellenge #fyp #dancechallenge #korea',
+    '최애의 완소 퍼펙트 반장❤️ #최애의아이',
+  ];
+
+  int currentIndex = 0;
+
+  void loadVideo() {
+    // 모든 비디오 로드
+    _videoControllers = List<VideoPlayerController>.generate(
+      videoLinks.length,
+      (index) => VideoPlayerController.network(videoLinks[index]),
+    );
+    notifyListeners();
+  }
+
+  void setVideo(int currentIndex) {
+    // 비디오 기본 값 설정
+    _videoControllers[currentIndex].play(); // 재생되는 상태
+    _videoControllers[currentIndex].setLooping(true); // 영상 무한 반복
+    _videoControllers[currentIndex].setVolume(1.0); // 볼륨 설정
+
+    notifyListeners();
+  }
+
+  void disposeVideoController() {
+    // 자원을 반환하기 위해 VideoPlayerController dispose.
+    for (int i = 0; i < videoLinks.length; i++) {
+      _videoControllers[i].dispose();
+    }
+
+    notifyListeners();
+  }
+}

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoPlayProvider with ChangeNotifier {
+  late PageController pageController;
   late List<VideoPlayerController> controllers;
+  late List<Future<void>> videoPlayerFutures;
 
   List<String> videoLinks = [
     'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
@@ -53,6 +55,19 @@ class VideoPlayProvider with ChangeNotifier {
   ];
 
   int currentIndex = 0;
+
+  void initializeVideoPlayerFutures() {
+    loadVideo();
+    pageController = PageController();
+
+    videoPlayerFutures = List<Future<void>>.generate(
+      videoLinks.length,
+      (index) => controllers[index].initialize(),
+    );
+    setVideo();
+
+    notifyListeners();
+  }
 
   void loadVideo() {
     // 모든 비디오 로드

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoPlayProvider with ChangeNotifier {
-  late List<VideoPlayerController> _videoControllers;
+  late List<VideoPlayerController> controllers;
 
   List<String> videoLinks = [
     'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
@@ -52,11 +52,9 @@ class VideoPlayProvider with ChangeNotifier {
     '최애의 완소 퍼펙트 반장❤️ #최애의아이',
   ];
 
-  int currentIndex = 0;
-
   void loadVideo() {
     // 모든 비디오 로드
-    _videoControllers = List<VideoPlayerController>.generate(
+    controllers = List<VideoPlayerController>.generate(
       videoLinks.length,
       (index) => VideoPlayerController.network(videoLinks[index]),
     );
@@ -65,9 +63,9 @@ class VideoPlayProvider with ChangeNotifier {
 
   void setVideo(int currentIndex) {
     // 비디오 기본 값 설정
-    _videoControllers[currentIndex].play(); // 재생되는 상태
-    _videoControllers[currentIndex].setLooping(true); // 영상 무한 반복
-    _videoControllers[currentIndex].setVolume(1.0); // 볼륨 설정
+    controllers[currentIndex].play(); // 재생되는 상태
+    controllers[currentIndex].setLooping(true); // 영상 무한 반복
+    controllers[currentIndex].setVolume(1.0); // 볼륨 설정
 
     notifyListeners();
   }
@@ -75,7 +73,7 @@ class VideoPlayProvider with ChangeNotifier {
   void disposeVideoController() {
     // 자원을 반환하기 위해 VideoPlayerController dispose.
     for (int i = 0; i < videoLinks.length; i++) {
-      _videoControllers[i].dispose();
+      controllers[i].dispose();
     }
 
     notifyListeners();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 
 // 카메라 목록 변수
@@ -11,7 +13,9 @@ Future<void> main() async {
   // 사용 가능한 카메라 목록 받아옴
   cameras = await availableCameras();
 
-  runApp(const MyApp());
+  runApp(MultiProvider(providers: [
+    ChangeNotifierProvider(create: (_) => VideoPlayProvider()),
+  ], child: const MyApp()));
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -12,102 +14,110 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   late PageController _pageController;
-  late List<VideoPlayerController> _videoControllers;
+  // late List<VideoPlayerController> _videoControllers;
   late List<Future<void>> _initializeVideoPlayerFutures;
 
-  List<String> videoLinks = [
-    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
-    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-4.mp4',
-    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-5.mp4',
-    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-3.mp4',
-    'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-1.mp4',
-  ];
+  late VideoPlayProvider _videoPlayProvider;
 
-  List<String> likes = [
-    '6.6천',
-    '1만',
-    '9.2만',
-    '9.4천',
-    '2.8만',
-  ];
+  // List<String> videoLinks = [
+  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
+  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-4.mp4',
+  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-5.mp4',
+  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-3.mp4',
+  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-1.mp4',
+  // ];
 
-  List<String> chats = [
-    '110',
-    '282',
-    '1.2천',
-    '230',
-    '437',
-  ];
+  // List<String> likes = [
+  //   '6.6천',
+  //   '1만',
+  //   '9.2만',
+  //   '9.4천',
+  //   '2.8만',
+  // ];
 
-  List<String> profiles = [
-    'assets/images/home_profile_1.jpg',
-    'assets/images/home_profile_2.jpg',
-    'assets/images/home_profile_3.jpg',
-    'assets/images/home_profile_4.jpg',
-    'assets/images/home_profile_5.jpg',
-  ];
+  // List<String> chats = [
+  //   '110',
+  //   '282',
+  //   '1.2천',
+  //   '230',
+  //   '437',
+  // ];
 
-  List<String> nicknames = [
-    '@okoi2202',
-    '@ONEUS',
-    '@joyseoworld',
-    '@yunamong_',
-    '@hyezz',
-  ];
+  // List<String> profiles = [
+  //   'assets/images/home_profile_1.jpg',
+  //   'assets/images/home_profile_2.jpg',
+  //   'assets/images/home_profile_3.jpg',
+  //   'assets/images/home_profile_4.jpg',
+  //   'assets/images/home_profile_5.jpg',
+  // ];
 
-  List<String> contents = [
-    '나이트댄서 춤 댄스챌린지 🌸🤍 | 가사 발음 포함 버전',
-    '늦었지만 토카토카 댄스!! (난 추고 본적 없음) #원어스 #ONEUS #서호',
-    '띵띵땅땅 이 노래 가사가 이런 뜻이었어...',
-    '요즘 난리난 챌린지 #아디아디챌린지 #아디아디아디 #dance #dancevideo #tiktok #reels #chellenge #fyp #dancechallenge #korea',
-    '최애의 완소 퍼펙트 반장❤️ #최애의아이',
-  ];
+  // List<String> nicknames = [
+  //   '@okoi2202',
+  //   '@ONEUS',
+  //   '@joyseoworld',
+  //   '@yunamong_',
+  //   '@hyezz',
+  // ];
+
+  // List<String> contents = [
+  //   '나이트댄서 춤 댄스챌린지 🌸🤍 | 가사 발음 포함 버전',
+  //   '늦었지만 토카토카 댄스!! (난 추고 본적 없음) #원어스 #ONEUS #서호',
+  //   '띵띵땅땅 이 노래 가사가 이런 뜻이었어...',
+  //   '요즘 난리난 챌린지 #아디아디챌린지 #아디아디아디 #dance #dancevideo #tiktok #reels #chellenge #fyp #dancechallenge #korea',
+  //   '최애의 완소 퍼펙트 반장❤️ #최애의아이',
+  // ];
 
   int currentIndex = 0;
 
   @override
   void initState() {
     _pageController = PageController();
+    // listen: false 상태 변화에 대해 위젯을 새로고치지 않겠다.
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
 
-    // 모든 비디오 로드
-    _videoControllers = List<VideoPlayerController>.generate(
-      videoLinks.length,
-      (index) => VideoPlayerController.network(videoLinks[index]),
-    );
+    // // 모든 비디오 로드
+    // _videoControllers = List<VideoPlayerController>.generate(
+    //   videoLinks.length,
+    //   (index) => VideoPlayerController.network(videoLinks[index]),
+    // );
+    _videoPlayProvider.loadVideo();
 
     // 비디오 초기화 완료를 기다리는 Future 리스트
     _initializeVideoPlayerFutures = List<Future<void>>.generate(
-      videoLinks.length,
-      (index) => _videoControllers[index].initialize(),
+      _videoPlayProvider.videoLinks.length,
+      (index) => _videoPlayProvider.controllers[index].initialize(),
     );
 
-    // 비디오 기본 값 설정
-    _videoControllers[currentIndex].play(); // 재생되는 상태
-    _videoControllers[currentIndex].setLooping(true); // 영상 무한 반복
-    _videoControllers[currentIndex].setVolume(1.0); // 볼륨 설정
+    // // 비디오 기본 값 설정
+    // _videoControllers[currentIndex].play(); // 재생되는 상태
+    // _videoControllers[currentIndex].setLooping(true); // 영상 무한 반복
+    // _videoControllers[currentIndex].setVolume(1.0); // 볼륨 설정
+    _videoPlayProvider.setVideo(currentIndex);
 
     super.initState();
   }
 
   @override
   void dispose() {
-    // 자원을 반환하기 위해 VideoPlayerController dispose.
-    for (int i = 0; i < videoLinks.length; i++) {
-      _videoControllers[i].dispose();
-    }
+    // // 자원을 반환하기 위해 VideoPlayerController dispose.
+    // for (int i = 0; i < videoLinks.length; i++) {
+    //   _videoControllers[i].dispose();
+    // }
+    _videoPlayProvider.dispose();
     super.dispose();
   }
 
   void onPageChanged(int index) {
     setState(() {
-      _videoControllers[currentIndex].pause().then((_) {
+      _videoPlayProvider.controllers[currentIndex].pause().then((_) {
         // 다음 비디오로 변경
         currentIndex = index;
 
         // 다음 비디오 기본 값 설정
-        _videoControllers[currentIndex].play();
-        _videoControllers[currentIndex].setLooping(true);
-        _videoControllers[currentIndex].setVolume(1.0);
+        // _videoControllers[currentIndex].play();
+        // _videoControllers[currentIndex].setLooping(true);
+        // _videoControllers[currentIndex].setVolume(1.0);
+        _videoPlayProvider.setVideo(currentIndex);
       });
     });
   }
@@ -120,7 +130,7 @@ class _HomeScreenState extends State<HomeScreen> {
           controller: _pageController,
           scrollDirection: Axis.vertical,
           allowImplicitScrolling: true,
-          itemCount: videoLinks.length,
+          itemCount: _videoPlayProvider.videoLinks.length,
           itemBuilder: (context, index) {
             return FutureBuilder(
                 future: _initializeVideoPlayerFutures[currentIndex],
@@ -131,23 +141,21 @@ class _HomeScreenState extends State<HomeScreen> {
                       GestureDetector(
                         // 비디오 클릭 시 영상 정지/재생
                         onTap: () {
-                          if (_videoControllers[index].value.isPlaying) {
-                            _videoControllers[index].pause();
+                          if (_videoPlayProvider
+                              .controllers[index].value.isPlaying) {
+                            _videoPlayProvider.controllers[index].pause();
                           } else {
                             // 만약 영상 일시 중지 상태였다면, 재생.
-                            _videoControllers[index].play();
+                            _videoPlayProvider.controllers[index].play();
                           }
                         },
-                        child: VideoPlayer(_videoControllers[index]),
+                        child:
+                            VideoPlayer(_videoPlayProvider.controllers[index]),
                       ),
                       // like, chat, share, progress
-                      VideoFrameRightWidget(
-                          like: likes[index], chat: chats[index]),
+                      VideoFrameRightWidget(index: index),
                       // profile, nicname, content
-                      VideoFrameContentWidget(
-                          profile: profiles[index],
-                          nickname: nicknames[index],
-                          content: contents[index]),
+                      VideoFrameContentWidget(index: index),
                     ]);
                   } else {
                     // 만약 VideoPlayerController가 여전히 초기화 중이라면, 로딩 스피너를 보여줌.
@@ -207,17 +215,15 @@ class VideoFrameHeaderWidget extends StatelessWidget {
 }
 
 class VideoFrameRightWidget extends StatelessWidget {
-  const VideoFrameRightWidget({
-    super.key,
-    required this.like,
-    required this.chat,
-  });
+  VideoFrameRightWidget({super.key, required this.index});
 
-  final String like;
-  final String chat;
+  late VideoPlayProvider _videoPlayProvider;
+  final int index;
 
   @override
   Widget build(BuildContext context) {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+
     return Container(
       //color: Colors.orange,
       width: 60,
@@ -235,7 +241,7 @@ class VideoFrameRightWidget extends StatelessWidget {
                 ),
                 const Padding(padding: EdgeInsets.only(bottom: 2)),
                 Text(
-                  like,
+                  _videoPlayProvider.likes[index],
                   style: const TextStyle(color: Colors.white, fontSize: 12),
                 ),
               ]),
@@ -251,7 +257,7 @@ class VideoFrameRightWidget extends StatelessWidget {
                 ),
                 const Padding(padding: EdgeInsets.only(bottom: 2)),
                 Text(
-                  chat,
+                  _videoPlayProvider.chats[index],
                   style: const TextStyle(color: Colors.white, fontSize: 12),
                 ),
               ]),
@@ -280,19 +286,15 @@ class VideoFrameRightWidget extends StatelessWidget {
 }
 
 class VideoFrameContentWidget extends StatelessWidget {
-  const VideoFrameContentWidget({
-    super.key,
-    required this.profile,
-    required this.nickname,
-    required this.content,
-  });
+  VideoFrameContentWidget({super.key, required this.index});
 
-  final String profile;
-  final String nickname;
-  final String content;
+  late VideoPlayProvider _videoPlayProvider;
+  final int index;
 
   @override
   Widget build(BuildContext context) {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+
     return Container(
       //color: Colors.green,
       margin: const EdgeInsets.fromLTRB(20, 620, 100, 80),
@@ -304,17 +306,18 @@ class VideoFrameContentWidget extends StatelessWidget {
           child: Row(children: <Widget>[
             ClipRRect(
                 borderRadius: BorderRadius.circular(50),
-                child: Image.asset(profile, width: 35)),
+                child:
+                    Image.asset(_videoPlayProvider.profiles[index], width: 35)),
             const Padding(padding: EdgeInsets.only(left: 8)),
             Text(
-              nickname,
+              _videoPlayProvider.nicknames[index],
               style: const TextStyle(color: Colors.white),
             ),
           ]),
         ),
         const Padding(padding: EdgeInsets.only(bottom: 8)),
         Text(
-          content,
+          _videoPlayProvider.contents[index],
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
           style: const TextStyle(

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -67,7 +67,7 @@ class _HomeScreenState extends State<HomeScreen> {
   //   '최애의 완소 퍼펙트 반장❤️ #최애의아이',
   // ];
 
-  int currentIndex = 0;
+  // int currentIndex = 0;
 
   @override
   void initState() {
@@ -80,7 +80,7 @@ class _HomeScreenState extends State<HomeScreen> {
     //   videoLinks.length,
     //   (index) => VideoPlayerController.network(videoLinks[index]),
     // );
-    _videoPlayProvider.loadVideo();
+    //_videoPlayProvider.loadVideo();
 
     // 비디오 초기화 완료를 기다리는 Future 리스트
     _initializeVideoPlayerFutures = List<Future<void>>.generate(
@@ -92,7 +92,7 @@ class _HomeScreenState extends State<HomeScreen> {
     // _videoControllers[currentIndex].play(); // 재생되는 상태
     // _videoControllers[currentIndex].setLooping(true); // 영상 무한 반복
     // _videoControllers[currentIndex].setVolume(1.0); // 볼륨 설정
-    _videoPlayProvider.setVideo(currentIndex);
+    _videoPlayProvider.setVideo();
 
     super.initState();
   }
@@ -103,21 +103,24 @@ class _HomeScreenState extends State<HomeScreen> {
     // for (int i = 0; i < videoLinks.length; i++) {
     //   _videoControllers[i].dispose();
     // }
-    _videoPlayProvider.dispose();
+    //_videoPlayProvider.disposeVideoController();
+    _videoPlayProvider.pauseVideo();
     super.dispose();
   }
 
   void onPageChanged(int index) {
     setState(() {
-      _videoPlayProvider.controllers[currentIndex].pause().then((_) {
+      _videoPlayProvider.controllers[_videoPlayProvider.currentIndex]
+          .pause()
+          .then((_) {
         // 다음 비디오로 변경
-        currentIndex = index;
+        _videoPlayProvider.currentIndex = index;
 
         // 다음 비디오 기본 값 설정
         // _videoControllers[currentIndex].play();
         // _videoControllers[currentIndex].setLooping(true);
         // _videoControllers[currentIndex].setVolume(1.0);
-        _videoPlayProvider.setVideo(currentIndex);
+        _videoPlayProvider.setVideo();
       });
     });
   }
@@ -133,7 +136,8 @@ class _HomeScreenState extends State<HomeScreen> {
           itemCount: _videoPlayProvider.videoLinks.length,
           itemBuilder: (context, index) {
             return FutureBuilder(
-                future: _initializeVideoPlayerFutures[currentIndex],
+                future: _initializeVideoPlayerFutures[
+                    _videoPlayProvider.currentIndex],
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.done) {
                     // 데이터가 수신되었을 때

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -115,49 +115,51 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: PageView.builder(
-        controller: _pageController,
-        scrollDirection: Axis.vertical,
-        allowImplicitScrolling: true,
-        itemCount: videoLinks.length,
-        itemBuilder: (context, index) {
-          return FutureBuilder(
-              future: _initializeVideoPlayerFutures[currentIndex],
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.done) {
-                  // 데이터가 수신되었을 때
-                  return Stack(children: <Widget>[
-                    GestureDetector(
-                      // 비디오 클릭 시 영상 정지/재생
-                      onTap: () {
-                        if (_videoControllers[index].value.isPlaying) {
-                          _videoControllers[index].pause();
-                        } else {
-                          // 만약 영상 일시 중지 상태였다면, 재생.
-                          _videoControllers[index].play();
-                        }
-                      },
-                      child: VideoPlayer(_videoControllers[index]),
-                    ),
-                    // PoPo, Upload, Search
-                    const VideoFrameHeaderWidget(),
-                    // like, chat, share, progress
-                    VideoFrameRightWidget(
-                        like: likes[index], chat: chats[index]),
-                    // profile, nicname, content
-                    VideoFrameContentWidget(
-                        profile: profiles[index],
-                        nickname: nicknames[index],
-                        content: contents[index]),
-                  ]);
-                } else {
-                  // 만약 VideoPlayerController가 여전히 초기화 중이라면, 로딩 스피너를 보여줌.
-                  return const Center(child: CircularProgressIndicator());
-                }
-              });
-        },
-        onPageChanged: onPageChanged,
-      ),
+      body: Stack(children: <Widget>[
+        PageView.builder(
+          controller: _pageController,
+          scrollDirection: Axis.vertical,
+          allowImplicitScrolling: true,
+          itemCount: videoLinks.length,
+          itemBuilder: (context, index) {
+            return FutureBuilder(
+                future: _initializeVideoPlayerFutures[currentIndex],
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    // 데이터가 수신되었을 때
+                    return Stack(children: <Widget>[
+                      GestureDetector(
+                        // 비디오 클릭 시 영상 정지/재생
+                        onTap: () {
+                          if (_videoControllers[index].value.isPlaying) {
+                            _videoControllers[index].pause();
+                          } else {
+                            // 만약 영상 일시 중지 상태였다면, 재생.
+                            _videoControllers[index].play();
+                          }
+                        },
+                        child: VideoPlayer(_videoControllers[index]),
+                      ),
+                      // like, chat, share, progress
+                      VideoFrameRightWidget(
+                          like: likes[index], chat: chats[index]),
+                      // profile, nicname, content
+                      VideoFrameContentWidget(
+                          profile: profiles[index],
+                          nickname: nicknames[index],
+                          content: contents[index]),
+                    ]);
+                  } else {
+                    // 만약 VideoPlayerController가 여전히 초기화 중이라면, 로딩 스피너를 보여줌.
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                });
+          },
+          onPageChanged: onPageChanged,
+        ),
+        // PoPo, upload, search
+        const VideoFrameHeaderWidget(),
+      ]),
     );
   }
 }

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -220,7 +220,8 @@ class VideoFrameRightWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       //color: Colors.orange,
-      margin: const EdgeInsets.fromLTRB(335, 520, 20, 60),
+      width: 60,
+      margin: const EdgeInsets.fromLTRB(330, 520, 10, 60),
       child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
@@ -235,7 +236,7 @@ class VideoFrameRightWidget extends StatelessWidget {
                 const Padding(padding: EdgeInsets.only(bottom: 2)),
                 Text(
                   like,
-                  style: const TextStyle(color: Colors.white),
+                  style: const TextStyle(color: Colors.white, fontSize: 12),
                 ),
               ]),
             ),
@@ -251,7 +252,7 @@ class VideoFrameRightWidget extends StatelessWidget {
                 const Padding(padding: EdgeInsets.only(bottom: 2)),
                 Text(
                   chat,
-                  style: const TextStyle(color: Colors.white),
+                  style: const TextStyle(color: Colors.white, fontSize: 12),
                 ),
               ]),
             ),

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -12,66 +12,18 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
-  late PageController _pageController;
-  // late List<VideoPlayerController> _videoControllers;
-  late List<Future<void>> _initializeVideoPlayerFutures;
-
+class _HomeScreenState extends State<HomeScreen>
+    with AutomaticKeepAliveClientMixin {
+  // (1) 추가
   late VideoPlayProvider _videoPlayProvider;
 
-  // List<String> videoLinks = [
-  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
-  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-4.mp4',
-  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-5.mp4',
-  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-3.mp4',
-  //   'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-1.mp4',
-  // ];
-
-  // List<String> likes = [
-  //   '6.6천',
-  //   '1만',
-  //   '9.2만',
-  //   '9.4천',
-  //   '2.8만',
-  // ];
-
-  // List<String> chats = [
-  //   '110',
-  //   '282',
-  //   '1.2천',
-  //   '230',
-  //   '437',
-  // ];
-
-  // List<String> profiles = [
-  //   'assets/images/home_profile_1.jpg',
-  //   'assets/images/home_profile_2.jpg',
-  //   'assets/images/home_profile_3.jpg',
-  //   'assets/images/home_profile_4.jpg',
-  //   'assets/images/home_profile_5.jpg',
-  // ];
-
-  // List<String> nicknames = [
-  //   '@okoi2202',
-  //   '@ONEUS',
-  //   '@joyseoworld',
-  //   '@yunamong_',
-  //   '@hyezz',
-  // ];
-
-  // List<String> contents = [
-  //   '나이트댄서 춤 댄스챌린지 🌸🤍 | 가사 발음 포함 버전',
-  //   '늦었지만 토카토카 댄스!! (난 추고 본적 없음) #원어스 #ONEUS #서호',
-  //   '띵띵땅땅 이 노래 가사가 이런 뜻이었어...',
-  //   '요즘 난리난 챌린지 #아디아디챌린지 #아디아디아디 #dance #dancevideo #tiktok #reels #chellenge #fyp #dancechallenge #korea',
-  //   '최애의 완소 퍼펙트 반장❤️ #최애의아이',
-  // ];
-
-  // int currentIndex = 0;
+  // (2) 추가
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
-    _pageController = PageController();
+    // _pageController = PageController();
     // listen: false 상태 변화에 대해 위젯을 새로고치지 않겠다.
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
 
@@ -83,30 +35,31 @@ class _HomeScreenState extends State<HomeScreen> {
     //_videoPlayProvider.loadVideo();
 
     // 비디오 초기화 완료를 기다리는 Future 리스트
-    _initializeVideoPlayerFutures = List<Future<void>>.generate(
-      _videoPlayProvider.videoLinks.length,
-      (index) => _videoPlayProvider.controllers[index].initialize(),
-    );
+    // _initializeVideoPlayerFutures = List<Future<void>>.generate(
+    //   _videoPlayProvider.videoLinks.length,
+    //   (index) => _videoPlayProvider.controllers[index].initialize(),
+    // );
 
     // // 비디오 기본 값 설정
     // _videoControllers[currentIndex].play(); // 재생되는 상태
     // _videoControllers[currentIndex].setLooping(true); // 영상 무한 반복
     // _videoControllers[currentIndex].setVolume(1.0); // 볼륨 설정
-    _videoPlayProvider.setVideo();
+    // _videoPlayProvider.setVideo();
 
+    //_videoPlayProvider.playVideo();
     super.initState();
   }
 
-  @override
-  void dispose() {
-    // // 자원을 반환하기 위해 VideoPlayerController dispose.
-    // for (int i = 0; i < videoLinks.length; i++) {
-    //   _videoControllers[i].dispose();
-    // }
-    //_videoPlayProvider.disposeVideoController();
-    _videoPlayProvider.pauseVideo();
-    super.dispose();
-  }
+  // @override
+  // void dispose() {
+  //   // // 자원을 반환하기 위해 VideoPlayerController dispose.
+  //   // for (int i = 0; i < videoLinks.length; i++) {
+  //   //   _videoControllers[i].dispose();
+  //   // }
+  //   //_videoPlayProvider.disposeVideoController();
+  //   // _videoPlayProvider.pauseVideo();
+  //   //super.dispose();
+  // }
 
   void onPageChanged(int index) {
     setState(() {
@@ -130,14 +83,17 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       body: Stack(children: <Widget>[
         PageView.builder(
-          controller: _pageController,
+          //controller: _videoPlayProvider.pageController,
+          controller: PageController(
+            initialPage: _videoPlayProvider.currentIndex, //시작 페이지
+          ),
           scrollDirection: Axis.vertical,
           allowImplicitScrolling: true,
           itemCount: _videoPlayProvider.videoLinks.length,
           itemBuilder: (context, index) {
             return FutureBuilder(
-                future: _initializeVideoPlayerFutures[
-                    _videoPlayProvider.currentIndex],
+                future: _videoPlayProvider
+                    .videoPlayerFutures[_videoPlayProvider.currentIndex],
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.done) {
                     // 데이터가 수신되었을 때

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -20,6 +20,15 @@ class _MainScreenState extends State<MainScreen> {
   late VideoPlayProvider _videoPlayProvider;
   int _bottomNavIndex = 0;
 
+  @override
+  void initState() {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+    _videoPlayProvider.initializeVideoPlayerFutures();
+
+    // TODO: implement initState
+    super.initState();
+  }
+
   final List<Widget> _screens = <Widget>[
     const HomeScreen(),
     const ProfileScreen(),
@@ -28,6 +37,12 @@ class _MainScreenState extends State<MainScreen> {
   void _onItemTapped(int index) {
     setState(() {
       _bottomNavIndex = index;
+
+      if (index == 1) {
+        _videoPlayProvider.pauseVideo();
+      } else {
+        _videoPlayProvider.playVideo();
+      }
     });
   }
 
@@ -42,9 +57,6 @@ class _MainScreenState extends State<MainScreen> {
 
   @override
   Widget build(BuildContext context) {
-    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
-    _videoPlayProvider.loadVideo();
-
     return Scaffold(
       extendBody: true,
       body: _screens[_bottomNavIndex],

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -3,9 +3,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/ui/screen/home_screen.dart';
 import 'package:pocket_pose/ui/screen/popo_wait_screen.dart';
 import 'package:pocket_pose/ui/screen/profile_screen.dart';
+import 'package:provider/provider.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -15,6 +17,7 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> {
+  late VideoPlayProvider _videoPlayProvider;
   int _bottomNavIndex = 0;
 
   final List<Widget> _screens = <Widget>[
@@ -29,14 +32,19 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   void _onFloatingButtonClicked() {
+    _videoPlayProvider.pauseVideo();
+
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => const PoPoWaitScreen()),
+      MaterialPageRoute(builder: (context) => PoPoWaitScreen()),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+    _videoPlayProvider.loadVideo();
+
     return Scaffold(
       extendBody: true,
       body: _screens[_bottomNavIndex],

--- a/lib/ui/screen/popo_result_screen.dart
+++ b/lib/ui/screen/popo_result_screen.dart
@@ -21,8 +21,7 @@ class PoPoResultScreen extends StatelessWidget {
                 onPressed: () {
                   Navigator.pop(context);
                   Navigator.of(context).push(MaterialPageRoute(
-                      builder: (BuildContext context) =>
-                          const PoPoWaitScreen()));
+                      builder: (BuildContext context) => PoPoWaitScreen()));
                 },
                 icon: const Icon(Icons.navigate_next_rounded))
           ],

--- a/lib/ui/screen/popo_wait_screen.dart
+++ b/lib/ui/screen/popo_wait_screen.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/ui/screen/popo_catch_screen.dart';
+import 'package:provider/provider.dart';
 
 class PoPoWaitScreen extends StatelessWidget {
-  const PoPoWaitScreen({super.key});
+  PoPoWaitScreen({super.key});
+  late VideoPlayProvider _videoPlayProvider;
 
   @override
   Widget build(BuildContext context) {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+
     return Container(
       decoration: const BoxDecoration(
         image: DecorationImage(
@@ -16,7 +21,14 @@ class PoPoWaitScreen extends StatelessWidget {
       child: Scaffold(
         backgroundColor: Colors.transparent,
         appBar: AppBar(
+          automaticallyImplyLeading: false,
           actions: [
+            IconButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  _videoPlayProvider.playVideo();
+                },
+                icon: const Icon(Icons.home)),
             IconButton(
                 onPressed: () {
                   Navigator.pop(context);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   audio_session:
     dependency: "direct main"
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cross_file:
     dependency: transitive
     description:
@@ -268,10 +268,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -284,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -300,18 +300,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -473,10 +473,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
@@ -590,5 +590,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=2.19.5 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,14 +198,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.15"
-  flutter_provider:
-    dependency: "direct main"
-    description:
-      name: flutter_provider
-      sha256: "5bc7d1e9edcf364397f312b9eb901337a644a5e4a907225bcd1d7e9b020ac914"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.15"
+  flutter_provider:
+    dependency: "direct main"
+    description:
+      name: flutter_provider
+      sha256: "5bc7d1e9edcf364397f312b9eb901337a644a5e4a907225bcd1d7e9b020ac914"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -304,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -400,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.5"
   quiver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_provider: ^2.1.0
+  provider: ^6.0.5 
   flutter_svg: ^2.0.5
   cupertino_icons: ^1.0.2
   google_mlkit_commons: ^0.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_provider: ^2.1.0
   provider: ^6.0.5 
   flutter_svg: ^2.0.5
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/55472669-8b67-48ca-b58a-f7fb10383b68

## 💬 작업 설명
#7 이후 홈 화면 오류를 수정하고 비디오 재생 기능을 보완했습니다.

## ✅ 한 일
### 1. 스크롤 시 프레임 앱 바만 고정
### 2. 오른쪽 프레임 텍스트 위젯 깨지는 문제 해결

**수정 전(민영언니 기기): 핸드폰 기종에 따라 글씨가 아래로 내려감**
<img width="150" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/cb0ed399-69b6-4d13-8f83-80aca09aa88a">

**수정 후: 핸드폰 기종 상관없이 글씨는 한 라인에서 보임**
<img width="150" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/ec943a4d-f4e8-413b-aa44-e4f7ab2440cb">


### 3. Provider를 사용해 영상 재생 상태 관리
**수정 전**
기존에는 프로필 화면 이동시 무조건 제일 첫번째 영상부터 실행되었습니다.
또, 포포 스테이지로 이동시 음악이 정지되지 않았습니다.

**수정 후**
- 홈에서 영상 **재생중**인 상태 -> (다른 화면으로 전환) -> 영상 정지 -> (다시 홈으로 돌아옴) -> **영상 보던 거 재실행**
- 홈에서 영상 **정지한** 상태 -> (다른 화면으로 전환) -> 영상 정지 -> (다시 홈으로 돌아옴) -> **영상 보던 거 재실행**

## 😥 어려웠던점
1.  Provider로 상태관리(관리할게 넘 많아서 복잡하고 어려웠습니다)
2. Page 이동시 영상 정지 및 재생 처리...(포포스테이지는 floating button으로 이동하고, 프로필은 bottom navigation으로 이동해 두개의 처리를 각각 다르게 해야해서 꽤나 복잡 어렵 힘들었습니다)

## 🔧 보완할 점
1. 아.. 바보같이 코드 정리를 안하고 올려버렸네요.. 주석이 좀 있답니다 (빨리 공개하고 싶은 마음에 급해져서...ㅋㅋ..헷..) 오늘중으로 정리해서 다시 올릴게요!

## 💃 부탁 드립니다~
1. 실기기에서 잘 실행되는지 확인 부탁드립니다~
2. 포포 스테이지 화면에서 앱 바에 홈으로 가는 아이콘 UI 개발중이실 것 같아서 제가 아무거나 일단 넣었습니다!  다음에 수정 부탁드립니다~
3. 영상 제일 처음에 재생될 때 소리 크기 어떤가요? 작은가요? 큰가요? 적당한가요?

## 🤓 다음에 할 일
1. 코드 정리해서 다시 올리기
4. 스켈레톤 머리 구현 다시
5. 카카오 로그인
