### PR TITLE
[feat] 스켈레톤 얼굴 그리기 로직 1개에서 3개로 변경 (HH-176)

### DIFF
--- a/lib/config/ml_kit/custom_pose_painter.dart
+++ b/lib/config/ml_kit/custom_pose_painter.dart
@@ -125,35 +125,54 @@ class CustomPosePainter extends CustomPainter {
           PoseLandmarkType.leftShoulder, PoseLandmarkType.rightShoulder, paint);
       paintNeonLine(PoseLandmarkType.leftHip, PoseLandmarkType.rightHip, paint);
 
-      // Draw face
-      final noseLandmark = pose.landmarks[PoseLandmarkType.nose];
-      final leftEyeLandmark = pose.landmarks[PoseLandmarkType.leftEye];
-      final rightEyeLandmark = pose.landmarks[PoseLandmarkType.rightEye];
+      // Draw Face
+      Offset centerPoint;
+      Offset leftPoint;
+      Offset rightPoint;
 
-      if (noseLandmark != null &&
-          leftEyeLandmark != null &&
-          rightEyeLandmark != null) {
-        final nosePoint = Offset(
+      final noseLandmark = pose.landmarks[PoseLandmarkType.nose];
+
+      if (noseLandmark != null) {
+        // 코가 추출될 경우
+        centerPoint = Offset(
           translateX(noseLandmark.x, rotation, size, absoluteImageSize),
           translateY(noseLandmark.y, rotation, size, absoluteImageSize),
         );
-        final leftEyePoint = Offset(
-          translateX(leftEyeLandmark.x, rotation, size, absoluteImageSize),
-          translateY(leftEyeLandmark.y, rotation, size, absoluteImageSize),
-        );
-        final rightEyePoint = Offset(
-          translateX(rightEyeLandmark.x, rotation, size, absoluteImageSize),
-          translateY(rightEyeLandmark.y, rotation, size, absoluteImageSize),
-        );
+
+        final leftEyeLandmark = pose.landmarks[PoseLandmarkType.leftEye];
+        final rightEyeLandmark = pose.landmarks[PoseLandmarkType.rightEye];
+
+        if (leftEyeLandmark != null && rightEyeLandmark != null) {
+          // 눈이 추출될 경우: 가장 perfect
+          leftPoint = Offset(
+            translateX(leftEyeLandmark.x, rotation, size, absoluteImageSize),
+            translateY(leftEyeLandmark.y, rotation, size, absoluteImageSize),
+          );
+          rightPoint = Offset(
+            translateX(rightEyeLandmark.x, rotation, size, absoluteImageSize),
+            translateY(rightEyeLandmark.y, rotation, size, absoluteImageSize),
+          );
+        } else {
+          //눈 추출이 안되면 임의의 값으로 그림
+          int dis = 10; // 적당한 값인지 테스트 필요..
+          leftPoint = Offset(
+            translateX(noseLandmark.x - dis, rotation, size, absoluteImageSize),
+            translateY(noseLandmark.y, rotation, size, absoluteImageSize),
+          );
+          rightPoint = Offset(
+            translateX(noseLandmark.x + dis, rotation, size, absoluteImageSize),
+            translateY(noseLandmark.y, rotation, size, absoluteImageSize),
+          );
+        }
 
         // Calculate face radius
-        final eyeDistance = leftEyePoint.dx - rightEyePoint.dx;
-        final faceRadius = eyeDistance * 1.5;
+        final distance = leftPoint.dx - rightPoint.dx;
+        final faceRadius = distance * 2;
 
         // Draw face circle
-        canvas.drawCircle(nosePoint, faceRadius, neonOuterPaint);
-        canvas.drawCircle(nosePoint, faceRadius, neonInnerPaint);
-        canvas.drawCircle(nosePoint, faceRadius, paint);
+        canvas.drawCircle(centerPoint, faceRadius, neonOuterPaint);
+        canvas.drawCircle(centerPoint, faceRadius, neonInnerPaint);
+        canvas.drawCircle(centerPoint, faceRadius, paint);
       }
     }
   }

--- a/lib/config/ml_kit/custom_pose_painter.dart
+++ b/lib/config/ml_kit/custom_pose_painter.dart
@@ -131,6 +131,10 @@ class CustomPosePainter extends CustomPainter {
       Offset rightPoint;
 
       final noseLandmark = pose.landmarks[PoseLandmarkType.nose];
+      final leftShoulderLandmark =
+          pose.landmarks[PoseLandmarkType.leftShoulder];
+      final rightShoulderLandmark =
+          pose.landmarks[PoseLandmarkType.rightShoulder];
 
       if (noseLandmark != null) {
         // 코가 추출될 경우
@@ -168,6 +172,41 @@ class CustomPosePainter extends CustomPainter {
         // Calculate face radius
         final distance = leftPoint.dx - rightPoint.dx;
         final faceRadius = distance * 2;
+
+        // Draw face circle
+        canvas.drawCircle(centerPoint, faceRadius, neonOuterPaint);
+        canvas.drawCircle(centerPoint, faceRadius, neonInnerPaint);
+        canvas.drawCircle(centerPoint, faceRadius, paint);
+      } else if (leftShoulderLandmark != null &&
+          rightShoulderLandmark != null) {
+        // 양쪽 어깨가 추출될 경우
+        // 어께로부터 떨어진 거리(임의의 값)
+        int upHeight = 2;
+
+        leftPoint = Offset(
+          translateX(leftShoulderLandmark.x, rotation, size, absoluteImageSize),
+          translateY(leftShoulderLandmark.y + upHeight, rotation, size,
+              absoluteImageSize),
+        );
+
+        rightPoint = Offset(
+          translateX(
+              rightShoulderLandmark.x, rotation, size, absoluteImageSize),
+          translateY(rightShoulderLandmark.y + upHeight, rotation, size,
+              absoluteImageSize),
+        );
+
+        // Calculate face radius
+        final xDistance = leftPoint.dx - rightPoint.dx;
+        final yDistance = leftPoint.dx - rightPoint.dx;
+
+        centerPoint = Offset(
+          translateX(xDistance, rotation, size, absoluteImageSize),
+          translateY(yDistance, rotation, size, absoluteImageSize),
+        );
+
+        // Calculate face radius
+        final faceRadius = xDistance * 2;
 
         // Draw face circle
         canvas.drawCircle(centerPoint, faceRadius, neonOuterPaint);


### PR DESCRIPTION
## 📱 작업 사진 
<img width="258" alt="nose_sk" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/06812415-b90e-484e-bcff-fb680f882ada">


## 💬 작업 설명
후면 카메라로는 사람 얼굴을 나타내는 원이 잘 나오는데
전면 카메라로 찍으면 안 나온다는 제보가 있어
얼굴 원을 그리는 로직을 다양한 방법으로 만들어봤습니다.


## ✅ 한 일
### 1. [Best] **코**와 **왼쪽 눈**, **오른쪽 눈**이 모두 추출될 경우
### 2. 왼쪽 눈, 오른쪽 눈은 추출되지 않고 **코**만 추출될 경우
양 눈의 좌표는 코의 좌표를 임의의 값만큼 변경해 만듬
<테스트 이미지>
![nose](https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/7446d322-8af4-4282-8dc6-06dcd589642d)
<결과 이미지>
<img width="278" alt="sh_sk" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/4918f6e4-ea74-46dc-8174-337dba9e6226">


### 3. 코는 추출되지 않고 **왼쪽 어깨**, **오른쪽 어깨**가 추출될 경우
<테스트 이미지> 
![sh](https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/cae043b7-5390-4bc7-9992-289a55efeb80)
<결과 이미지>
<img width="258" alt="nose_sk" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/d5ddb8ce-2d47-4685-a620-47980397bb11">

## ☝️ 참고 하세요~
1. 코도, 어깨도 추출되지 않는 무지막지한 경우는 .. 없을 겁니다...
그런 경우가 있더라도 어깨가 추출되지 않는 다는 건 다른 관절들도 추출이 안된다는 것일텐데, 얼굴 원만 나오는건 아닌 것 같아서 이렇게 세가지 경우로만 만들었습니다.
2. 실기기에서 테스트해 보고 원의 크기나 위치가 부적절하다면 보완해야 합니다. 내일 만나서 같이 보면서 임의로 설정해둔 값을 수정해야할 것 같습니다. (애뮬에선 명확한 확인이 안됩니다.)

## 🤓 다음에 할 일
1. 카카오 로그인
