### PR TITLE
[Bug] 포포에서 홈으로 돌아왔을 때 영상 다시 재생 안 되는 문제 해결 (HH-176)

### DIFF
--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -7,6 +7,9 @@ import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
+import 'package:provider/provider.dart';
+
+import '../../data/local/provider/video_play_provider.dart';
 
 enum StageStage { waitState, catchState, playState, resultState }
 
@@ -22,7 +25,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   late Timer _timer;
 
   StageStage _stageStage = StageStage.waitState;
-
+  late VideoPlayProvider _videoPlayProvider;
   @override
   void initState() {
     super.initState();
@@ -60,6 +63,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
   @override
   Widget build(BuildContext context) {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+
     return Container(
         decoration: BoxDecoration(
           image: DecorationImage(
@@ -84,6 +89,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
               onPressed: () {
                 AudioPlayerUtil().stop();
                 Navigator.pop(context);
+                _videoPlayProvider.playVideo();
               },
               icon: SvgPicture.asset(
                 'assets/icons/ic_home.svg',


### PR DESCRIPTION
## 💬 작업 설명
원래 포포에서 홈 화면으로 돌아갈 때
이전에 실행되던 영상이 재생되어야 하는데
아마 충돌 해결 과정에서 해당 기능이 없어진 것 같습니다.
다시 추가했습니다.

## ✅ 한 일
1. PoPoStageScreen에서 home 아이콘을 눌렀을 때 영상을 replay