### PR TITLE
[feat] 홈 화면에서 스크롤 시 깜빡임 없앰 (HH-176)

### DIFF
--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -82,6 +82,29 @@ class _HomeScreenState extends State<HomeScreen>
                       // profile, nicname, content
                       VideoFrameContentWidget(index: index),
                     ]);
+                  } else if (snapshot.connectionState ==
+                      ConnectionState.waiting) {
+                    // 데이터가 로딩중일 때
+                    return Stack(children: <Widget>[
+                      GestureDetector(
+                        // 비디오 클릭 시 영상 정지/재생
+                        onTap: () {
+                          if (_videoPlayProvider
+                              .controllers[index].value.isPlaying) {
+                            _videoPlayProvider.controllers[index].pause();
+                          } else {
+                            // 만약 영상 일시 중지 상태였다면, 재생.
+                            _videoPlayProvider.controllers[index].play();
+                          }
+                        },
+                        child:
+                            VideoPlayer(_videoPlayProvider.controllers[index]),
+                      ),
+                      // like, chat, share, progress
+                      VideoFrameRightWidget(index: index),
+                      // profile, nicname, content
+                      VideoFrameContentWidget(index: index),
+                    ]);
                   } else {
                     // 만약 VideoPlayerController가 여전히 초기화 중이라면, 로딩 스피너를 보여줌.
                     return const Center(child: CircularProgressIndicator());


### PR DESCRIPTION
## 📱 작업 사진 
**수정 전**
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/cffd1633-b06d-498b-bc0f-79cbb1aaa527

**수정 후**
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/497ba384-389b-4d99-a302-6454822ad488

## 💬 작업 설명
홈 화며면에서 영상을 스크롤 하면 하얀 배경에 로딩 화면이 잠깐 보여 깜박이는 것처럼 보였는데,
사용자가 계속 보고 있다보면 눈이 피로해질 것 같아
로딩 중에도 기존의 화면을 그대로 보이게 해 깜박임을 해결했습니다.

## 💃 부탁 드립니다~
1. 영상 스크롤 시 깜박임 없이 자연스럽게 이동되는지 확인 부탁드릴게요.
2. 포포스테이지에서 뒤로가기 눌렀을 때 영상 재실행 되는지 확인 부탁드릴게요.

## 🤓 다음에 할 일
1. 카카오 로그인
