### PR TITLE
[refactor] 홈 화면 처음에만 포포 스피너 보이기, 하단 위젯 위치(HH-176)

### DIFF
--- a/assets/icons/ic_dancing_popo.svg
+++ b/assets/icons/ic_dancing_popo.svg
@@ -1,0 +1,409 @@
+<svg width="322" height="363" viewBox="0 0 322 363" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_366_681)">
+<mask id="path-1-inside-1_366_681" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M256.511 152.594C255.898 95.8182 213.572 50 161.449 50C109.326 50 67.0004 95.8182 66.3867 152.594H80.1351C80.7478 104.11 116.92 65.0136 161.451 65.0136C205.983 65.0136 242.155 104.11 242.768 152.594H256.511Z"/>
+</mask>
+<g filter="url(#filter1_i_366_681)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M256.511 152.594C255.898 95.8182 213.572 50 161.449 50C109.326 50 67.0004 95.8182 66.3867 152.594H80.1351C80.7478 104.11 116.92 65.0136 161.451 65.0136C205.983 65.0136 242.155 104.11 242.768 152.594H256.511Z" fill="white"/>
+</g>
+<path d="M256.511 152.594V153.594H257.522L257.511 152.583L256.511 152.594ZM66.3867 152.594L65.3868 152.583L65.3759 153.594H66.3867V152.594ZM80.1351 152.594V153.594H81.1226L81.135 152.606L80.1351 152.594ZM242.768 152.594L241.768 152.606L241.78 153.594H242.768V152.594ZM257.511 152.583C256.893 95.3436 214.201 49 161.449 49V51C212.943 51 254.903 96.2928 255.512 152.604L257.511 152.583ZM161.449 49C108.698 49 66.0055 95.3436 65.3868 152.583L67.3867 152.604C67.9953 96.2928 109.955 51 161.449 51V49ZM66.3867 153.594H80.1351V151.594H66.3867V153.594ZM161.451 64.0136C116.292 64.0136 79.7538 103.634 79.1352 152.581L81.135 152.606C81.7419 104.586 117.548 66.0136 161.451 66.0136V64.0136ZM243.768 152.581C243.149 103.634 206.611 64.0136 161.451 64.0136V66.0136C205.355 66.0136 241.161 104.586 241.768 152.606L243.768 152.581ZM242.768 153.594H256.511V151.594H242.768V153.594Z" fill="#BFC1F4" mask="url(#path-1-inside-1_366_681)"/>
+<g filter="url(#filter2_i_366_681)">
+<ellipse cx="85.1795" cy="185.828" rx="34.6795" ry="40.4594" fill="white"/>
+</g>
+<path d="M119.359 185.828C119.359 207.972 103.987 225.788 85.1795 225.788C66.3722 225.788 51 207.972 51 185.828C51 163.684 66.3722 145.869 85.1795 145.869C103.987 145.869 119.359 163.684 119.359 185.828Z" stroke="#BFC1F4"/>
+<g filter="url(#filter3_i_366_681)">
+<ellipse cx="236.906" cy="185.828" rx="34.6795" ry="40.4594" fill="white"/>
+</g>
+<path d="M271.086 185.828C271.086 207.972 255.713 225.788 236.906 225.788C218.099 225.788 202.727 207.972 202.727 185.828C202.727 163.684 218.099 145.869 236.906 145.869C255.713 145.869 271.086 163.684 271.086 185.828Z" stroke="#BFC1F4"/>
+<g filter="url(#filter4_ii_366_681)">
+<rect x="128.531" y="220.508" width="24.5647" height="86.6988" fill="#8D91F3"/>
+</g>
+<rect x="129.031" y="221.008" width="23.5647" height="85.6988" stroke="#BFC1F4"/>
+<g filter="url(#filter5_ii_366_681)">
+<rect x="176.211" y="220.508" width="24.5647" height="86.6988" fill="#8D91F3"/>
+</g>
+<rect x="176.711" y="221.008" width="23.5647" height="85.6988" stroke="#BFC1F4"/>
+<g filter="url(#filter6_i_366_681)">
+<path d="M249.902 152.594C259.854 178.92 259.212 193.449 249.902 219.063" stroke="#EFE372" stroke-width="5" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter7_i_366_681)">
+<path d="M73.6172 152.594C63.6654 178.92 64.3079 193.449 73.6172 219.063" stroke="#EFE372" stroke-width="5" stroke-linecap="round"/>
+</g>
+<mask id="path-13-inside-2_366_681" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M61.2865 198.13C61.8529 198.044 62.4329 198 63.0233 198C67.9619 198 72.1744 201.109 73.8101 205.477L109.082 224.196L100.985 239.453L65.6874 220.72C64.8323 220.922 63.9403 221.029 63.0233 221.029C56.6639 221.029 51.5086 215.874 51.5086 209.515C51.5086 207.354 52.1039 205.332 53.1395 203.604C51.344 201.853 50 199.731 50 198.019C50 195.587 54.777 196.671 58.9749 197.623C59.7793 197.805 60.5623 197.983 61.2865 198.13Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M61.2865 198.13C61.8529 198.044 62.4329 198 63.0233 198C67.9619 198 72.1744 201.109 73.8101 205.477L109.082 224.196L100.985 239.453L65.6874 220.72C64.8323 220.922 63.9403 221.029 63.0233 221.029C56.6639 221.029 51.5086 215.874 51.5086 209.515C51.5086 207.354 52.1039 205.332 53.1395 203.604C51.344 201.853 50 199.731 50 198.019C50 195.587 54.777 196.671 58.9749 197.623C59.7793 197.805 60.5623 197.983 61.2865 198.13Z" fill="#8D91F3"/>
+<path d="M63.0233 198V197V198ZM61.2865 198.13L61.0874 199.11L61.2609 199.145L61.4361 199.119L61.2865 198.13ZM73.8101 205.477L72.8736 205.827L73.0066 206.182L73.3413 206.36L73.8101 205.477ZM109.082 224.196L109.965 224.665L110.434 223.782L109.551 223.313L109.082 224.196ZM100.985 239.453L100.516 240.336L101.4 240.805L101.868 239.921L100.985 239.453ZM65.6874 220.72L66.1562 219.836L65.8234 219.66L65.4569 219.747L65.6874 220.72ZM51.5086 209.515H52.5086H51.5086ZM53.1395 203.604L53.9972 204.118L54.4036 203.44L53.8377 202.888L53.1395 203.604ZM58.9749 197.623L58.7537 198.598L58.9749 197.623ZM63.0233 197C62.3827 197 61.7527 197.048 61.1369 197.141L61.4361 199.119C61.9532 199.041 62.4832 199 63.0233 199V197ZM74.7466 205.126C72.9694 200.381 68.3924 197 63.0233 197V199C67.5315 199 71.3794 201.838 72.8736 205.827L74.7466 205.126ZM109.551 223.313L74.2789 204.593L73.3413 206.36L108.613 225.079L109.551 223.313ZM101.868 239.921L109.965 224.665L108.199 223.727L100.102 238.984L101.868 239.921ZM65.2186 221.603L100.516 240.336L101.454 238.569L66.1562 219.836L65.2186 221.603ZM63.0233 222.029C64.0185 222.029 64.9878 221.913 65.9179 221.693L65.4569 219.747C64.6768 219.931 63.8621 220.029 63.0233 220.029V222.029ZM50.5086 209.515C50.5086 216.426 56.1116 222.029 63.0233 222.029V220.029C57.2162 220.029 52.5086 215.322 52.5086 209.515H50.5086ZM52.2817 203.09C51.1557 204.969 50.5086 207.168 50.5086 209.515H52.5086C52.5086 207.54 53.0522 205.695 53.9972 204.118L52.2817 203.09ZM53.8377 202.888C52.991 202.062 52.267 201.164 51.7608 200.294C51.247 199.411 51 198.63 51 198.019H49C49 199.12 49.425 200.256 50.0321 201.3C50.6467 202.356 51.4925 203.394 52.4413 204.32L53.8377 202.888ZM51 198.019C51 197.886 51.03 197.842 51.0366 197.833C51.0468 197.818 51.0854 197.77 51.2142 197.713C51.5077 197.584 52.0428 197.51 52.8633 197.551C54.4763 197.632 56.624 198.115 58.7537 198.598L59.1961 196.648C57.1279 196.179 54.7882 195.645 52.9631 195.553C52.0646 195.509 51.1432 195.56 50.4098 195.882C50.0252 196.051 49.6578 196.31 49.3903 196.697C49.1193 197.09 49 197.545 49 198.019H51ZM58.7537 198.598C59.5555 198.78 60.3501 198.96 61.0874 199.11L61.4856 197.15C60.7746 197.006 60.003 196.831 59.1961 196.648L58.7537 198.598Z" fill="#B9BBEC" mask="url(#path-13-inside-2_366_681)"/>
+<g filter="url(#filter8_ii_366_681)">
+<path d="M160.31 266.747C55.7907 265.444 77.9465 174.991 85.8939 138.867C89.5065 117.914 94.5636 103.465 98.176 83.2349C98.9553 102.397 103.233 114.302 109.013 110.689C114.793 107.077 127.798 80.3449 127.798 80.3449C127.798 80.3449 129.965 96.9622 135.023 96.9622C140.08 96.9622 145.138 86.8473 145.138 86.8473C151.525 106.355 153.074 106.355 158.09 106.355H158.143C163.2 106.355 167.216 107.387 179.095 78.8999C183.142 94.9521 182.764 112.546 200.047 115.747C215.975 118.697 223.737 91.9579 224.278 84.8735C224.024 83.8033 223.889 83.2348 223.889 83.2348C224.243 82.9776 224.374 83.6159 224.278 84.8735C225.791 91.2407 231.536 115.368 238.339 143.202C246.286 175.713 264.829 268.051 160.31 266.747Z" fill="#8D91F3" stroke="#BFC1F4"/>
+<path d="M161.451 258.068C78.9117 257.135 96.4083 192.431 102.684 166.59C105.537 151.603 109.531 141.266 112.384 126.795C112.999 140.502 116.378 149.019 120.942 146.434C125.506 143.85 135.776 124.728 135.776 124.728C135.776 124.728 137.488 136.615 141.482 136.615C145.476 136.615 149.47 129.379 149.47 129.379C154.514 143.334 155.737 143.334 159.698 143.334H159.74C163.734 143.334 166.905 144.072 176.286 123.694C179.482 135.177 179.183 147.762 192.832 150.052C205.41 152.162 211.539 133.035 211.967 127.967C211.766 127.202 211.66 126.795 211.66 126.795C211.939 126.611 212.043 127.068 211.967 127.967C213.162 132.522 217.698 149.781 223.071 169.691C229.347 192.948 243.991 259 161.451 258.068Z" fill="#B5B8F4"/>
+<path d="M160.993 258.07C99.3148 257.378 112.389 209.372 117.079 190.2C119.211 179.08 122.195 171.411 124.327 160.674C124.787 170.844 127.311 177.163 130.722 175.245C134.133 173.328 141.807 159.141 141.807 159.141C141.807 159.141 143.086 167.96 146.071 167.96C149.055 167.96 152.039 162.592 152.039 162.592C155.809 172.945 156.723 172.945 159.682 172.945H159.714C162.698 172.945 165.068 173.493 172.078 158.374C174.466 166.893 174.243 176.231 184.442 177.93C193.841 179.495 198.421 165.304 198.741 161.544C198.591 160.976 198.511 160.674 198.511 160.674C198.72 160.538 198.798 160.877 198.741 161.544C199.633 164.923 203.024 177.728 207.038 192.501C211.728 209.756 222.671 258.762 160.993 258.07Z" fill="#C8C9EF"/>
+</g>
+<g filter="url(#filter9_ii_366_681)">
+<path d="M153.597 307.929C153.597 313.515 147.002 312.987 135.032 312.987C123.061 312.987 116.75 313.515 116.75 307.929C116.75 302.343 123.061 292.757 135.032 292.757C147.002 292.757 153.597 302.343 153.597 307.929Z" fill="#8D91F3"/>
+</g>
+<path d="M153.097 307.929C153.097 309.217 152.722 310.085 152.042 310.707C151.34 311.349 150.252 311.784 148.715 312.061C146.139 312.524 142.531 312.511 137.909 312.494C136.99 312.49 136.031 312.487 135.032 312.487C134.031 312.487 133.072 312.49 132.155 312.494C127.553 312.511 124.007 312.524 121.492 312.061C119.993 311.785 118.942 311.351 118.267 310.713C117.611 310.093 117.25 309.224 117.25 307.929C117.25 305.297 118.753 301.624 121.757 298.6C124.744 295.593 129.19 293.257 135.032 293.257C140.875 293.257 145.393 295.593 148.453 298.605C151.529 301.632 153.097 305.303 153.097 307.929Z" stroke="#BFC1F4"/>
+<g filter="url(#filter10_ii_366_681)">
+<path d="M201.499 307.929C201.499 313.515 194.905 312.987 182.934 312.987C170.964 312.987 164.652 313.515 164.652 307.929C164.652 302.343 170.964 292.757 182.934 292.757C194.905 292.757 201.499 302.343 201.499 307.929Z" fill="#8D91F3"/>
+</g>
+<path d="M200.999 307.929C200.999 309.217 200.625 310.085 199.945 310.707C199.242 311.349 198.154 311.784 196.617 312.061C194.042 312.524 190.433 312.511 185.811 312.494C184.892 312.49 183.933 312.487 182.934 312.487C181.933 312.487 180.974 312.49 180.058 312.494C175.455 312.511 171.909 312.524 169.395 312.061C167.895 311.785 166.845 311.351 166.169 310.713C165.513 310.093 165.152 309.224 165.152 307.929C165.152 305.297 166.655 301.624 169.659 298.6C172.647 295.593 177.092 293.257 182.934 293.257C188.777 293.257 193.295 295.593 196.355 298.605C199.431 301.632 200.999 305.303 200.999 307.929Z" stroke="#BFC1F4"/>
+<g filter="url(#filter11_i_366_681)">
+<circle cx="183.442" cy="185.828" r="14.4498" fill="white"/>
+<g filter="url(#filter12_ii_366_681)">
+<path d="M197.893 184.125C197.893 189.682 191.072 190.163 184.494 190.163C177.916 190.163 173.328 186.328 173.328 180.77C173.328 175.213 177.916 171.378 184.494 171.378C191.072 171.378 197.893 178.567 197.893 184.125Z" fill="#565656"/>
+</g>
+<line x1="183.445" y1="178.325" x2="193.56" y2="178.325" stroke="white" stroke-width="2"/>
+<line x1="189.508" y1="174.268" x2="189.508" y2="184.383" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter13_i_366_681)">
+<circle cx="140.09" cy="185.828" r="14.4498" fill="white"/>
+<g filter="url(#filter14_ii_366_681)">
+<path d="M154.541 184.125C154.541 189.682 147.72 190.163 141.142 190.163C134.565 190.163 129.977 186.328 129.977 180.77C129.977 175.213 134.565 171.378 141.142 171.378C147.72 171.378 154.541 178.567 154.541 184.125Z" fill="#565656"/>
+</g>
+<line x1="140.098" y1="178.325" x2="150.213" y2="178.325" stroke="white" stroke-width="2"/>
+<line x1="146.16" y1="174.268" x2="146.16" y2="184.383" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter15_diii_366_681)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M116.34 103.459C107.97 115.6 110.282 132.477 122.054 142.224C133.826 151.97 150.838 151.091 161.204 140.603L116.34 103.459Z" fill="#565656"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M208.199 103.459C216.569 115.6 214.257 132.477 202.485 142.224C190.713 151.97 173.701 151.091 163.335 140.603L208.199 103.459Z" fill="#565656"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M162.488 214.214L162.796 214.728L177.246 206.058L176.217 204.343L162.488 212.58L148.759 204.343L147.73 206.058L162.18 214.728L162.488 214.214Z" fill="black"/>
+<g filter="url(#filter16_ii_366_681)">
+<rect x="140.086" y="130.919" width="5.77992" height="5.77992" fill="white"/>
+</g>
+<g filter="url(#filter17_ii_366_681)">
+<rect x="147.312" y="135.254" width="2.88996" height="2.88996" fill="white"/>
+</g>
+<g filter="url(#filter18_ii_366_681)">
+<rect x="192.109" y="130.919" width="5.77992" height="5.77992" fill="white"/>
+</g>
+<g filter="url(#filter19_ii_366_681)">
+<rect x="199.332" y="135.254" width="2.88996" height="2.88996" fill="white"/>
+</g>
+<g filter="url(#filter20_i_366_681)">
+<path d="M224.167 190.507C222.975 186.727 214.062 183.959 213.058 183.636L211.924 183.304L206.896 203.736C206.68 203.469 206.442 203.219 206.184 202.99C205.258 202.242 204.183 201.682 203.026 201.345C201.869 201.007 200.652 200.898 199.449 201.025C194.806 201.385 191.091 204.582 191.163 208.15C191.189 208.907 191.376 209.65 191.714 210.334C192.051 211.018 192.532 211.628 193.125 212.125C194.141 212.986 195.365 213.586 196.686 213.87C197.747 214.109 198.84 214.185 199.925 214.095C204.093 213.776 207.499 211.167 208.108 208.063L212.472 190.329C213.489 190.687 214.871 191.225 216.313 191.881C217.761 192.442 219.082 193.269 220.201 194.317C221.085 195.219 220.128 196.32 220.051 196.409C219.371 197.026 218.622 197.57 217.818 198.029C217.582 198.167 217.411 198.387 217.34 198.643C217.268 198.899 217.301 199.171 217.433 199.404C217.564 199.637 217.783 199.813 218.045 199.895C218.307 199.977 218.592 199.959 218.841 199.845C219.118 199.664 225.92 196.051 224.167 190.507Z" fill="#C67EFF"/>
+</g>
+<g filter="url(#filter21_i_366_681)">
+<path d="M100.983 192.594C101.949 188.751 110.683 185.459 111.666 185.077L112.778 184.678L119.009 204.776C119.208 204.497 119.431 204.233 119.676 203.989C120.556 203.188 121.595 202.565 122.73 202.16C123.866 201.754 125.074 201.573 126.282 201.628C130.938 201.712 134.837 204.683 134.976 208.249C134.995 209.006 134.852 209.76 134.556 210.462C134.259 211.165 133.816 211.802 133.253 212.334C132.29 213.253 131.103 213.925 129.802 214.286C128.757 214.589 127.671 214.729 126.582 214.703C122.402 214.632 118.848 212.23 118.056 209.167L112.648 191.723C111.653 192.142 110.306 192.76 108.906 193.501C107.493 194.147 106.224 195.051 105.169 196.162C104.34 197.115 105.36 198.158 105.443 198.242C106.158 198.818 106.938 199.316 107.768 199.726C108.011 199.851 108.195 200.06 108.281 200.311C108.368 200.563 108.351 200.837 108.234 201.077C108.117 201.317 107.908 201.506 107.652 201.603C107.395 201.7 107.11 201.7 106.855 201.601C106.567 201.436 99.5624 198.233 100.983 192.594Z" fill="#F3ECA6"/>
+</g>
+<mask id="path-39-inside-3_366_681" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M248.694 238.498L227.259 215L214.498 226.64L225.202 238.374L215.246 244.056C214.386 243.88 213.491 243.8 212.575 243.828C206.219 244.024 201.224 249.335 201.42 255.691C201.615 262.047 206.926 267.042 213.282 266.847C218.219 266.695 222.335 263.458 223.835 259.041L245.869 246.466C247.441 246.195 250 244.348 249.998 242.5C249.998 240.904 249.657 238.874 248.694 238.498Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M248.694 238.498L227.259 215L214.498 226.64L225.202 238.374L215.246 244.056C214.386 243.88 213.491 243.8 212.575 243.828C206.219 244.024 201.224 249.335 201.42 255.691C201.615 262.047 206.926 267.042 213.282 266.847C218.219 266.695 222.335 263.458 223.835 259.041L245.869 246.466C247.441 246.195 250 244.348 249.998 242.5C249.998 240.904 249.657 238.874 248.694 238.498Z" fill="url(#paint0_linear_366_681)"/>
+<path d="M248.694 238.498L247.955 239.172L248.112 239.345L248.33 239.43L248.694 238.498ZM227.259 215L227.998 214.326L227.324 213.587L226.585 214.261L227.259 215ZM214.498 226.64L213.824 225.901L213.086 226.575L213.759 227.314L214.498 226.64ZM225.202 238.374L225.698 239.242L226.783 238.623L225.941 237.7L225.202 238.374ZM215.246 244.056L215.046 245.036L215.415 245.111L215.742 244.924L215.246 244.056ZM212.575 243.828L212.606 244.828L212.575 243.828ZM201.42 255.691L202.419 255.66L201.42 255.691ZM213.282 266.847L213.313 267.846H213.313L213.282 266.847ZM223.835 259.041L223.339 258.173L223.01 258.36L222.888 258.719L223.835 259.041ZM245.869 246.466L245.699 245.48L245.526 245.51L245.373 245.597L245.869 246.466ZM249.998 242.5H248.998V242.501L249.998 242.5ZM249.433 237.824L227.998 214.326L226.52 215.674L247.955 239.172L249.433 237.824ZM226.585 214.261L213.824 225.901L215.172 227.379L227.933 215.739L226.585 214.261ZM213.759 227.314L224.463 239.048L225.941 237.7L215.237 225.966L213.759 227.314ZM224.706 237.505L214.751 243.187L215.742 244.924L225.698 239.242L224.706 237.505ZM215.447 243.076C214.511 242.885 213.539 242.798 212.545 242.829L212.606 244.828C213.444 244.802 214.261 244.875 215.046 245.036L215.447 243.076ZM212.545 242.829C205.636 243.041 200.208 248.813 200.42 255.722L202.419 255.66C202.241 249.856 206.802 245.006 212.606 244.828L212.545 242.829ZM200.42 255.722C200.632 262.63 206.405 268.059 213.313 267.846L213.252 265.847C207.447 266.026 202.597 261.465 202.419 255.66L200.42 255.722ZM213.313 267.846C218.68 267.682 223.152 264.161 224.782 259.363L222.888 258.719C221.517 262.754 217.758 265.709 213.252 265.847L213.313 267.846ZM224.331 259.91L246.364 247.334L245.373 245.597L223.339 258.173L224.331 259.91ZM248.998 242.501C248.999 242.986 248.63 243.657 247.868 244.319C247.128 244.962 246.258 245.384 245.699 245.48L246.039 247.451C247.052 247.277 248.247 246.639 249.18 245.829C250.09 245.038 250.999 243.861 250.998 242.499L248.998 242.501ZM248.33 239.43C248.302 239.418 248.356 239.427 248.456 239.587C248.554 239.745 248.655 239.983 248.743 240.305C248.918 240.947 248.998 241.759 248.998 242.5H250.998C250.998 241.645 250.908 240.644 250.672 239.778C250.554 239.346 250.389 238.907 250.152 238.528C249.917 238.152 249.568 237.766 249.057 237.567L248.33 239.43Z" fill="url(#paint1_linear_366_681)" mask="url(#path-39-inside-3_366_681)"/>
+</g>
+<defs>
+<filter id="filter0_d_366_681" x="0" y="0" width="321.586" height="363" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="25"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.337255 0 0 0 0 0.360784 0 0 0 0 0.917647 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_366_681"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_366_681" result="shape"/>
+</filter>
+<filter id="filter1_i_366_681" x="65.3867" y="49" width="191.125" height="103.594" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter2_i_366_681" x="50.5" y="143.369" width="69.3594" height="82.9189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter3_i_366_681" x="202.227" y="143.369" width="69.3594" height="82.9189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter4_ii_366_681" x="127.531" y="219.508" width="26.2664" height="88.6987" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.7" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter5_ii_366_681" x="175.211" y="219.508" width="26.2664" height="88.6987" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.7" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter6_i_366_681" x="246.402" y="149.093" width="13.2266" height="72.4705" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter7_i_366_681" x="62.8906" y="149.093" width="13.2266" height="72.4705" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter8_ii_366_681" x="67.8594" y="67.3198" width="177.508" height="199.941" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-10" dy="-10"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="-3"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter9_ii_366_681" x="115.75" y="291.757" width="38.3477" height="21.7432" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter10_ii_366_681" x="163.652" y="291.757" width="38.3477" height="21.7432" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter11_i_366_681" x="167.992" y="170.378" width="29.9023" height="29.8997" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter12_ii_366_681" x="172.328" y="170.378" width="26.0664" height="20.2847" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter13_i_366_681" x="124.641" y="170.378" width="29.9023" height="29.8997" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter14_ii_366_681" x="128.977" y="170.378" width="26.0664" height="20.2847" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter15_diii_366_681" x="107.344" y="100.459" width="109.852" height="53.5713" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_366_681"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_366_681" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.35"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.979167 0 0 0 0 0.983333 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_366_681" result="effect3_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect3_innerShadow_366_681" result="effect4_innerShadow_366_681"/>
+</filter>
+<filter id="filter16_ii_366_681" x="139.586" y="130.419" width="6.28125" height="6.28003" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter17_ii_366_681" x="146.812" y="134.754" width="3.39062" height="3.38989" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter18_ii_366_681" x="191.609" y="130.419" width="6.28125" height="6.28003" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter19_ii_366_681" x="198.832" y="134.754" width="3.39062" height="3.38989" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_366_681" result="effect2_innerShadow_366_681"/>
+</filter>
+<filter id="filter20_i_366_681" x="190.164" y="182.304" width="34.293" height="31.8279" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<filter id="filter21_i_366_681" x="99.793" y="183.678" width="35.1836" height="31.0281" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_366_681"/>
+</filter>
+<linearGradient id="paint0_linear_366_681" x1="224.5" y1="220.5" x2="248" y2="260.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8D91F3" stop-opacity="0"/>
+<stop offset="0.214926" stop-color="#8D91F3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_366_681" x1="225.706" y1="215" x2="235.5" y2="231" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BFC1F4" stop-opacity="0"/>
+<stop offset="1" stop-color="#BFC1F4"/>
+</linearGradient>
+</defs>
+</svg>

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -6,6 +6,8 @@ class VideoPlayProvider with ChangeNotifier {
   late List<VideoPlayerController> controllers;
   late List<Future<void>> videoPlayerFutures;
 
+  late bool loading = false;
+
   List<String> videoLinks = [
     'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
     'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-4.mp4',

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/ui/widget/dancing_popo_widget.dart';
 import 'package:pocket_pose/ui/widget/home_video_frame_header_widget.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
@@ -62,10 +63,8 @@ class _HomeScreenState extends State<HomeScreen>
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.done) {
                     // 데이터가 수신되었을 때
+                    _videoPlayProvider.loading = true;
 
-                    if (_videoPlayProvider.loading == false) {
-                      _videoPlayProvider.loading = true;
-                    }
                     return Stack(children: <Widget>[
                       GestureDetector(
                         // 비디오 클릭 시 영상 정지/재생
@@ -111,8 +110,8 @@ class _HomeScreenState extends State<HomeScreen>
                       VideoFrameContentWidget(index: index),
                     ]);
                   } else {
-                    // 만약 VideoPlayerController가 여전히 초기화 중이라면, 로딩 스피너를 보여줌.
-                    return const Center(child: CircularProgressIndicator());
+                    // 만약 VideoPlayerController가 여전히 초기화 중이라면, 포포 로딩 스피너를 보여줌.
+                    return const DancingPopo();
                   }
                 });
           },

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -62,6 +62,10 @@ class _HomeScreenState extends State<HomeScreen>
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.done) {
                     // 데이터가 수신되었을 때
+
+                    if (_videoPlayProvider.loading == false) {
+                      _videoPlayProvider.loading = true;
+                    }
                     return Stack(children: <Widget>[
                       GestureDetector(
                         // 비디오 클릭 시 영상 정지/재생
@@ -83,7 +87,8 @@ class _HomeScreenState extends State<HomeScreen>
                       VideoFrameContentWidget(index: index),
                     ]);
                   } else if (snapshot.connectionState ==
-                      ConnectionState.waiting) {
+                          ConnectionState.waiting &&
+                      _videoPlayProvider.loading) {
                     // 데이터가 로딩중일 때
                     return Stack(children: <Widget>[
                       GestureDetector(

--- a/lib/ui/widget/dancing_popo_widget.dart
+++ b/lib/ui/widget/dancing_popo_widget.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class DancingPopo extends StatelessWidget {
+  const DancingPopo({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.black87,
+      child: SpinKitSpinningCircle(
+        size: 160.0,
+        duration: const Duration(milliseconds: 2400),
+        itemBuilder: (context, index) {
+          return Center(
+            child: SvgPicture.asset(
+              'assets/icons/ic_dancing_popo.svg',
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/widget/home_video_frame_content_widget.dart
+++ b/lib/ui/widget/home_video_frame_content_widget.dart
@@ -15,36 +15,39 @@ class VideoFrameContentWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
 
-    return Container(
-      //color: Colors.green,
-      margin: const EdgeInsets.fromLTRB(20, 620, 100, 80),
-      child: Column(children: <Widget>[
-        GestureDetector(
-          onTap: () {
-            Fluttertoast.showToast(msg: 'user 클릭');
-          },
-          child: Row(children: <Widget>[
-            ClipRRect(
-                borderRadius: BorderRadius.circular(50),
-                child:
-                    Image.asset(_videoPlayProvider.profiles[index], width: 35)),
-            const Padding(padding: EdgeInsets.only(left: 8)),
+    return Positioned(
+        bottom: 110,
+        left: 20,
+        child: SizedBox(
+          //color: Colors.green,
+          width: 300,
+          child: Column(children: <Widget>[
+            GestureDetector(
+              onTap: () {
+                Fluttertoast.showToast(msg: 'user 클릭');
+              },
+              child: Row(children: <Widget>[
+                ClipRRect(
+                    borderRadius: BorderRadius.circular(50),
+                    child: Image.asset(_videoPlayProvider.profiles[index],
+                        width: 35)),
+                const Padding(padding: EdgeInsets.only(left: 8)),
+                Text(
+                  _videoPlayProvider.nicknames[index],
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ]),
+            ),
+            const Padding(padding: EdgeInsets.only(bottom: 8)),
             Text(
-              _videoPlayProvider.nicknames[index],
-              style: const TextStyle(color: Colors.white),
+              _videoPlayProvider.contents[index],
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Colors.white,
+              ),
             ),
           ]),
-        ),
-        const Padding(padding: EdgeInsets.only(bottom: 8)),
-        Text(
-          _videoPlayProvider.contents[index],
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            color: Colors.white,
-          ),
-        ),
-      ]),
-    );
+        ));
   }
 }

--- a/lib/ui/widget/home_video_frame_right_widget.dart
+++ b/lib/ui/widget/home_video_frame_right_widget.dart
@@ -16,63 +16,65 @@ class VideoFrameRightWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
 
-    return Container(
-      //color: Colors.orange,
-      width: 60,
-      margin: const EdgeInsets.fromLTRB(330, 520, 10, 60),
-      child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            GestureDetector(
-              onTap: () {
-                Fluttertoast.showToast(msg: 'like 클릭');
-              },
-              child: Column(children: <Widget>[
-                SvgPicture.asset(
-                  'assets/icons/home_like.svg',
-                ),
-                const Padding(padding: EdgeInsets.only(bottom: 2)),
-                Text(
-                  _videoPlayProvider.likes[index],
-                  style: const TextStyle(color: Colors.white, fontSize: 12),
-                ),
-              ]),
-            ),
-            const Padding(padding: EdgeInsets.only(bottom: 14)),
-            GestureDetector(
-              onTap: () {
-                Fluttertoast.showToast(msg: 'chat 클릭');
-              },
-              child: Column(children: <Widget>[
-                SvgPicture.asset(
-                  'assets/icons/home_chat.svg',
-                ),
-                const Padding(padding: EdgeInsets.only(bottom: 2)),
-                Text(
-                  _videoPlayProvider.chats[index],
-                  style: const TextStyle(color: Colors.white, fontSize: 12),
-                ),
-              ]),
-            ),
-            const Padding(padding: EdgeInsets.only(bottom: 14)),
-            Column(children: <Widget>[
+    return Positioned(
+      right: 12,
+      bottom: 100,
+      child: SizedBox(
+        //color: Colors.orange,
+        width: 60,
+        child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
               GestureDetector(
                 onTap: () {
-                  Fluttertoast.showToast(msg: 'share 클릭');
+                  Fluttertoast.showToast(msg: 'like 클릭');
                 },
-                child: SvgPicture.asset(
-                  'assets/icons/home_share.svg',
+                child: Column(children: <Widget>[
+                  SvgPicture.asset(
+                    'assets/icons/home_like.svg',
+                  ),
+                  const Padding(padding: EdgeInsets.only(bottom: 2)),
+                  Text(
+                    _videoPlayProvider.likes[index],
+                    style: const TextStyle(color: Colors.white, fontSize: 12),
+                  ),
+                ]),
+              ),
+              const Padding(padding: EdgeInsets.only(bottom: 14)),
+              GestureDetector(
+                onTap: () {
+                  Fluttertoast.showToast(msg: 'chat 클릭');
+                },
+                child: Column(children: <Widget>[
+                  SvgPicture.asset(
+                    'assets/icons/home_chat.svg',
+                  ),
+                  const Padding(padding: EdgeInsets.only(bottom: 2)),
+                  Text(
+                    _videoPlayProvider.chats[index],
+                    style: const TextStyle(color: Colors.white, fontSize: 12),
+                  ),
+                ]),
+              ),
+              const Padding(padding: EdgeInsets.only(bottom: 14)),
+              Column(children: <Widget>[
+                GestureDetector(
+                  onTap: () {
+                    Fluttertoast.showToast(msg: 'share 클릭');
+                  },
+                  child: SvgPicture.asset(
+                    'assets/icons/home_share.svg',
+                  ),
+                )
+              ]),
+              const Padding(padding: EdgeInsets.only(bottom: 14)),
+              Column(children: <Widget>[
+                SvgPicture.asset(
+                  'assets/icons/home_progress.svg',
                 ),
-              ),
-              const Padding(padding: EdgeInsets.only(bottom: 2)),
+              ]),
             ]),
-            const Padding(padding: EdgeInsets.only(bottom: 14)),
-            Column(children: <Widget>[
-              SvgPicture.asset(
-                'assets/icons/home_progress.svg',
-              ),
-            ]),
-          ]),
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   audio_session:
     dependency: "direct main"
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
@@ -468,10 +468,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -484,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -516,10 +516,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -745,10 +745,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timing:
     dependency: transitive
     description:
@@ -894,5 +894,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=2.19.5 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -318,6 +318,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.15"
+  flutter_spinkit:
+    dependency: "direct main"
+    description:
+      name: flutter_spinkit
+      sha256: b39c753e909d4796906c5696a14daf33639a76e017136c8d82bf3e620ce5bb8e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   audioplayers: ^0.20.0
   video_player: ^2.6.1
   json_annotation: ^4.8.0
+  flutter_spinkit: ^5.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진

(애뮬레이터가 느려서 영상이 버벅거립니다)

https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/0f593059-1407-4f62-b271-7b8702dcc3f2

## ✅ 한 일
1. 앱 시작시 발생하는 로딩에만 포포 스피너로 로딩 되는 기능 구현
2. 커뮤니티 페이지의 바텀쪽에 있는 위젯을 화면 크기에 상관없이 동일하게 보이도록 수정

## 😥 어려웠던점
1. 갑자기 안드로이드 빌드 오류가 생겨서.. 해결하는데 엄청 시간 쓰다가 결국 다시 clone 받았습니다... 
2. 애뮬레이터................ ㅎ......엄청 버벅거리고 계속 지웠다 다시 깔고.... 2시간은 쓴 것 같습니다..
3. 원래는 배경에 애니메이션을 주고 싶었는데 자료가 없어서 일단 포포 캐릭터로 대체했습니다.. 나중에 계속 혼자 신경쓸 예정..


## 💃 부탁 드립니다~
1. 앱 입장시 포포 이미지로 로딩 잘 되는지 확인 부탁드립니다!
(만약에 안될 경우를 대비해서 민영님 핸드폰에 발표할 기존 버전 앱은 남겨둬주세요!!!)

## 🤓 다음에 할 일
1. 아이콘 이름 통일
3. 프로필 UI 개발
5. 카카오 로그인
