### PR TITLE
[ui] 스테이지 사용자 목록 다이얼로그 개발 (HH-233)

### DIFF
--- a/lib/data/entity/response/stage_user_list_response.dart
+++ b/lib/data/entity/response/stage_user_list_response.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
+
+part 'stage_user_list_response.g.dart';
+
+@JsonSerializable()
+class StageUserListResponse {
+  List<StageUserListItem>? list;
+
+  StageUserListResponse({
+    required this.list,
+  });
+
+  factory StageUserListResponse.fromJson(Map<String, dynamic> json) =>
+      _$StageUserListResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageUserListResponseToJson(this);
+}

--- a/lib/data/entity/response/stage_user_list_response.g.dart
+++ b/lib/data/entity/response/stage_user_list_response.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_user_list_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageUserListResponse _$StageUserListResponseFromJson(
+        Map<String, dynamic> json) =>
+    StageUserListResponse(
+      list: (json['list'] as List<dynamic>?)
+          ?.map((e) => StageUserListItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$StageUserListResponseToJson(
+        StageUserListResponse instance) =>
+    <String, dynamic>{
+      'list': instance.list,
+    };

--- a/lib/domain/entity/stage_user_list_item.dart
+++ b/lib/domain/entity/stage_user_list_item.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'stage_user_list_item.g.dart';
+
+@JsonSerializable()
+class StageUserListItem {
+  String userId = "";
+  String nickname = "";
+  String? profileImg;
+
+  StageUserListItem(
+      {required this.userId, required this.nickname, this.profileImg});
+
+  factory StageUserListItem.fromJson(Map<String, dynamic> json) =>
+      _$StageUserListItemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageUserListItemToJson(this);
+}

--- a/lib/domain/entity/stage_user_list_item.g.dart
+++ b/lib/domain/entity/stage_user_list_item.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_user_list_item.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageUserListItem _$StageUserListItemFromJson(Map<String, dynamic> json) =>
+    StageUserListItem(
+      userId: json['userId'] as String,
+      nickname: json['nickname'] as String,
+      profileImg: json['profileImg'] as String?,
+    );
+
+Map<String, dynamic> _$StageUserListItemToJson(StageUserListItem instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'nickname': instance.nickname,
+      'profileImg': instance.profileImg,
+    };

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -2,12 +2,84 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
+import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
 import 'package:provider/provider.dart';
+
+final userListItem = {
+  "list": [
+    {
+      "userId": "1",
+      "profileImg": "assets/images/home_profile_1.jpg",
+      "nickname": "나비"
+    },
+    {
+      "userId": "2",
+      "profileImg": "assets/images/home_profile_2.jpg",
+      "nickname": "고양이"
+    },
+    {
+      "userId": "3",
+      "profileImg": "assets/images/home_profile_3.jpg",
+      "nickname": "네코"
+    },
+    {
+      "userId": "4",
+      "profileImg": "assets/images/home_profile_4.jpg",
+      "nickname": "냥코"
+    },
+    {
+      "userId": "5",
+      "profileImg": "assets/images/home_profile_5.jpg",
+      "nickname": "멍멍이"
+    },
+    {
+      "userId": "6",
+      "profileImg": "assets/images/home_profile_1.jpg",
+      "nickname": "강아지"
+    },
+    {
+      "userId": "7",
+      "profileImg": "assets/images/home_profile_2.jpg",
+      "nickname": "개"
+    },
+    {
+      "userId": "8",
+      "profileImg": "assets/images/home_profile_3.jpg",
+      "nickname": "포챠코"
+    },
+    {
+      "userId": "9",
+      "profileImg": "assets/images/home_profile_4.jpg",
+      "nickname": "왕왕이"
+    },
+    {
+      "userId": "10",
+      "profileImg": "assets/images/home_profile_5.jpg",
+      "nickname": "컹컹이"
+    },
+    {
+      "userId": "11",
+      "profileImg": "assets/images/home_profile_1.jpg",
+      "nickname": "왈왈이"
+    },
+    {
+      "userId": "12",
+      "profileImg": "assets/images/home_profile_2.jpg",
+      "nickname": "바둑이"
+    },
+    {
+      "userId": "13",
+      "profileImg": "assets/images/home_profile_3.jpg",
+      "nickname": "마리"
+    },
+  ]
+};
+StageUserListResponse? userList;
 
 enum StageStage { waitState, catchState, playState, resultState }
 
@@ -152,6 +224,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   }
 
   Future<dynamic> showUserListDialog() {
+    userList = StageUserListResponse.fromJson(userListItem);
+
     return showDialog(
         context: context,
         barrierColor: Colors.transparent,
@@ -192,7 +266,37 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 ),
               ],
             ),
-            content: const Text("context"),
+            content: SizedBox(
+              width: 300,
+              height: 400,
+              child: GridView.builder(
+                itemCount: userList!.list!.length,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                ),
+                itemBuilder: (BuildContext context, int index) {
+                  return Column(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(50),
+                        child: Image.asset(
+                          userList!.list!.elementAt(index).profileImg!,
+                          width: 58,
+                          height: 58,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      Text(
+                        userList!.list!.elementAt(index).nickname,
+                        style: const TextStyle(
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
           );
         });
   }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -128,7 +128,52 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     return Container(
       margin: const EdgeInsets.only(right: 16.0, top: 10.0, bottom: 10.0),
       child: OutlinedButton.icon(
-        onPressed: () {},
+        onPressed: () {
+          showDialog(
+            context: context,
+            barrierColor: Colors.transparent,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                  side: const BorderSide(
+                    color: Colors.white,
+                    width: 1.0,
+                  ),
+                ),
+                backgroundColor: Colors.white.withOpacity(0.4),
+                title: Row(
+                  children: [
+                    const Expanded(
+                      child: Padding(
+                        padding: EdgeInsets.only(left: 20),
+                        child: Text(
+                          '참여자 목록',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        Navigator.of(context).pop();
+                      },
+                      child: const Icon(
+                        Icons.close,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ],
+                ),
+                content: const Text('내용'),
+              );
+            },
+          );
+        },
         style: OutlinedButton.styleFrom(
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(30.0),

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -129,50 +129,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       margin: const EdgeInsets.only(right: 16.0, top: 10.0, bottom: 10.0),
       child: OutlinedButton.icon(
         onPressed: () {
-          showDialog(
-            context: context,
-            barrierColor: Colors.transparent,
-            builder: (BuildContext context) {
-              return AlertDialog(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                  side: const BorderSide(
-                    color: Colors.white,
-                    width: 1.0,
-                  ),
-                ),
-                backgroundColor: Colors.white.withOpacity(0.4),
-                title: Row(
-                  children: [
-                    const Expanded(
-                      child: Padding(
-                        padding: EdgeInsets.only(left: 20),
-                        child: Text(
-                          '참여자 목록',
-                          style: TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                    ),
-                    GestureDetector(
-                      onTap: () {
-                        Navigator.of(context).pop();
-                      },
-                      child: const Icon(
-                        Icons.close,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
-                ),
-                content: const Text('내용'),
-              );
-            },
-          );
+          showUserListDialog();
         },
         style: OutlinedButton.styleFrom(
           shape: RoundedRectangleBorder(
@@ -192,6 +149,52 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         ),
       ),
     );
+  }
+
+  Future<dynamic> showUserListDialog() {
+    return showDialog(
+        context: context,
+        barrierColor: Colors.transparent,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10.0),
+              side: const BorderSide(
+                color: Colors.white,
+                width: 1.0,
+              ),
+            ),
+            backgroundColor: Colors.white.withOpacity(0.4),
+            title: Row(
+              children: [
+                const Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(left: 20),
+                    child: Text(
+                      '참여자 목록',
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Icon(
+                    Icons.close,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+            content: const Text("context"),
+          );
+        });
   }
 
   Widget getStageView(StageStage state) {

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
@@ -230,71 +231,78 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         context: context,
         barrierColor: Colors.transparent,
         builder: (BuildContext context) {
-          return AlertDialog(
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10.0),
-              side: const BorderSide(
-                color: Colors.white,
-                width: 1.0,
+          return BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+            child: AlertDialog(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10.0),
+                side: const BorderSide(
+                  color: Colors.white,
+                  width: 1.0,
+                ),
               ),
-            ),
-            backgroundColor: Colors.white.withOpacity(0.4),
-            title: Row(
-              children: [
-                const Expanded(
-                  child: Padding(
-                    padding: EdgeInsets.only(left: 20),
-                    child: Text(
-                      '참여자 목록',
-                      style: TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
+              backgroundColor: Colors.white.withOpacity(0.3),
+              title: Row(
+                children: [
+                  const Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.only(left: 20),
+                      child: Text(
+                        '참여자 목록',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
                     ),
                   ),
-                ),
-                GestureDetector(
-                  onTap: () {
-                    Navigator.of(context).pop();
-                  },
-                  child: const Icon(
-                    Icons.close,
-                    color: Colors.white,
+                  GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).pop();
+                    },
+                    child: const Icon(
+                      Icons.close,
+                      size: 20,
+                      color: Colors.white,
+                    ),
                   ),
-                ),
-              ],
-            ),
-            content: SizedBox(
-              width: 300,
-              height: 400,
-              child: GridView.builder(
-                itemCount: userList!.list!.length,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 3,
-                ),
-                itemBuilder: (BuildContext context, int index) {
-                  return Column(
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(50),
-                        child: Image.asset(
-                          userList!.list!.elementAt(index).profileImg!,
-                          width: 58,
-                          height: 58,
-                          fit: BoxFit.cover,
+                ],
+              ),
+              content: SizedBox(
+                width: 265,
+                height: 365,
+                child: GridView.builder(
+                  itemCount: userList!.list!.length,
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                  ),
+                  itemBuilder: (BuildContext context, int index) {
+                    return Column(
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(50),
+                          child: Image.asset(
+                            userList!.list!.elementAt(index).profileImg!,
+                            width: 58,
+                            height: 58,
+                            fit: BoxFit.cover,
+                          ),
                         ),
-                      ),
-                      Text(
-                        userList!.list!.elementAt(index).nickname,
-                        style: const TextStyle(
-                          fontSize: 12,
+                        const SizedBox(
+                          height: 4,
                         ),
-                      ),
-                    ],
-                  );
-                },
+                        Text(
+                          userList!.list!.elementAt(index).nickname,
+                          style: const TextStyle(
+                            fontSize: 12,
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                ),
               ),
             ),
           );

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -107,9 +107,11 @@ class _CameraViewState extends State<CameraView> {
       if (_seconds == 1) {
         _stopTimer();
 
-        setState(() {
-          _countdownVisibility = false;
-        });
+        if (mounted) {
+          setState(() {
+            _countdownVisibility = false;
+          });
+        }
         AudioPlayerUtil().play(
             "https://popo2023.s3.ap-northeast-2.amazonaws.com/music/M3-1.mp3",
             widget.setIsSkeletonDetectMode);


### PR DESCRIPTION
## 📱 작업 사진 
<img width="250" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/adfeeccf-7be0-4fd0-b139-67e1a4d3f176">

## 💬 작업 설명
- 포포 스테이지 오른쪽 상단의 사용자 버튼을 누르면 사용자 목록 다이얼로그가 뜨도록 개발했습니다.

## ✅ 한 일
1. 사용자 목록 다이얼로그 추가
2. ui 디자인
3. 더미 데이터 추가

## ☝️ 참고 하세요~
1. 기존 UI와 다른 부분이 있습니다.
    - 다이얼로그 내부만 블러처리 > 뒷배경까지 블러처리로 수정: 다이얼로그에 집중시키기 위함
    - x버튼 위치 수정: 이게 더 안정적이어 보여서 수정했슴다...
    - 바텀 패딩 없는데 있도록 수정: 어느정도 공간이 있는 게 사용자가 인식하기 편할 거 같아서 수정

## 🤓 다음에 할 일
1. 포포 스테이지 실시간 채팅 ui 개발
2. 포포 스테이지 입장 시 나는 오류 고치기

