### PR TITLE
[ui] 스테이지 실시간 채팅 바 ui 생성(HH-234)

### DIFF
--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -97,6 +97,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
+  final TextEditingController _textController = TextEditingController();
 
   StageStage _stageStage = StageStage.waitState;
   @override
@@ -153,6 +154,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Scaffold(
+        resizeToAvoidBottomInset: false,
         body: Container(
             decoration: BoxDecoration(
               image: DecorationImage(
@@ -163,6 +165,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
               ),
             ),
             child: Scaffold(
+              resizeToAvoidBottomInset: false,
               extendBodyBehindAppBar: true,
               backgroundColor: Colors.transparent,
               appBar: AppBar(
@@ -175,7 +178,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 elevation: 0.0,
                 leading: IconButton(
                   onPressed: () {
-                    AudioPlayerUtil().stop();
                     AudioPlayerUtil().stop();
                     if (widget.getIndex() == 0) {
                       Navigator.pop(context);
@@ -192,7 +194,66 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 ],
               ),
               body: getStageView(_stageStage),
+              bottomSheet: SafeArea(
+                child: Padding(
+                  padding: EdgeInsets.only(
+                      bottom: MediaQuery.of(context).viewInsets.bottom),
+                  child: Container(
+                    width: double.infinity,
+                    color: Colors.white,
+                    child: TextField(
+                      controller: _textController,
+                      cursorColor: Colors.white,
+                      decoration: const InputDecoration(
+                        hintText: 'nickname(으)로 댓글 달기...',
+                        labelStyle: TextStyle(color: Colors.grey),
+                        border: InputBorder.none,
+                      ),
+                      textInputAction: TextInputAction.next,
+                    ),
+                  ),
+                ),
+              ),
             )),
+      ),
+    );
+  }
+
+  Widget buildInputArea() {
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Row(
+        children: [
+          Container(
+            height: 50,
+            padding: const EdgeInsets.only(left: 15),
+            decoration: BoxDecoration(
+              color: Colors.black12,
+              borderRadius: BorderRadius.circular(36),
+            ),
+            child: TextField(
+              controller: _textController,
+              cursorColor: Colors.white,
+              decoration: const InputDecoration(
+                hintText: '메시지 보내기',
+                labelStyle: TextStyle(color: Colors.grey),
+                border: InputBorder.none,
+              ),
+              textInputAction: TextInputAction.next,
+            ),
+          ),
+          const SizedBox(
+            width: 10,
+          ),
+          IconButton(
+            icon: const Icon(
+              Icons.send,
+              size: 30,
+              color: Colors.grey,
+            ),
+            onPressed: () => {},
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -9,6 +9,7 @@ import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
+import 'package:pocket_pose/ui/widget/stage/stage_live_chat_widget.dart';
 import 'package:provider/provider.dart';
 
 final userListItem = {
@@ -98,14 +99,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen>
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
-  final TextEditingController _textController = TextEditingController();
-  final FocusNode _inputFieldFocusNode = FocusNode();
-  bool _isFireIconVisible = true;
-
-  List<Widget> selectWidgets = [];
-  final List<AnimationController> _animationControllers = [];
-  final List<Animation<Offset>> _animations = [];
-  bool isLeft = true;
 
   StageStage _stageStage = StageStage.waitState;
   @override
@@ -113,11 +106,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen>
     super.initState();
 
     _startTimer();
-    _inputFieldFocusNode.addListener(() {
-      setState(() {
-        _isFireIconVisible = (_inputFieldFocusNode.hasFocus) ? false : true;
-      });
-    });
   }
 
   @override
@@ -126,11 +114,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen>
     if (widget.getIndex() == 0) {
       _videoPlayProvider.playVideo();
     }
-    for (final animationController in _animationControllers) {
-      animationController.dispose();
-    }
-    _textController.dispose();
-    _inputFieldFocusNode.dispose();
     super.dispose();
   }
 
@@ -164,13 +147,12 @@ class _PoPoStageScreenState extends State<PoPoStageScreen>
                 body: Stack(
                   children: [
                     _buildStageView(_stageStage),
-                    Positioned(
+                    const Positioned(
                       bottom: 0,
                       left: 0,
                       right: 0,
-                      child: _buildInputArea(context),
+                      child: StageLiveChatWidget(),
                     ),
-                    ...selectWidgets,
                   ],
                 ),
               )),
@@ -237,80 +219,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen>
   }
 
   bool getIsResultState() => _stageStage == StageStage.resultState;
-
-  SafeArea _buildInputArea(BuildContext context) {
-    return SafeArea(
-      child: Container(
-        color: Colors.black.withOpacity(0.3),
-        child: Padding(
-          padding:
-              EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-          child: Row(
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(14),
-                  child: Container(
-                    padding: const EdgeInsets.only(left: 14),
-                    width: double.infinity,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(36),
-                      color: Colors.transparent,
-                      border: Border.all(
-                        color: Colors.white,
-                        width: 2.0,
-                      ),
-                    ),
-                    child: TextField(
-                      style: const TextStyle(color: Colors.white),
-                      controller: _textController,
-                      cursorColor: Colors.white,
-                      focusNode: _inputFieldFocusNode,
-                      decoration: const InputDecoration(
-                        hintText: 'nickname(으)로 댓글 달기...',
-                        hintStyle: TextStyle(color: Colors.white70),
-                        labelStyle: TextStyle(color: Colors.white),
-                        border: InputBorder.none,
-                      ),
-                      textInputAction: TextInputAction.next,
-                    ),
-                  ),
-                ),
-              ),
-              AnimatedContainer(
-                duration: const Duration(milliseconds: 300),
-                width: _isFireIconVisible ? 20 : 0,
-                child: Visibility(
-                  visible: _isFireIconVisible,
-                  child: InkWell(
-                    highlightColor: Colors.transparent,
-                    splashColor: Colors.transparent,
-                    onTap: _handleIconClick,
-                    child: SvgPicture.asset(
-                        'assets/icons/ic_popo_fire_unselect.svg'),
-                  ),
-                ),
-              ),
-              AnimatedContainer(
-                duration: const Duration(milliseconds: 300),
-                width: _isFireIconVisible ? 14 : 0,
-                child: Visibility(
-                  visible: _isFireIconVisible,
-                  child: InkWell(
-                      highlightColor: Colors.transparent,
-                      splashColor: Colors.transparent,
-                      onTap: _handleIconClick,
-                      child: const SizedBox(
-                        width: 14,
-                      )),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 
   Container _buildUserCountWidget() {
     return Container(
@@ -441,85 +349,5 @@ class _PoPoStageScreenState extends State<PoPoStageScreen>
       default:
         return const PoPoWaitView();
     }
-  }
-
-  void _handleIconClick() {
-    setState(() {
-      isLeft = !isLeft;
-
-      final animationController = AnimationController(
-        duration: const Duration(milliseconds: 4000),
-        vsync: this,
-      );
-
-      const beginOffset = Offset(0.0, 0.0);
-      final middleOffset =
-          isLeft ? const Offset(-8.0, -100.0) : const Offset(8.0, -100.0);
-      const endOffset = Offset(0.0, -200.0);
-
-      final animation = TweenSequence([
-        TweenSequenceItem(
-          tween: Tween<Offset>(begin: beginOffset, end: middleOffset),
-          weight: 0.5,
-        ),
-        TweenSequenceItem(
-          tween: Tween<Offset>(begin: middleOffset, end: endOffset),
-          weight: 0.5,
-        ),
-      ]).animate(CurvedAnimation(
-        parent: animationController,
-        curve: Curves.easeInOut,
-      ));
-      animationController.addListener(() {
-        setState(() {});
-      });
-
-      animationController.addStatusListener((status) {
-        if (status == AnimationStatus.completed) {
-          setState(() {
-            selectWidgets.removeAt(0);
-            _animationControllers.removeAt(0);
-            _animations.removeAt(0);
-          });
-        }
-      });
-
-      selectWidgets.add(_buildSelectWidget(
-        selectWidgets.length,
-        animationController,
-        animation,
-      ));
-      _animationControllers.add(animationController);
-      _animations.add(animation);
-    });
-
-    _animationControllers.last.forward(from: 0);
-  }
-
-  Widget _buildSelectWidget(int index, AnimationController animationController,
-      Animation<Offset> animation) {
-    return Positioned(
-      bottom: 14,
-      right: 0,
-      child: AnimatedBuilder(
-        animation: animation,
-        builder: (context, child) {
-          return Transform.translate(
-            offset: Offset(
-              animation.value.dx,
-              animation.value.dy,
-            ),
-            child: FadeTransition(
-              opacity: animationController.drive(Tween(begin: 1.0, end: 0.0)),
-              child: child,
-            ),
-          );
-        },
-        child: Image.asset(
-          'assets/icons/ic_popo_fire_select.png',
-          height: 50,
-        ),
-      ),
-    );
   }
 }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -92,12 +92,18 @@ class PoPoStageScreen extends StatefulWidget {
   State<PoPoStageScreen> createState() => _PoPoStageScreenState();
 }
 
-class _PoPoStageScreenState extends State<PoPoStageScreen> {
+class _PoPoStageScreenState extends State<PoPoStageScreen>
+    with TickerProviderStateMixin {
   int _userCount = 1;
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
   final TextEditingController _textController = TextEditingController();
+
+  List<Widget> selectWidgets = [];
+  final List<AnimationController> _animationControllers = [];
+  final List<Animation<Offset>> _animations = [];
+  bool isLeft = true;
 
   StageStage _stageStage = StageStage.waitState;
   @override
@@ -112,6 +118,9 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     AudioPlayerUtil().stop();
     if (widget.getIndex() == 0) {
       _videoPlayProvider.playVideo();
+    }
+    for (final animationController in _animationControllers) {
+      animationController.dispose();
     }
     super.dispose();
   }
@@ -202,6 +211,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                     right: 0,
                     child: buildInputArea(context),
                   ),
+                  ...selectWidgets,
                 ],
               ),
             )),
@@ -216,29 +226,48 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         child: Padding(
           padding:
               EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-          child: Container(
-            padding: const EdgeInsets.only(left: 15),
-            width: double.infinity,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(36),
-              color: Colors.transparent,
-              border: Border.all(
-                color: Colors.white,
-                width: 2.0,
+          child: Row(
+            children: [
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(14),
+                  child: Container(
+                    padding: const EdgeInsets.only(left: 14),
+                    width: double.infinity,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(36),
+                      color: Colors.transparent,
+                      border: Border.all(
+                        color: Colors.white,
+                        width: 2.0,
+                      ),
+                    ),
+                    child: TextField(
+                      style: const TextStyle(color: Colors.white),
+                      controller: _textController,
+                      cursorColor: Colors.white,
+                      decoration: const InputDecoration(
+                        hintText: 'nickname(으)로 댓글 달기...',
+                        hintStyle: TextStyle(color: Colors.white70),
+                        labelStyle: TextStyle(color: Colors.white),
+                        border: InputBorder.none,
+                      ),
+                      textInputAction: TextInputAction.next,
+                    ),
+                  ),
+                ),
               ),
-            ),
-            child: TextField(
-              style: const TextStyle(color: Colors.white),
-              controller: _textController,
-              cursorColor: Colors.white,
-              decoration: const InputDecoration(
-                hintText: 'nickname(으)로 댓글 달기...',
-                hintStyle: TextStyle(color: Colors.white70),
-                labelStyle: TextStyle(color: Colors.white),
-                border: InputBorder.none,
+              InkWell(
+                highlightColor: Colors.transparent,
+                splashColor: Colors.transparent,
+                onTap: _handleIconClick,
+                child:
+                    SvgPicture.asset('assets/icons/ic_popo_fire_unselect.svg'),
               ),
-              textInputAction: TextInputAction.next,
-            ),
+              const SizedBox(
+                width: 14,
+              )
+            ],
           ),
         ),
       ),
@@ -374,5 +403,85 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       default:
         return const PoPoWaitView();
     }
+  }
+
+  void _handleIconClick() {
+    setState(() {
+      isLeft = !isLeft;
+
+      final animationController = AnimationController(
+        duration: const Duration(milliseconds: 4000),
+        vsync: this,
+      );
+
+      const beginOffset = Offset(0.0, 0.0);
+      final middleOffset =
+          isLeft ? const Offset(-8.0, -100.0) : const Offset(8.0, -100.0);
+      const endOffset = Offset(0.0, -200.0);
+
+      final animation = TweenSequence([
+        TweenSequenceItem(
+          tween: Tween<Offset>(begin: beginOffset, end: middleOffset),
+          weight: 0.5,
+        ),
+        TweenSequenceItem(
+          tween: Tween<Offset>(begin: middleOffset, end: endOffset),
+          weight: 0.5,
+        ),
+      ]).animate(CurvedAnimation(
+        parent: animationController,
+        curve: Curves.easeInOut,
+      ));
+      animationController.addListener(() {
+        setState(() {});
+      });
+
+      animationController.addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          setState(() {
+            selectWidgets.removeAt(0);
+            _animationControllers.removeAt(0);
+            _animations.removeAt(0);
+          });
+        }
+      });
+
+      selectWidgets.add(buildSelectWidget(
+        selectWidgets.length,
+        animationController,
+        animation,
+      ));
+      _animationControllers.add(animationController);
+      _animations.add(animation);
+    });
+
+    _animationControllers.last.forward(from: 0);
+  }
+
+  Widget buildSelectWidget(int index, AnimationController animationController,
+      Animation<Offset> animation) {
+    return Positioned(
+      bottom: 0,
+      right: 0,
+      child: AnimatedBuilder(
+        animation: animation,
+        builder: (context, child) {
+          return Transform.translate(
+            offset: Offset(
+              animation.value.dx,
+              animation.value.dy,
+            ),
+            child: FadeTransition(
+              opacity: animationController.drive(Tween(begin: 1.0, end: 0.0)),
+              child: child,
+            ),
+          );
+        },
+        child: Image.asset(
+          'assets/icons/ic_popo_fire_select.png',
+          height: 50,
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -93,8 +93,7 @@ class PoPoStageScreen extends StatefulWidget {
   State<PoPoStageScreen> createState() => _PoPoStageScreenState();
 }
 
-class _PoPoStageScreenState extends State<PoPoStageScreen>
-    with TickerProviderStateMixin {
+class _PoPoStageScreenState extends State<PoPoStageScreen> {
   int _userCount = 1;
   int _count = 1;
   late Timer _timer;

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -193,67 +193,54 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                   userCountWidget(),
                 ],
               ),
-              body: getStageView(_stageStage),
-              bottomSheet: SafeArea(
-                child: Padding(
-                  padding: EdgeInsets.only(
-                      bottom: MediaQuery.of(context).viewInsets.bottom),
-                  child: Container(
-                    width: double.infinity,
-                    color: Colors.white,
-                    child: TextField(
-                      controller: _textController,
-                      cursorColor: Colors.white,
-                      decoration: const InputDecoration(
-                        hintText: 'nickname(으)로 댓글 달기...',
-                        labelStyle: TextStyle(color: Colors.grey),
-                        border: InputBorder.none,
-                      ),
-                      textInputAction: TextInputAction.next,
-                    ),
+              body: Stack(
+                children: [
+                  getStageView(_stageStage),
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: buildInputArea(context),
                   ),
-                ),
+                ],
               ),
             )),
       ),
     );
   }
 
-  Widget buildInputArea() {
-    return Padding(
-      padding: const EdgeInsets.all(10),
-      child: Row(
-        children: [
-          Container(
-            height: 50,
+  SafeArea buildInputArea(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        color: Colors.black.withOpacity(0.3),
+        child: Padding(
+          padding:
+              EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+          child: Container(
             padding: const EdgeInsets.only(left: 15),
+            width: double.infinity,
             decoration: BoxDecoration(
-              color: Colors.black12,
               borderRadius: BorderRadius.circular(36),
+              color: Colors.transparent,
+              border: Border.all(
+                color: Colors.white,
+                width: 2.0,
+              ),
             ),
             child: TextField(
+              style: const TextStyle(color: Colors.white),
               controller: _textController,
               cursorColor: Colors.white,
               decoration: const InputDecoration(
-                hintText: '메시지 보내기',
-                labelStyle: TextStyle(color: Colors.grey),
+                hintText: 'nickname(으)로 댓글 달기...',
+                hintStyle: TextStyle(color: Colors.white70),
+                labelStyle: TextStyle(color: Colors.white),
                 border: InputBorder.none,
               ),
               textInputAction: TextInputAction.next,
             ),
           ),
-          const SizedBox(
-            width: 10,
-          ),
-          IconButton(
-            icon: const Icon(
-              Icons.send,
-              size: 30,
-              color: Colors.grey,
-            ),
-            onPressed: () => {},
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -116,9 +116,11 @@ class _CameraViewState extends State<CameraView> {
             "https://popo2023.s3.ap-northeast-2.amazonaws.com/music/M3-1.mp3",
             widget.setIsSkeletonDetectMode);
       } else {
-        setState(() {
-          _seconds--;
-        });
+        if (mounted) {
+          setState(() {
+            _seconds--;
+          });
+        }
       }
     });
   }

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -138,6 +138,7 @@ class _CameraViewState extends State<CameraView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: Colors.transparent,
       // 카메라 화면 보여주기 + 화면에서 실시간으로 포즈 추출
       body: _liveFeedBody(),

--- a/lib/ui/widget/stage/stage_live_chat_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_widget.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class StageLiveChatWidget extends StatefulWidget {
+  const StageLiveChatWidget({super.key});
+
+  @override
+  State<StageLiveChatWidget> createState() => _StageLiveChatWidgetState();
+}
+
+class _StageLiveChatWidgetState extends State<StageLiveChatWidget>
+    with TickerProviderStateMixin {
+  final TextEditingController _textController = TextEditingController();
+  final FocusNode _inputFieldFocusNode = FocusNode();
+  bool _isFireIconVisible = true;
+
+  List<Widget> selectWidgets = [];
+  final List<AnimationController> _animationControllers = [];
+  final List<Animation<Offset>> _animations = [];
+  bool isLeft = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _inputFieldFocusNode.addListener(() {
+      setState(() {
+        _isFireIconVisible = (_inputFieldFocusNode.hasFocus) ? false : true;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    for (final animationController in _animationControllers) {
+      animationController.dispose();
+    }
+    _textController.dispose();
+    _inputFieldFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildInputArea(context);
+  }
+
+  SafeArea _buildInputArea(BuildContext context) {
+    return SafeArea(
+      child: Stack(
+        children: [
+          Container(
+            color: Colors.black.withOpacity(0.3),
+            child: Padding(
+              padding: EdgeInsets.only(
+                  bottom: MediaQuery.of(context).viewInsets.bottom),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(14),
+                      child: Container(
+                        padding: const EdgeInsets.only(left: 14),
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(36),
+                          color: Colors.transparent,
+                          border: Border.all(
+                            color: Colors.white,
+                            width: 2.0,
+                          ),
+                        ),
+                        child: TextField(
+                          style: const TextStyle(color: Colors.white),
+                          controller: _textController,
+                          cursorColor: Colors.white,
+                          focusNode: _inputFieldFocusNode,
+                          decoration: const InputDecoration(
+                            hintText: 'nickname(으)로 댓글 달기...',
+                            hintStyle: TextStyle(color: Colors.white70),
+                            labelStyle: TextStyle(color: Colors.white),
+                            border: InputBorder.none,
+                          ),
+                          textInputAction: TextInputAction.next,
+                        ),
+                      ),
+                    ),
+                  ),
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 300),
+                    width: _isFireIconVisible ? 20 : 0,
+                    child: Visibility(
+                      visible: _isFireIconVisible,
+                      child: InkWell(
+                        highlightColor: Colors.transparent,
+                        splashColor: Colors.transparent,
+                        onTap: _handleIconClick,
+                        child: SvgPicture.asset(
+                            'assets/icons/ic_popo_fire_unselect.svg'),
+                      ),
+                    ),
+                  ),
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 300),
+                    width: _isFireIconVisible ? 14 : 0,
+                    child: Visibility(
+                      visible: _isFireIconVisible,
+                      child: InkWell(
+                          highlightColor: Colors.transparent,
+                          splashColor: Colors.transparent,
+                          onTap: _handleIconClick,
+                          child: const SizedBox(
+                            width: 14,
+                          )),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          ...selectWidgets
+        ],
+      ),
+    );
+  }
+
+  void _handleIconClick() {
+    setState(() {
+      isLeft = !isLeft;
+
+      final animationController = AnimationController(
+        duration: const Duration(milliseconds: 4000),
+        vsync: this,
+      );
+
+      const beginOffset = Offset(0.0, 0.0);
+      final middleOffset =
+          isLeft ? const Offset(-8.0, -100.0) : const Offset(8.0, -100.0);
+      const endOffset = Offset(0.0, -200.0);
+
+      final animation = TweenSequence([
+        TweenSequenceItem(
+          tween: Tween<Offset>(begin: beginOffset, end: middleOffset),
+          weight: 0.5,
+        ),
+        TweenSequenceItem(
+          tween: Tween<Offset>(begin: middleOffset, end: endOffset),
+          weight: 0.5,
+        ),
+      ]).animate(CurvedAnimation(
+        parent: animationController,
+        curve: Curves.easeInOut,
+      ));
+      animationController.addListener(() {
+        setState(() {});
+      });
+
+      animationController.addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          setState(() {
+            selectWidgets.removeAt(0);
+            _animationControllers.removeAt(0);
+            _animations.removeAt(0);
+          });
+        }
+      });
+
+      selectWidgets.add(_buildSelectWidget(
+        selectWidgets.length,
+        animationController,
+        animation,
+      ));
+      _animationControllers.add(animationController);
+      _animations.add(animation);
+    });
+
+    _animationControllers.last.forward(from: 0);
+  }
+
+  Widget _buildSelectWidget(int index, AnimationController animationController,
+      Animation<Offset> animation) {
+    return Positioned(
+      bottom: 14,
+      right: 0,
+      child: AnimatedBuilder(
+        animation: animation,
+        builder: (context, child) {
+          return Transform.translate(
+            offset: Offset(
+              animation.value.dx,
+              animation.value.dy,
+            ),
+            child: FadeTransition(
+              opacity: animationController.drive(Tween(begin: 1.0, end: 0.0)),
+              child: child,
+            ),
+          );
+        },
+        child: Image.asset(
+          'assets/icons/ic_popo_fire_select.png',
+          height: 50,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/08290438-8dc4-47db-a5b1-488418e0b5c5

## 💬 작업 설명
- 포포 스테이지의 모든 상태 내내 보이는 실시간 채팅 바 ui를 개발했습니다.
- 서연님께서 만드신 불꽃 애니메이션도 추가하였습니다!
- 키보드에 포커스가 맞춰져있으면 불꽃 버튼 누를 수 없게 불꽃 아이콘 공간을 없애고, textField의 width를 늘렸습니다.
- 키보드에서 포커스가 없어지면 불꽃 버튼을 수 있게 불꽃 아이콘 공간이 다시 생성되도록 했습니다.

## ✅ 한 일
1. 스테이지 실시간 채팅 바 ui 생성
   - 키보드 올라오고 내려올 때 뒷배경에 영향 없도록 개발
   - 불꽃 아이콘 코드 위젯화
   - 키보드 포커스에 따른 textfield width, 불꽃 아이콘 공간 조절

## ☝️ 참고 하세요~
1. 서연님이 아이콘을 미리 만드실 때, 이렇게 다른 화면에서 개발하고 제가 그 코드를 가져오는 식으로 개발하는 거 좋은 거 같습니다! 충돌 걱정도 없고 코드 옮길 때 편했습니다.ㅎㅎ

## 🤓 다음에 할 일
1. 스테이지 실시간 채팅 목록 ui 개발
2. 스테이지 입장 시 오류 해결