### PR TITLE
[ui] 스테이지 실시간 채팅 목록 ui 생성 (HH-239)

### DIFF
--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -10,7 +10,7 @@ import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
 import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
-import 'package:pocket_pose/ui/widget/stage/stage_live_chat_widget.dart';
+import 'package:pocket_pose/ui/widget/stage/stage_live_chat_bar_widget.dart';
 import 'package:provider/provider.dart';
 
 final userListItem = {
@@ -155,7 +155,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                         mainAxisAlignment: MainAxisAlignment.end,
                         children: [
                           StageLiveChatListWidget(),
-                          StageLiveChatWidget(),
+                          StageLiveChatBarWidget(),
                         ],
                       ),
                     ),

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -9,6 +9,7 @@ import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
+import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
 import 'package:pocket_pose/ui/widget/stage/stage_live_chat_widget.dart';
 import 'package:provider/provider.dart';
 
@@ -150,7 +151,13 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                       bottom: 0,
                       left: 0,
                       right: 0,
-                      child: StageLiveChatWidget(),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          StageLiveChatListWidget(),
+                          StageLiveChatWidget(),
+                        ],
+                      ),
                     ),
                   ],
                 ),

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -148,16 +148,16 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                   children: [
                     _buildStageView(_stageStage),
                     const Positioned(
+                      bottom: 68,
+                      left: 0,
+                      right: 0,
+                      child: StageLiveChatListWidget(),
+                    ),
+                    const Positioned(
                       bottom: 0,
                       left: 0,
                       right: 0,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          StageLiveChatListWidget(),
-                          StageLiveChatBarWidget(),
-                        ],
-                      ),
+                      child: StageLiveChatBarWidget(),
                     ),
                   ],
                 ),

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -9,6 +9,8 @@ import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
+import 'package:pocket_pose/ui/widget/stage/stage_live_chat_bar_widget.dart';
+import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
 import 'package:provider/provider.dart';
 
 final userListItem = {
@@ -145,18 +147,18 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 body: Stack(
                   children: [
                     _buildStageView(_stageStage),
-                    // const Positioned(
-                    //   bottom: 68,
-                    //   left: 0,
-                    //   right: 0,
-                    //   child: StageLiveChatListWidget(),
-                    // ),
-                    // const Positioned(
-                    //   bottom: 0,
-                    //   left: 0,
-                    //   right: 0,
-                    //   child: StageLiveChatBarWidget(),
-                    // ),
+                    const Positioned(
+                      bottom: 68,
+                      left: 0,
+                      right: 0,
+                      child: StageLiveChatListWidget(),
+                    ),
+                    const Positioned(
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      child: StageLiveChatBarWidget(),
+                    ),
                   ],
                 ),
               )),

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -9,8 +9,6 @@ import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
 import 'package:pocket_pose/ui/view/popo_wait_view.dart';
-import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
-import 'package:pocket_pose/ui/widget/stage/stage_live_chat_bar_widget.dart';
 import 'package:provider/provider.dart';
 
 final userListItem = {
@@ -147,18 +145,18 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 body: Stack(
                   children: [
                     _buildStageView(_stageStage),
-                    const Positioned(
-                      bottom: 68,
-                      left: 0,
-                      right: 0,
-                      child: StageLiveChatListWidget(),
-                    ),
-                    const Positioned(
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      child: StageLiveChatBarWidget(),
-                    ),
+                    // const Positioned(
+                    //   bottom: 68,
+                    //   left: 0,
+                    //   right: 0,
+                    //   child: StageLiveChatListWidget(),
+                    // ),
+                    // const Positioned(
+                    //   bottom: 0,
+                    //   left: 0,
+                    //   right: 0,
+                    //   child: StageLiveChatBarWidget(),
+                    // ),
                   ],
                 ),
               )),
@@ -275,18 +273,16 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
               backgroundColor: Colors.white.withOpacity(0.3),
               title: Row(
                 children: [
-                  const Expanded(
-                    child: Padding(
-                      padding: EdgeInsets.only(left: 20),
-                      child: Text(
-                        '참여자 목록',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                        textAlign: TextAlign.center,
+                  const Padding(
+                    padding: EdgeInsets.only(left: 20),
+                    child: Text(
+                      '참여자 목록',
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
                       ),
+                      textAlign: TextAlign.center,
                     ),
                   ),
                   GestureDetector(

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -95,7 +95,7 @@ class PoPoStageScreen extends StatefulWidget {
 }
 
 class _PoPoStageScreenState extends State<PoPoStageScreen> {
-  double _userCount = 1;
+  int _userCount = 1;
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
@@ -197,19 +197,19 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
   void _startTimer() {
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_userCount >= 3) {
-        _stopTimer();
+      if (mounted) {
+        if (_userCount >= 5) {
+          _stopTimer();
 
-        if (mounted) {
           setState(() {
             _stageStage = StageStage.catchState;
           });
+        } else {
+          setState(() {
+            _count++;
+            _userCount = _count;
+          });
         }
-      } else {
-        setState(() {
-          _count++;
-          _userCount = _count + 0.5;
-        });
       }
     });
   }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -94,7 +94,7 @@ class PoPoStageScreen extends StatefulWidget {
 }
 
 class _PoPoStageScreenState extends State<PoPoStageScreen> {
-  int _userCount = 1;
+  double _userCount = 1;
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
@@ -190,7 +190,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
   void _startTimer() {
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_userCount == 3) {
+      if (_userCount >= 3) {
         _stopTimer();
 
         if (mounted) {
@@ -201,7 +201,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       } else {
         setState(() {
           _count++;
-          _userCount = _count + 1;
+          _userCount = _count + 0.5;
         });
       }
     });
@@ -212,9 +212,11 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   }
 
   void setStageState(StageStage newStageStage) {
-    setState(() {
-      _stageStage = newStageStage;
-    });
+    if (mounted) {
+      setState(() {
+        _stageStage = newStageStage;
+      });
+    }
   }
 
   bool getIsResultState() => _stageStage == StageStage.resultState;

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -69,11 +69,11 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   Widget build(BuildContext context) {
     return Expanded(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           const SizedBox(
-            height: 40.0,
+            height: 80.0,
             width: double.infinity,
           ),
           const Text(
@@ -81,13 +81,14 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
             textAlign: TextAlign.center,
             style: TextStyle(fontSize: 18, color: Colors.white),
           ),
-          const SizedBox(height: 30.0),
+          const SizedBox(height: 10.0),
           musicTitleContainer('I AM-IVE'),
-          const SizedBox(height: 30.0),
+          const SizedBox(height: 10.0),
           SvgPicture.asset(
             'assets/images/charactor_popo_catch.svg',
+            height: 200,
           ),
-          const SizedBox(height: 10.0),
+          // const SizedBox(height: 10.0),
           ElevatedButton(
             style: ElevatedButton.styleFrom(
                 shape: RoundedRectangleBorder(

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -69,47 +69,54 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   Widget build(BuildContext context) {
     return Expanded(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          const SizedBox(
-            height: 80.0,
-            width: double.infinity,
-          ),
-          const Text(
-            "이번 곡은...",
-            textAlign: TextAlign.center,
-            style: TextStyle(fontSize: 18, color: Colors.white),
-          ),
-          const SizedBox(height: 10.0),
-          musicTitleContainer('I AM-IVE'),
-          const SizedBox(height: 10.0),
-          SvgPicture.asset(
-            'assets/images/charactor_popo_catch.svg',
-            height: 200,
-          ),
-          // const SizedBox(height: 10.0),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30.0),
+          Flexible(
+            flex: 2,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const SizedBox(height: 80.0),
+                const Text(
+                  "이번 곡은...",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 18, color: Colors.white),
                 ),
-                backgroundColor: Colors.transparent,
-                foregroundColor: Colors.white,
-                elevation: 0,
-                side: const BorderSide(
-                  width: 1.0,
-                  color: Colors.white,
-                )),
-            child: const Text(
-              '캐치!',
-              style: TextStyle(color: Colors.white, fontSize: 24),
+                const SizedBox(height: 10.0),
+                musicTitleContainer('I AM-IVE'),
+                const SizedBox(height: 10.0),
+                Flexible(
+                  child: SvgPicture.asset(
+                    'assets/images/charactor_popo_catch.svg',
+                  ),
+                ),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30.0),
+                      ),
+                      backgroundColor: Colors.transparent,
+                      foregroundColor: Colors.white,
+                      elevation: 0,
+                      side: const BorderSide(
+                        width: 1.0,
+                        color: Colors.white,
+                      )),
+                  child: const Text(
+                    '캐치!',
+                    style: TextStyle(color: Colors.white, fontSize: 24),
+                  ),
+                  onPressed: () {},
+                ),
+                const SizedBox(height: 10.0),
+                Text('$_seconds',
+                    style: const TextStyle(fontSize: 14, color: Colors.white)),
+              ],
             ),
-            onPressed: () {},
           ),
-          const SizedBox(height: 10.0),
-          Text('$_seconds',
-              style: const TextStyle(fontSize: 14, color: Colors.white))
+          const Flexible(flex: 1, child: SizedBox(height: 60.0 + 150.0)),
         ],
       ),
     );

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -67,58 +67,56 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.end,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Flexible(
-            flex: 2,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                const SizedBox(height: 80.0),
-                const Text(
-                  "이번 곡은...",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 18, color: Colors.white),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Flexible(
+          flex: 2,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(height: 80.0),
+              const Text(
+                "이번 곡은...",
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 18, color: Colors.white),
+              ),
+              const SizedBox(height: 10.0),
+              musicTitleContainer('I AM-IVE'),
+              const SizedBox(height: 10.0),
+              Flexible(
+                child: SvgPicture.asset(
+                  'assets/images/charactor_popo_catch.svg',
                 ),
-                const SizedBox(height: 10.0),
-                musicTitleContainer('I AM-IVE'),
-                const SizedBox(height: 10.0),
-                Flexible(
-                  child: SvgPicture.asset(
-                    'assets/images/charactor_popo_catch.svg',
-                  ),
+              ),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30.0),
+                    ),
+                    backgroundColor: Colors.transparent,
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    side: const BorderSide(
+                      width: 1.0,
+                      color: Colors.white,
+                    )),
+                child: const Text(
+                  '캐치!',
+                  style: TextStyle(color: Colors.white, fontSize: 24),
                 ),
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(30.0),
-                      ),
-                      backgroundColor: Colors.transparent,
-                      foregroundColor: Colors.white,
-                      elevation: 0,
-                      side: const BorderSide(
-                        width: 1.0,
-                        color: Colors.white,
-                      )),
-                  child: const Text(
-                    '캐치!',
-                    style: TextStyle(color: Colors.white, fontSize: 24),
-                  ),
-                  onPressed: () {},
-                ),
-                const SizedBox(height: 10.0),
-                Text('$_seconds',
-                    style: const TextStyle(fontSize: 14, color: Colors.white)),
-              ],
-            ),
+                onPressed: () {},
+              ),
+              const SizedBox(height: 10.0),
+              Text('$_seconds',
+                  style: const TextStyle(fontSize: 14, color: Colors.white)),
+            ],
           ),
-          const Flexible(flex: 1, child: SizedBox(height: 60.0 + 150.0)),
-        ],
-      ),
+        ),
+        const Flexible(flex: 1, child: SizedBox(height: 60.0 + 150.0)),
+      ],
     );
   }
 

--- a/lib/ui/view/popo_wait_view.dart
+++ b/lib/ui/view/popo_wait_view.dart
@@ -13,28 +13,43 @@ class _PoPoWaitViewState extends State<PoPoWaitView> {
   Widget build(BuildContext context) {
     return Expanded(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          const SizedBox(
-            height: 100.0,
-            width: double.infinity,
+          Flexible(
+            flex: 2,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: 80.0),
+                const Text(
+                  "대기중...",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 40, color: Colors.white),
+                ),
+                const SizedBox(height: 20.0),
+                const Text(
+                  "3명 이상 참여하면 시작됩니다!",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 18, color: Colors.white),
+                ),
+                const SizedBox(height: 20.0),
+                Flexible(
+                  child: SvgPicture.asset(
+                    'assets/images/charactor_popo_wait.svg',
+                  ),
+                ),
+              ],
+            ),
           ),
-          const Text(
-            "대기중...",
-            textAlign: TextAlign.center,
-            style: TextStyle(fontSize: 40, color: Colors.white),
-          ),
-          const SizedBox(height: 20.0),
-          const Text(
-            "3명 이상 참여하면 시작됩니다!",
-            textAlign: TextAlign.center,
-            style: TextStyle(fontSize: 18, color: Colors.white),
-          ),
-          const SizedBox(height: 20.0),
-          SvgPicture.asset(
-            'assets/images/charactor_popo_wait.svg',
-            height: 300,
+          const Flexible(
+            flex: 1,
+            child: SizedBox(
+              height: 60.0 + 150.0,
+              width: double.infinity,
+            ),
           ),
         ],
       ),

--- a/lib/ui/view/popo_wait_view.dart
+++ b/lib/ui/view/popo_wait_view.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -14,7 +13,7 @@ class _PoPoWaitViewState extends State<PoPoWaitView> {
   Widget build(BuildContext context) {
     return Expanded(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           const SizedBox(
@@ -26,15 +25,16 @@ class _PoPoWaitViewState extends State<PoPoWaitView> {
             textAlign: TextAlign.center,
             style: TextStyle(fontSize: 40, color: Colors.white),
           ),
-          const SizedBox(height: 40.0),
+          const SizedBox(height: 20.0),
           const Text(
             "3명 이상 참여하면 시작됩니다!",
             textAlign: TextAlign.center,
             style: TextStyle(fontSize: 18, color: Colors.white),
           ),
-          const SizedBox(height: 40.0),
+          const SizedBox(height: 20.0),
           SvgPicture.asset(
             'assets/images/charactor_popo_wait.svg',
+            height: 300,
           ),
         ],
       ),

--- a/lib/ui/view/popo_wait_view.dart
+++ b/lib/ui/view/popo_wait_view.dart
@@ -11,48 +11,46 @@ class PoPoWaitView extends StatefulWidget {
 class _PoPoWaitViewState extends State<PoPoWaitView> {
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.end,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Flexible(
-            flex: 2,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const SizedBox(height: 80.0),
-                const Text(
-                  "대기중...",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 40, color: Colors.white),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Flexible(
+          flex: 2,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 80.0),
+              const Text(
+                "대기중...",
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 40, color: Colors.white),
+              ),
+              const SizedBox(height: 20.0),
+              const Text(
+                "3명 이상 참여하면 시작됩니다!",
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 18, color: Colors.white),
+              ),
+              const SizedBox(height: 20.0),
+              Flexible(
+                child: SvgPicture.asset(
+                  'assets/images/charactor_popo_wait.svg',
                 ),
-                const SizedBox(height: 20.0),
-                const Text(
-                  "3명 이상 참여하면 시작됩니다!",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 18, color: Colors.white),
-                ),
-                const SizedBox(height: 20.0),
-                Flexible(
-                  child: SvgPicture.asset(
-                    'assets/images/charactor_popo_wait.svg',
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
-          const Flexible(
-            flex: 1,
-            child: SizedBox(
-              height: 60.0 + 150.0,
-              width: double.infinity,
-            ),
+        ),
+        const Flexible(
+          flex: 1,
+          child: SizedBox(
+            height: 60.0 + 150.0,
+            width: double.infinity,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-class StageLiveChatWidget extends StatefulWidget {
-  const StageLiveChatWidget({super.key});
+class StageLiveChatBarWidget extends StatefulWidget {
+  const StageLiveChatBarWidget({super.key});
 
   @override
-  State<StageLiveChatWidget> createState() => _StageLiveChatWidgetState();
+  State<StageLiveChatBarWidget> createState() => _StageLiveChatBarWidgetState();
 }
 
-class _StageLiveChatWidgetState extends State<StageLiveChatWidget>
+class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
     with TickerProviderStateMixin {
   final TextEditingController _textController = TextEditingController();
   final FocusNode _inputFieldFocusNode = FocusNode();

--- a/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
@@ -47,13 +47,8 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
   Widget _buildInputArea(BuildContext context) {
     return Stack(
       children: [
-        Column(
-          children: [
-            // const StageLiveChatListWidget(),
-            _buildLiveChatBar(context),
-          ],
-        ),
-        ...selectWidgets
+        _buildLiveChatBar(context),
+        ...selectWidgets,
       ],
     );
   }
@@ -70,6 +65,7 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
               child: Padding(
                 padding: const EdgeInsets.all(14),
                 child: Container(
+                  height: 40,
                   padding: const EdgeInsets.only(left: 14),
                   width: double.infinity,
                   decoration: BoxDecoration(
@@ -81,13 +77,13 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
                     ),
                   ),
                   child: TextField(
-                    style: const TextStyle(color: Colors.white),
+                    style: const TextStyle(color: Colors.white, fontSize: 14),
                     controller: _textController,
                     cursorColor: Colors.white,
                     focusNode: _inputFieldFocusNode,
                     decoration: const InputDecoration(
                       hintText: 'nickname(으)로 댓글 달기...',
-                      hintStyle: TextStyle(color: Colors.white70),
+                      hintStyle: TextStyle(color: Colors.white70, fontSize: 14),
                       labelStyle: TextStyle(color: Colors.white),
                       border: InputBorder.none,
                     ),

--- a/lib/ui/widget/stage/stage_live_chat_list.widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_list.widget.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class StageLiveChatListWidget extends StatelessWidget {
+  const StageLiveChatListWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<String> entries = <String>['a', 'b', 'c', 'd'];
+
+    return SafeArea(
+      child: SingleChildScrollView(
+        child: Container(
+          color: Colors.black.withOpacity(0.3),
+          height: 200,
+          child: ListView.builder(
+              padding: const EdgeInsets.fromLTRB(8, 8, 8, 100),
+              itemCount: entries.length,
+              itemBuilder: (BuildContext context, int index) {
+                return SizedBox(
+                    child: Center(
+                        child: Text(
+                  '순서대로 ${entries[index]}',
+                  style: const TextStyle(color: Colors.white),
+                )));
+              }),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widget/stage/stage_live_chat_list.widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_list.widget.dart
@@ -1,24 +1,51 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
-class StageLiveChatListWidget extends StatelessWidget {
+class StageLiveChatListWidget extends StatefulWidget {
   const StageLiveChatListWidget({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final List<String> entries = <String>[
-      'a',
-      'b',
-      'c',
-      'd',
-      'e',
-      'f',
-      'g',
-      '1',
-      '2',
-      '3'
-    ];
+  State<StageLiveChatListWidget> createState() =>
+      _StageLiveChatListWidgetState();
+}
 
-    return _buildStageChatList(entries);
+class _StageLiveChatListWidgetState extends State<StageLiveChatListWidget> {
+  final List<String> _messageList = [];
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+
+    //이전 채팅 목록 가져오기
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() {
+        _messageList.addAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', '1', '2', '3']);
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    _scrollController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // build마다 채팅 스크롤 맨 밑으로
+    if (_messageList.isNotEmpty) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 50),
+          curve: Curves.easeOut,
+        );
+      });
+    }
+
+    return _buildStageChatList(_messageList);
   }
 
   SingleChildScrollView _buildStageChatList(List<String> entries) {
@@ -27,6 +54,7 @@ class StageLiveChatListWidget extends StatelessWidget {
         color: Colors.black.withOpacity(0.3),
         height: 150,
         child: ListView.separated(
+            controller: _scrollController,
             padding: const EdgeInsets.all(14),
             itemCount: entries.length,
             separatorBuilder: (context, index) {

--- a/lib/ui/widget/stage/stage_live_chat_list.widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_list.widget.dart
@@ -18,51 +18,53 @@ class StageLiveChatListWidget extends StatelessWidget {
       '3'
     ];
 
-    return SafeArea(
-      child: SingleChildScrollView(
-        child: Container(
-          color: Colors.black.withOpacity(0.3),
-          height: 150,
-          child: ListView.separated(
-              padding: const EdgeInsets.all(14),
-              itemCount: entries.length,
-              separatorBuilder: (context, index) {
-                return const SizedBox(height: 12);
-              },
-              itemBuilder: (BuildContext context, int index) {
-                return Row(
-                  children: [
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(50),
-                      child: Image.asset(
-                        'assets/images/home_profile_1.jpg',
-                        width: 35,
-                        height: 35,
+    return _buildStageChatList(entries);
+  }
+
+  SingleChildScrollView _buildStageChatList(List<String> entries) {
+    return SingleChildScrollView(
+      child: Container(
+        color: Colors.black.withOpacity(0.3),
+        height: 150,
+        child: ListView.separated(
+            padding: const EdgeInsets.all(14),
+            itemCount: entries.length,
+            separatorBuilder: (context, index) {
+              return const SizedBox(height: 12);
+            },
+            itemBuilder: (BuildContext context, int index) {
+              return Row(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(50),
+                    child: Image.asset(
+                      'assets/images/home_profile_1.jpg',
+                      width: 35,
+                      height: 35,
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 12,
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'nickname ${entries[index]}',
+                        style: const TextStyle(color: Colors.white),
                       ),
-                    ),
-                    const SizedBox(
-                      width: 12,
-                    ),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'nickname ${entries[index]}',
-                          style: const TextStyle(color: Colors.white),
-                        ),
-                        const SizedBox(
-                          height: 4,
-                        ),
-                        Text(
-                          'content ${entries[index]}',
-                          style: const TextStyle(color: Colors.white),
-                        )
-                      ],
-                    )
-                  ],
-                );
-              }),
-        ),
+                      const SizedBox(
+                        height: 4,
+                      ),
+                      Text(
+                        'content ${entries[index]}',
+                        style: const TextStyle(color: Colors.white),
+                      )
+                    ],
+                  )
+                ],
+              );
+            }),
       ),
     );
   }

--- a/lib/ui/widget/stage/stage_live_chat_list.widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_list.widget.dart
@@ -5,23 +5,62 @@ class StageLiveChatListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<String> entries = <String>['a', 'b', 'c', 'd'];
+    final List<String> entries = <String>[
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+      'f',
+      'g',
+      '1',
+      '2',
+      '3'
+    ];
 
     return SafeArea(
       child: SingleChildScrollView(
         child: Container(
           color: Colors.black.withOpacity(0.3),
-          height: 200,
-          child: ListView.builder(
-              padding: const EdgeInsets.fromLTRB(8, 8, 8, 100),
+          height: 150,
+          child: ListView.separated(
+              padding: const EdgeInsets.all(14),
               itemCount: entries.length,
+              separatorBuilder: (context, index) {
+                return const SizedBox(height: 12);
+              },
               itemBuilder: (BuildContext context, int index) {
-                return SizedBox(
-                    child: Center(
-                        child: Text(
-                  '순서대로 ${entries[index]}',
-                  style: const TextStyle(color: Colors.white),
-                )));
+                return Row(
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(50),
+                      child: Image.asset(
+                        'assets/images/home_profile_1.jpg',
+                        width: 35,
+                        height: 35,
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 12,
+                    ),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'nickname ${entries[index]}',
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                        const SizedBox(
+                          height: 4,
+                        ),
+                        Text(
+                          'content ${entries[index]}',
+                          style: const TextStyle(color: Colors.white),
+                        )
+                      ],
+                    )
+                  ],
+                );
               }),
         ),
       ),

--- a/lib/ui/widget/stage/stage_live_chat_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
 
 class StageLiveChatWidget extends StatefulWidget {
   const StageLiveChatWidget({super.key});
@@ -45,19 +44,17 @@ class _StageLiveChatWidgetState extends State<StageLiveChatWidget>
     return _buildInputArea(context);
   }
 
-  SafeArea _buildInputArea(BuildContext context) {
-    return SafeArea(
-      child: Stack(
-        children: [
-          Column(
-            children: [
-              const StageLiveChatListWidget(),
-              _buildLiveChatBar(context),
-            ],
-          ),
-          ...selectWidgets
-        ],
-      ),
+  Widget _buildInputArea(BuildContext context) {
+    return Stack(
+      children: [
+        Column(
+          children: [
+            // const StageLiveChatListWidget(),
+            _buildLiveChatBar(context),
+          ],
+        ),
+        ...selectWidgets
+      ],
     );
   }
 

--- a/lib/ui/widget/stage/stage_live_chat_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
 
 class StageLiveChatWidget extends StatefulWidget {
   const StageLiveChatWidget({super.key});
@@ -48,77 +49,86 @@ class _StageLiveChatWidgetState extends State<StageLiveChatWidget>
     return SafeArea(
       child: Stack(
         children: [
-          Container(
-            color: Colors.black.withOpacity(0.3),
-            child: Padding(
-              padding: EdgeInsets.only(
-                  bottom: MediaQuery.of(context).viewInsets.bottom),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.all(14),
-                      child: Container(
-                        padding: const EdgeInsets.only(left: 14),
-                        width: double.infinity,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(36),
-                          color: Colors.transparent,
-                          border: Border.all(
-                            color: Colors.white,
-                            width: 2.0,
-                          ),
-                        ),
-                        child: TextField(
-                          style: const TextStyle(color: Colors.white),
-                          controller: _textController,
-                          cursorColor: Colors.white,
-                          focusNode: _inputFieldFocusNode,
-                          decoration: const InputDecoration(
-                            hintText: 'nickname(으)로 댓글 달기...',
-                            hintStyle: TextStyle(color: Colors.white70),
-                            labelStyle: TextStyle(color: Colors.white),
-                            border: InputBorder.none,
-                          ),
-                          textInputAction: TextInputAction.next,
-                        ),
-                      ),
-                    ),
-                  ),
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 300),
-                    width: _isFireIconVisible ? 20 : 0,
-                    child: Visibility(
-                      visible: _isFireIconVisible,
-                      child: InkWell(
-                        highlightColor: Colors.transparent,
-                        splashColor: Colors.transparent,
-                        onTap: _handleIconClick,
-                        child: SvgPicture.asset(
-                            'assets/icons/ic_popo_fire_unselect.svg'),
-                      ),
-                    ),
-                  ),
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 300),
-                    width: _isFireIconVisible ? 14 : 0,
-                    child: Visibility(
-                      visible: _isFireIconVisible,
-                      child: InkWell(
-                          highlightColor: Colors.transparent,
-                          splashColor: Colors.transparent,
-                          onTap: _handleIconClick,
-                          child: const SizedBox(
-                            width: 14,
-                          )),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+          Column(
+            children: [
+              const StageLiveChatListWidget(),
+              _buildLiveChatBar(context),
+            ],
           ),
           ...selectWidgets
         ],
+      ),
+    );
+  }
+
+  Container _buildLiveChatBar(BuildContext context) {
+    return Container(
+      color: Colors.black.withOpacity(0.3),
+      child: Padding(
+        padding:
+            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        child: Row(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Container(
+                  padding: const EdgeInsets.only(left: 14),
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(36),
+                    color: Colors.transparent,
+                    border: Border.all(
+                      color: Colors.white,
+                      width: 2.0,
+                    ),
+                  ),
+                  child: TextField(
+                    style: const TextStyle(color: Colors.white),
+                    controller: _textController,
+                    cursorColor: Colors.white,
+                    focusNode: _inputFieldFocusNode,
+                    decoration: const InputDecoration(
+                      hintText: 'nickname(으)로 댓글 달기...',
+                      hintStyle: TextStyle(color: Colors.white70),
+                      labelStyle: TextStyle(color: Colors.white),
+                      border: InputBorder.none,
+                    ),
+                    textInputAction: TextInputAction.next,
+                  ),
+                ),
+              ),
+            ),
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              width: _isFireIconVisible ? 20 : 0,
+              child: Visibility(
+                visible: _isFireIconVisible,
+                child: InkWell(
+                  highlightColor: Colors.transparent,
+                  splashColor: Colors.transparent,
+                  onTap: _handleIconClick,
+                  child: SvgPicture.asset(
+                      'assets/icons/ic_popo_fire_unselect.svg'),
+                ),
+              ),
+            ),
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              width: _isFireIconVisible ? 14 : 0,
+              child: Visibility(
+                visible: _isFireIconVisible,
+                child: InkWell(
+                    highlightColor: Colors.transparent,
+                    splashColor: Colors.transparent,
+                    onTap: _handleIconClick,
+                    child: const SizedBox(
+                      width: 14,
+                    )),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/a0fcdff8-a318-4b38-9c22-3ff6ec72436c" width="250">

## 💬 작업 설명
- 실시간 채팅 목록 ui를 개발했습니다.
- 가장 최신(마지막) 아이템이 bottom에 위치하도록 하였습니다.

## ✅ 한 일
1. 실시간 채팅 목록 ui 개발
2. 스테이지 입장 시 나는 오류 해결

## 🤓 다음에 할 일
1. 스테이지 플레이 화면에서 스켈레톤 3개 보이기
