### PR TITLE
[ui] 스테이지 플레이 화면에 3명 스켈레톤 출력 + 캐치 버튼 ui 수정 (HH-240)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -7,6 +7,7 @@ class AppColor {
   static Color purpleColor2 = const Color(0xFFBD00FF);
   static Color blueColor = const Color(0xFF3959CD);
   static Color blueColor2 = const Color(0xFF0057FF);
+  static Color blueColor3 = const Color(0xFF565CEA);
   static Color greenColor = const Color(0xFF00FF19);
   static Color yellowColor = const Color(0xFFEFE372);
   static Color yellowColor2 = const Color(0xFFFAFF00);

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -99,23 +99,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
-
   StageStage _stageStage = StageStage.waitState;
-  @override
-  void initState() {
-    super.initState();
-
-    _startTimer();
-  }
-
-  @override
-  void dispose() {
-    AudioPlayerUtil().stop();
-    if (widget.getIndex() == 0) {
-      _videoPlayProvider.playVideo();
-    }
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -131,14 +115,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
           resizeToAvoidBottomInset: false,
           body: Container(
               // 플레이, 결과 상태에 따라 배경화면 변경
-              decoration: BoxDecoration(
-                image: DecorationImage(
-                  fit: BoxFit.cover,
-                  image: AssetImage((getIsResultState())
-                      ? 'assets/images/bg_popo_result.png'
-                      : 'assets/images/bg_popo_comm.png'),
-                ),
-              ),
+              decoration: buildBackgroundImage(),
               child: Scaffold(
                 resizeToAvoidBottomInset: false,
                 extendBodyBehindAppBar: true,
@@ -163,6 +140,33 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 ),
               )),
         ),
+      ),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _startTimer();
+  }
+
+  @override
+  void dispose() {
+    AudioPlayerUtil().stop();
+    if (widget.getIndex() == 0) {
+      _videoPlayProvider.playVideo();
+    }
+    super.dispose();
+  }
+
+  BoxDecoration buildBackgroundImage() {
+    return BoxDecoration(
+      image: DecorationImage(
+        fit: BoxFit.cover,
+        image: AssetImage((getIsResultState())
+            ? 'assets/images/bg_popo_result.png'
+            : 'assets/images/bg_popo_comm.png'),
       ),
     );
   }

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -173,7 +173,17 @@ class _CameraViewState extends State<CameraView> {
 
   // 결과 화면: MVP 1명의 스켈레톤만 보임
   Widget _liveFeedBodyResult() {
-    return (widget.customPaint != null) ? widget.customPaint! : Container();
+    return Row(
+      children: [
+        Expanded(flex: 2, child: Container()),
+        Expanded(
+            flex: 4,
+            child: (widget.customPaint != null)
+                ? SizedBox(height: 300, child: widget.customPaint!)
+                : Container()),
+        Expanded(flex: 2, child: Container()),
+      ],
+    );
   }
 
   // 플레이 화면: 플레이어 3명 스켈레톤 보임

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -54,6 +54,16 @@ class _CameraViewState extends State<CameraView> {
   late Timer _timer;
 
   @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      backgroundColor: Colors.transparent,
+      // 결과 화면이면 1명의 스켈레톤, 플레이 화면이면 3명의 스켈레톤 출력
+      body: _liveFeedBody(),
+    );
+  }
+
+  @override
   void initState() {
     super.initState();
 
@@ -137,16 +147,6 @@ class _CameraViewState extends State<CameraView> {
     super.dispose();
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      backgroundColor: Colors.transparent,
-      // 카메라 화면 보여주기 + 화면에서 실시간으로 포즈 추출
-      body: _liveFeedBody(),
-    );
-  }
-
   // 카메라 화면 보여주기 + 화면에서 실시간으로 포즈 추출
   Widget _liveFeedBody() {
     if (_controller?.value.isInitialized == false) {
@@ -163,37 +163,73 @@ class _CameraViewState extends State<CameraView> {
     return Stack(
       fit: StackFit.expand,
       children: <Widget>[
-        Positioned(
-          top: 80,
-          left: 0,
-          right: 0,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              SvgPicture.asset(
-                'assets/icons/ic_music_note_small.svg',
-              ),
-              const SizedBox(width: 8.0),
-              const Text(
-                "I AM-IVE",
-                style: TextStyle(fontSize: 10, color: Colors.white),
-              ),
-            ],
-          ),
-        ),
+        buildMusicInfoWidget(),
         // 추출된 스켈레톤 그리기
-        if (widget.customPaint != null) widget.customPaint!,
-        Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Visibility(
-              visible: _countdownVisibility,
-              child: Text('$_seconds',
-                  style: const TextStyle(fontSize: 72, color: Colors.white)),
-            )
-          ],
+        (widget.isResultState) ? _liveFeedBodyResult() : _liveFeedBodyPlay(),
+        buildCountdownWidget()
+      ],
+    );
+  }
+
+  // 결과 화면: MVP 1명의 스켈레톤만 보임
+  Widget _liveFeedBodyResult() {
+    return (widget.customPaint != null) ? widget.customPaint! : Container();
+  }
+
+  // 플레이 화면: 플레이어 3명 스켈레톤 보임
+  Widget _liveFeedBodyPlay() {
+    return Row(
+      children: [
+        Expanded(
+            flex: 3,
+            child: (widget.customPaint != null)
+                ? SizedBox(height: 150, child: widget.customPaint!)
+                : Container()),
+        Expanded(
+            flex: 4,
+            child: (widget.customPaint != null)
+                ? SizedBox(height: 200, child: widget.customPaint!)
+                : Container()),
+        Expanded(
+            flex: 3,
+            child: (widget.customPaint != null)
+                ? SizedBox(height: 150, child: widget.customPaint!)
+                : Container()),
+      ],
+    );
+  }
+
+  Column buildCountdownWidget() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Visibility(
+          visible: _countdownVisibility,
+          child: Text('$_seconds',
+              style: const TextStyle(fontSize: 72, color: Colors.white)),
         )
       ],
+    );
+  }
+
+  Positioned buildMusicInfoWidget() {
+    return Positioned(
+      top: 80,
+      left: 0,
+      right: 0,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SvgPicture.asset(
+            'assets/icons/ic_music_note_small.svg',
+          ),
+          const SizedBox(width: 8.0),
+          const Text(
+            "I AM-IVE",
+            style: TextStyle(fontSize: 10, color: Colors.white),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -76,15 +76,18 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
         bottomPadding: 0,
         strokeWidth: 2,
         backgroundColor: Colors.transparent,
-        child: Text(
-          '캐치!',
-          style: TextStyle(
-            fontSize: 24,
-            color: Colors.white,
-            shadows: [
-              for (double i = 1; i < 6; i++)
-                Shadow(color: AppColor.blueColor3, blurRadius: 6 * i)
-            ],
+        child: TextButton(
+          onPressed: () {},
+          child: Text(
+            '캐치!',
+            style: TextStyle(
+              fontSize: 24,
+              color: Colors.white,
+              shadows: [
+                for (double i = 1; i < 6; i++)
+                  Shadow(color: AppColor.blueColor3, blurRadius: 6 * i)
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -6,6 +6,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
 import 'package:semicircle_indicator/semicircle_indicator.dart';
+import 'dart:math' as math;
 
 class PoPoCatchView extends StatefulWidget {
   const PoPoCatchView({Key? key, required this.setStageState})
@@ -50,6 +51,12 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
                   'assets/images/charactor_popo_catch.svg',
                 ),
               ),
+              Padding(
+                padding: const EdgeInsets.only(right: 90),
+                child: CustomPaint(
+                  painter: CatchCountDownPainter(),
+                ),
+              ),
               _buildCatchButton(),
             ],
           ),
@@ -65,9 +72,10 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
       height: 45,
       child: SemicircularIndicator(
         progress: _catchCountDown,
-        color: Colors.white,
+        color: Colors.yellow,
         bottomPadding: 0,
-        strokeWidth: 4,
+        strokeWidth: 2,
+        backgroundColor: Colors.transparent,
         child: Text(
           '캐치!',
           style: TextStyle(
@@ -165,4 +173,48 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
       ),
     );
   }
+}
+
+class CatchCountDownPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Outer 네온 효과
+    final neonOuterPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 8.0
+      ..strokeCap = StrokeCap.round
+      ..color = AppColor.blueColor3
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3.0);
+
+    // Inner 네온 효과
+    final neonInnerPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 8.0
+      ..strokeCap = StrokeCap.round
+      ..color = AppColor.blueColor3
+      ..maskFilter = const MaskFilter.blur(BlurStyle.inner, 2.0);
+
+    // 흰 라인
+    final basePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 6.0
+      ..strokeCap = StrokeCap.round // 끝을 둥글게
+      ..color = Colors.white;
+
+    // 검정 라인
+    final innerBasePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round // 끝을 둥글게
+      ..color = Colors.black;
+
+    const rect = Rect.fromLTWH(0, 0, 90, 90);
+    canvas.drawArc(rect, -math.pi, math.pi, false, neonOuterPaint);
+    canvas.drawArc(rect, -math.pi, math.pi, false, neonInnerPaint);
+    canvas.drawArc(rect, -math.pi, math.pi, false, basePaint);
+    canvas.drawArc(rect, -math.pi, math.pi, false, innerBasePaint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => true;
 }

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -37,7 +37,7 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const SizedBox(height: 80.0),
+              const SizedBox(height: 60.0),
               const Text(
                 "이번 곡은...",
                 textAlign: TextAlign.center,
@@ -76,8 +76,11 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
         bottomPadding: 0,
         strokeWidth: 2,
         backgroundColor: Colors.transparent,
-        child: TextButton(
-          onPressed: () {},
+        child: InkWell(
+          onTap: () {},
+          borderRadius: const BorderRadius.all(
+            Radius.circular(20.0),
+          ),
           child: Text(
             '캐치!',
             style: TextStyle(
@@ -85,7 +88,7 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
               color: Colors.white,
               shadows: [
                 for (double i = 1; i < 6; i++)
-                  Shadow(color: AppColor.blueColor3, blurRadius: 6 * i)
+                  Shadow(color: AppColor.blueColor3, blurRadius: 5 * i)
               ],
             ),
           ),
@@ -195,7 +198,7 @@ class CatchCountDownPainter extends CustomPainter {
       ..strokeWidth = 8.0
       ..strokeCap = StrokeCap.round
       ..color = AppColor.blueColor3
-      ..maskFilter = const MaskFilter.blur(BlurStyle.inner, 2.0);
+      ..maskFilter = const MaskFilter.blur(BlurStyle.inner, 3.0);
 
     // 흰 라인
     final basePaint = Paint()

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
+import 'package:semicircle_indicator/semicircle_indicator.dart';
 
 class PoPoCatchView extends StatefulWidget {
   const PoPoCatchView({Key? key, required this.setStageState})
@@ -17,7 +18,8 @@ class PoPoCatchView extends StatefulWidget {
 
 class _PoPoCatchViewState extends State<PoPoCatchView>
     with SingleTickerProviderStateMixin {
-  int _seconds = 3;
+  int _milliseconds = 0;
+  double _catchCountDown = 0.0;
   late Timer _timer;
   late AnimationController _animationController;
   late Animation<double> _opacityAnimation;
@@ -48,32 +50,36 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
                   'assets/images/charactor_popo_catch.svg',
                 ),
               ),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30.0),
-                    ),
-                    backgroundColor: Colors.transparent,
-                    foregroundColor: Colors.white,
-                    elevation: 0,
-                    side: const BorderSide(
-                      width: 1.0,
-                      color: Colors.white,
-                    )),
-                child: const Text(
-                  '캐치!',
-                  style: TextStyle(color: Colors.white, fontSize: 24),
-                ),
-                onPressed: () {},
-              ),
-              const SizedBox(height: 10.0),
-              Text('$_seconds',
-                  style: const TextStyle(fontSize: 14, color: Colors.white)),
+              _buildCatchButton(),
             ],
           ),
         ),
         const Flexible(flex: 1, child: SizedBox(height: 60.0 + 150.0)),
       ],
+    );
+  }
+
+  SizedBox _buildCatchButton() {
+    return SizedBox(
+      width: 100,
+      height: 45,
+      child: SemicircularIndicator(
+        progress: _catchCountDown,
+        color: Colors.white,
+        bottomPadding: 0,
+        strokeWidth: 4,
+        child: Text(
+          '캐치!',
+          style: TextStyle(
+            fontSize: 24,
+            color: Colors.white,
+            shadows: [
+              for (double i = 1; i < 6; i++)
+                Shadow(color: AppColor.blueColor3, blurRadius: 6 * i)
+            ],
+          ),
+        ),
+      ),
     );
   }
 
@@ -95,15 +101,16 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   }
 
   void _startTimer() {
-    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_seconds == 0) {
+    _timer = Timer.periodic(const Duration(milliseconds: 10), (timer) {
+      if (_milliseconds >= 3000) {
         _stopTimer();
         Fluttertoast.showToast(msg: '캐치 성공!');
         widget.setStageState(StageStage.playState);
       } else {
         if (mounted) {
           setState(() {
-            _seconds--;
+            _milliseconds = _milliseconds + 10;
+            _catchCountDown = _milliseconds / 3000;
           });
         }
       }

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -23,49 +23,6 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   late Animation<double> _opacityAnimation;
 
   @override
-  void initState() {
-    super.initState();
-
-    _startTimer();
-
-    _animationController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 300),
-    );
-
-    _opacityAnimation =
-        Tween<double>(begin: 0.0, end: 1.0).animate(_animationController);
-
-    _animationController.forward();
-  }
-
-  void _startTimer() {
-    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_seconds == 0) {
-        _stopTimer();
-        Fluttertoast.showToast(msg: '캐치 성공!');
-        widget.setStageState(StageStage.playState);
-      } else {
-        if (mounted) {
-          setState(() {
-            _seconds--;
-          });
-        }
-      }
-    });
-  }
-
-  void _stopTimer() {
-    _timer.cancel();
-  }
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
@@ -118,6 +75,49 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
         const Flexible(flex: 1, child: SizedBox(height: 60.0 + 150.0)),
       ],
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _startTimer();
+
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+
+    _opacityAnimation =
+        Tween<double>(begin: 0.0, end: 1.0).animate(_animationController);
+
+    _animationController.forward();
+  }
+
+  void _startTimer() {
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_seconds == 0) {
+        _stopTimer();
+        Fluttertoast.showToast(msg: '캐치 성공!');
+        widget.setStageState(StageStage.playState);
+      } else {
+        if (mounted) {
+          setState(() {
+            _seconds--;
+          });
+        }
+      }
+    });
+  }
+
+  void _stopTimer() {
+    _timer.cancel();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
   }
 
   Widget musicTitleContainer(String title) {

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -37,13 +37,6 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
   final _provider = PoPoSkeletonProviderImpl();
 
   @override
-  void dispose() async {
-    _canProcess = false;
-    _poseDetector.close();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     // 카메라뷰 보이기
     return Stack(
@@ -80,6 +73,13 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
         ),
       ],
     );
+  }
+
+  @override
+  void dispose() async {
+    _canProcess = false;
+    _poseDetector.close();
+    super.dispose();
   }
 
   Column getProfile(String profileImg, String nickName, StagePlayScore score) {

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -33,13 +33,6 @@ class _PoPoResultViewState extends State<PoPoResultView> {
   final List<List<double>> _inputLists = [];
 
   @override
-  void dispose() async {
-    _canProcess = false;
-    _poseDetector.close();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     // 카메라뷰 보이기
     return Stack(
@@ -71,6 +64,13 @@ class _PoPoResultViewState extends State<PoPoResultView> {
         ),
       ],
     );
+  }
+
+  @override
+  void dispose() async {
+    _canProcess = false;
+    _poseDetector.close();
+    super.dispose();
   }
 
   Container buildMVPWidget(String profileImg, String nickName) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -856,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  semicircle_indicator:
+    dependency: "direct main"
+    description:
+      name: semicircle_indicator
+      sha256: "4ff9d80898c9032c314ea270f6f887f4056cac2f10cdfa1e7f5e6c300124e4e0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,8 @@ dependencies:
   flutter_secure_storage: ^8.0.0
   flutter_spinkit: ^5.2.0
   introduction_screen: ^3.1.9
-  like_button: ^2.0.5 
+  like_button: ^2.0.5
+  semicircle_indicator: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/627e73f9-5fc0-4053-a51d-f83c6bc319a2

## 💬 작업 설명
- 플레이 화면에서 플레이어 3명의 스켈레톤이 화면에 출력되도록 개발하였습니다.
- 지금은 카메라에 비친 1명의 사용자 스켈레톤을 3개로 보이게 했습니다.
- 캐치 버튼 ui를 피그마와 최대한 유사하개 개발해보았습니다..

## ✅ 한 일
1. 플레이 화면에서 플레이어 3명 스켈레톤 출력
2. 결과 화면에서 mvp 스켈레톤 비율 조정
3. 캐치 버튼 ui 수정

## ☝️ 참고 하세요~
1. 스켈레톤 3개를 보여지면서부터(화면에 3개의 스켈레톤이 그려지면서부터) 스켈레톤 출력 속도가 더 느려진 것 같습니다^-ㅜ 저 영상은 제가 노래에 맞춰 춤춘 것 입니다..
2. 이 풀리퀘를 끝으로 스테이지 ui가 완성되었습니다! 이후의 피드백 반영이나 세세한 추가 개발은 업로드 화면을 만든 후에 진행하겠습니다.

## 🤓 다음에 할 일
1. 업로드 ui 제작
