### PR TITLE
[feat] 업로드 화면 미리보기, 제목/태그 입력 ui 개발 (HH-247)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -5,10 +5,14 @@ class AppColor {
   static Color mainPurpleColor = const Color(0xFF565CEA);
   static Color purpleColor = const Color(0xFFB259F8);
   static Color purpleColor2 = const Color(0xFFBD00FF);
+  static Color blackColor = const Color(0xFF414B5A);
   static Color grayColor = const Color(0xFF3F3F3F);
+  static Color grayColor2 = const Color(0xFFC8C8C8);
   static Color blueColor = const Color(0xFF3959CD);
   static Color blueColor2 = const Color(0xFF0057FF);
   static Color blueColor3 = const Color(0xFF565CEA);
+  static Color blueColor4 = const Color(0xFFBAD6FF);
+  static Color blueColor5 = const Color(0xFF0D6EFD);
   static Color greenColor = const Color(0xFF00FF19);
   static Color yellowColor = const Color(0xFFEFE372);
   static Color yellowColor2 = const Color(0xFFFAFF00);

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
@@ -14,9 +15,8 @@ class UploadScreen extends StatefulWidget {
 }
 
 class _UploadScreenState extends State<UploadScreen> {
-  final TextEditingController _titleController = TextEditingController();
-  final TextEditingController _tagController = TextEditingController();
-  late VideoPlayerController _videoPlayerController;
+  final TextEditingController _titleTextController = TextEditingController();
+  VideoPlayerController? _videoPlayerController;
   late VideoPlayProvider _videoPlayProvider;
 
   @override
@@ -30,15 +30,17 @@ class _UploadScreenState extends State<UploadScreen> {
   @override
   void dispose() {
     _videoPlayProvider.playVideo();
-    _videoPlayerController.dispose();
+    _videoPlayerController?.dispose();
     super.dispose();
   }
 
   Future _initVideoPlayer() async {
-    _videoPlayerController = VideoPlayerController.file(widget.uploadFile);
-    await _videoPlayerController.initialize();
-    await _videoPlayerController.setLooping(true);
-    await _videoPlayerController.play();
+    if (_videoPlayerController == null) {
+      _videoPlayerController = VideoPlayerController.file(widget.uploadFile);
+      await _videoPlayerController!.initialize();
+      await _videoPlayerController!.setLooping(true);
+      await _videoPlayerController!.play();
+    }
   }
 
   @override
@@ -60,7 +62,7 @@ class _UploadScreenState extends State<UploadScreen> {
                   if (state.connectionState == ConnectionState.waiting) {
                     return const Center(child: CircularProgressIndicator());
                   } else {
-                    return VideoPlayer(_videoPlayerController);
+                    return VideoPlayer(_videoPlayerController!);
                   }
                 },
               ),
@@ -106,7 +108,7 @@ class _UploadScreenState extends State<UploadScreen> {
                   ),
                   child: TextField(
                     style: const TextStyle(color: Colors.black, fontSize: 14),
-                    controller: _titleController,
+                    controller: _titleTextController,
                     cursorColor: Colors.grey,
                     decoration: const InputDecoration(
                       hintText: '포포와 함께 댄스 파티',
@@ -121,44 +123,18 @@ class _UploadScreenState extends State<UploadScreen> {
             ],
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
+        const Padding(
+          padding: EdgeInsets.fromLTRB(18, 7, 18, 20),
           child: Row(
             children: [
-              const Text(
+              Text(
                 "태그",
                 style: TextStyle(fontSize: 14, color: Colors.black),
               ),
-              const SizedBox(
+              SizedBox(
                 width: 18,
               ),
-              Expanded(
-                child: Container(
-                  height: 40,
-                  width: double.infinity,
-                  padding: const EdgeInsets.only(left: 14),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(10),
-                    color: Colors.transparent,
-                    border: Border.all(
-                      color: Colors.grey,
-                      width: 2.5,
-                    ),
-                  ),
-                  child: TextField(
-                    style: const TextStyle(color: Colors.black, fontSize: 14),
-                    controller: _tagController,
-                    cursorColor: Colors.grey,
-                    decoration: const InputDecoration(
-                      hintText: '#포포 #댄스챌린지',
-                      hintStyle: TextStyle(color: Colors.grey, fontSize: 14),
-                      labelStyle: TextStyle(color: Colors.grey),
-                      border: InputBorder.none,
-                    ),
-                    textInputAction: TextInputAction.next,
-                  ),
-                ),
-              ),
+              UploadTagTextFieldWidget(),
             ],
           ),
         ),

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
 import 'package:provider/provider.dart';
@@ -90,9 +91,9 @@ class _UploadScreenState extends State<UploadScreen> {
             padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
             child: Row(
               children: [
-                const Text(
+                Text(
                   "제목",
-                  style: TextStyle(fontSize: 14, color: Colors.black),
+                  style: TextStyle(fontSize: 14, color: AppColor.blackColor),
                 ),
                 const SizedBox(
                   width: 18,
@@ -105,7 +106,7 @@ class _UploadScreenState extends State<UploadScreen> {
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(10),
                       border: Border.all(
-                        color: Colors.grey,
+                        color: AppColor.grayColor2,
                         width: 2.5,
                       ),
                     ),
@@ -113,10 +114,13 @@ class _UploadScreenState extends State<UploadScreen> {
                       style: const TextStyle(color: Colors.black, fontSize: 14),
                       controller: _titleTextController,
                       cursorColor: Colors.grey,
-                      decoration: const InputDecoration(
+                      decoration: InputDecoration(
                         hintText: '포포와 함께 댄스 파티',
-                        hintStyle: TextStyle(color: Colors.grey, fontSize: 14),
-                        labelStyle: TextStyle(color: Colors.grey),
+                        hintStyle: TextStyle(
+                            color: AppColor.blackColor,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w300),
+                        labelStyle: const TextStyle(color: Colors.grey),
                         border: InputBorder.none,
                       ),
                       textInputAction: TextInputAction.next,
@@ -129,18 +133,18 @@ class _UploadScreenState extends State<UploadScreen> {
         ),
         Container(
           color: Colors.white,
-          child: const Padding(
-            padding: EdgeInsets.fromLTRB(18, 7, 18, 20),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
             child: Row(
               children: [
                 Text(
                   "태그",
-                  style: TextStyle(fontSize: 14, color: Colors.black),
+                  style: TextStyle(fontSize: 14, color: AppColor.blackColor),
                 ),
-                SizedBox(
+                const SizedBox(
                   width: 18,
                 ),
-                UploadTagTextFieldWidget(),
+                const UploadTagTextFieldWidget(),
               ],
             ),
           ),
@@ -171,9 +175,9 @@ class _UploadScreenState extends State<UploadScreen> {
       actions: [
         TextButton(
           onPressed: () {},
-          child: const Text(
+          child: Text(
             "업로드",
-            style: TextStyle(color: Colors.blue, fontSize: 14),
+            style: TextStyle(color: AppColor.blueColor4, fontSize: 14),
           ),
         )
       ],

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -2,12 +2,146 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-class UploadScreen extends StatelessWidget {
+class UploadScreen extends StatefulWidget {
   const UploadScreen({super.key, required this.uploadFile});
   final File uploadFile;
 
   @override
+  State<UploadScreen> createState() => _UploadScreenState();
+}
+
+class _UploadScreenState extends State<UploadScreen> {
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _tagController = TextEditingController();
+
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(body: Text(uploadFile.toString()));
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text(
+          "미리보기",
+          style: TextStyle(
+              fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black),
+        ),
+        backgroundColor: Colors.white,
+        elevation: 0.0,
+        leading: TextButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          child: const Text(
+            "취소",
+            style: TextStyle(color: Colors.grey, fontSize: 14),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {},
+            child: const Text(
+              "업로드",
+              style: TextStyle(color: Colors.blue, fontSize: 14),
+            ),
+          )
+        ],
+      ),
+      body: Container(
+        child: Column(
+          children: [
+            Expanded(
+              child: Text(
+                widget.uploadFile.toString(),
+                style: const TextStyle(fontSize: 14, color: Colors.black),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 7, 18, 7),
+              child: Row(
+                children: [
+                  const Text(
+                    "제목",
+                    style: TextStyle(fontSize: 14, color: Colors.black),
+                  ),
+                  const SizedBox(
+                    width: 18,
+                  ),
+                  Expanded(
+                    child: Container(
+                      height: 40,
+                      width: double.infinity,
+                      padding: const EdgeInsets.only(left: 14),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(
+                          color: Colors.grey,
+                          width: 2.5,
+                        ),
+                      ),
+                      child: TextField(
+                        style:
+                            const TextStyle(color: Colors.black, fontSize: 14),
+                        controller: _titleController,
+                        cursorColor: Colors.grey,
+                        decoration: const InputDecoration(
+                          hintText: '포포와 함께 댄스 파티',
+                          hintStyle:
+                              TextStyle(color: Colors.grey, fontSize: 14),
+                          labelStyle: TextStyle(color: Colors.grey),
+                          border: InputBorder.none,
+                        ),
+                        textInputAction: TextInputAction.next,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
+              child: Row(
+                children: [
+                  const Text(
+                    "태그",
+                    style: TextStyle(fontSize: 14, color: Colors.black),
+                  ),
+                  const SizedBox(
+                    width: 18,
+                  ),
+                  Expanded(
+                    child: Container(
+                      height: 40,
+                      width: double.infinity,
+                      padding: const EdgeInsets.only(left: 14),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        color: Colors.transparent,
+                        border: Border.all(
+                          color: Colors.grey,
+                          width: 2.5,
+                        ),
+                      ),
+                      child: TextField(
+                        style:
+                            const TextStyle(color: Colors.black, fontSize: 14),
+                        controller: _tagController,
+                        cursorColor: Colors.grey,
+                        decoration: const InputDecoration(
+                          hintText: '#포포 #댄스챌린지',
+                          hintStyle:
+                              TextStyle(color: Colors.grey, fontSize: 14),
+                          labelStyle: TextStyle(color: Colors.grey),
+                          border: InputBorder.none,
+                        ),
+                        textInputAction: TextInputAction.next,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -49,13 +49,14 @@ class _UploadScreenState extends State<UploadScreen> {
       resizeToAvoidBottomInset: false,
       appBar: _buildAppBar(context),
       body: SafeArea(
-        child: Column(
+        child: Stack(
           children: [
             Container(
               color: Colors.purple,
               height: 3,
             ),
-            Expanded(
+            Padding(
+              padding: const EdgeInsets.fromLTRB(0, 3, 0, 134),
               child: FutureBuilder(
                 future: _initVideoPlayer(),
                 builder: (context, state) {
@@ -78,64 +79,70 @@ class _UploadScreenState extends State<UploadScreen> {
     );
   }
 
-  Column _buildVideoInfoArea() {
+  Widget _buildVideoInfoArea() {
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
-          child: Row(
-            children: [
-              const Text(
-                "제목",
-                style: TextStyle(fontSize: 14, color: Colors.black),
-              ),
-              const SizedBox(
-                width: 18,
-              ),
-              Expanded(
-                child: Container(
-                  height: 40,
-                  width: double.infinity,
-                  padding: const EdgeInsets.only(left: 14),
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: Colors.grey,
-                      width: 2.5,
+        Container(
+          color: Colors.white,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
+            child: Row(
+              children: [
+                const Text(
+                  "제목",
+                  style: TextStyle(fontSize: 14, color: Colors.black),
+                ),
+                const SizedBox(
+                  width: 18,
+                ),
+                Expanded(
+                  child: Container(
+                    height: 40,
+                    width: double.infinity,
+                    padding: const EdgeInsets.only(left: 14),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: Colors.grey,
+                        width: 2.5,
+                      ),
                     ),
-                  ),
-                  child: TextField(
-                    style: const TextStyle(color: Colors.black, fontSize: 14),
-                    controller: _titleTextController,
-                    cursorColor: Colors.grey,
-                    decoration: const InputDecoration(
-                      hintText: '포포와 함께 댄스 파티',
-                      hintStyle: TextStyle(color: Colors.grey, fontSize: 14),
-                      labelStyle: TextStyle(color: Colors.grey),
-                      border: InputBorder.none,
+                    child: TextField(
+                      style: const TextStyle(color: Colors.black, fontSize: 14),
+                      controller: _titleTextController,
+                      cursorColor: Colors.grey,
+                      decoration: const InputDecoration(
+                        hintText: '포포와 함께 댄스 파티',
+                        hintStyle: TextStyle(color: Colors.grey, fontSize: 14),
+                        labelStyle: TextStyle(color: Colors.grey),
+                        border: InputBorder.none,
+                      ),
+                      textInputAction: TextInputAction.next,
                     ),
-                    textInputAction: TextInputAction.next,
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(18, 7, 18, 20),
-          child: Row(
-            children: [
-              Text(
-                "태그",
-                style: TextStyle(fontSize: 14, color: Colors.black),
-              ),
-              SizedBox(
-                width: 18,
-              ),
-              UploadTagTextFieldWidget(),
-            ],
+        Container(
+          color: Colors.white,
+          child: const Padding(
+            padding: EdgeInsets.fromLTRB(18, 7, 18, 20),
+            child: Row(
+              children: [
+                Text(
+                  "태그",
+                  style: TextStyle(fontSize: 14, color: Colors.black),
+                ),
+                SizedBox(
+                  width: 18,
+                ),
+                UploadTagTextFieldWidget(),
+              ],
+            ),
           ),
         ),
       ],

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/ui/widget/upload/custom_tag_text_field_controller.dart';
 import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
@@ -19,11 +20,15 @@ class _UploadScreenState extends State<UploadScreen> {
   final TextEditingController _titleTextController = TextEditingController();
   VideoPlayerController? _videoPlayerController;
   late VideoPlayProvider _videoPlayProvider;
+  late CustomTagTextFieldController _tagController;
+  bool _isTitleFillOut = false;
+  bool _isTagsFillOut = false;
 
   @override
   void initState() {
     _videoPlayProvider = Provider.of(context, listen: false);
     _videoPlayProvider.pauseVideo();
+    _tagController = CustomTagTextFieldController(setIsTagsFillPutState);
 
     super.initState();
   }
@@ -32,6 +37,7 @@ class _UploadScreenState extends State<UploadScreen> {
   void dispose() {
     _videoPlayProvider.playVideo();
     _videoPlayerController?.dispose();
+    _tagController.dispose();
     super.dispose();
   }
 
@@ -111,6 +117,11 @@ class _UploadScreenState extends State<UploadScreen> {
                       ),
                     ),
                     child: TextField(
+                      onChanged: (value) {
+                        setState(() {
+                          _isTitleFillOut = value.isNotEmpty;
+                        });
+                      },
                       style: const TextStyle(color: Colors.black, fontSize: 14),
                       controller: _titleTextController,
                       cursorColor: Colors.grey,
@@ -144,13 +155,22 @@ class _UploadScreenState extends State<UploadScreen> {
                 const SizedBox(
                   width: 18,
                 ),
-                const UploadTagTextFieldWidget(),
+                UploadTagTextFieldWidget(
+                  tagController: _tagController,
+                  setIsTagsFillPutState: setIsTagsFillPutState,
+                ),
               ],
             ),
           ),
         ),
       ],
     );
+  }
+
+  setIsTagsFillPutState(bool state) {
+    setState(() {
+      _isTagsFillOut = state;
+    });
   }
 
   AppBar _buildAppBar(BuildContext context) {
@@ -174,10 +194,17 @@ class _UploadScreenState extends State<UploadScreen> {
       ),
       actions: [
         TextButton(
-          onPressed: () {},
+          onPressed: () {
+            // var title = _titleTextController.value.text;
+            // var tags = _tagController.getTags;
+          },
           child: Text(
             "업로드",
-            style: TextStyle(color: AppColor.blueColor4, fontSize: 14),
+            style: TextStyle(
+                color: (_isTitleFillOut && _isTagsFillOut)
+                    ? AppColor.blueColor5
+                    : AppColor.blueColor4,
+                fontSize: 14),
           ),
         )
       ],

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
 class UploadScreen extends StatefulWidget {
@@ -15,9 +17,19 @@ class _UploadScreenState extends State<UploadScreen> {
   final TextEditingController _titleController = TextEditingController();
   final TextEditingController _tagController = TextEditingController();
   late VideoPlayerController _videoPlayerController;
+  late VideoPlayProvider _videoPlayProvider;
+
+  @override
+  void initState() {
+    _videoPlayProvider = Provider.of(context, listen: false);
+    _videoPlayProvider.pauseVideo();
+
+    super.initState();
+  }
 
   @override
   void dispose() {
+    _videoPlayProvider.playVideo();
     _videoPlayerController.dispose();
     super.dispose();
   }
@@ -53,7 +65,11 @@ class _UploadScreenState extends State<UploadScreen> {
                 },
               ),
             ),
-            _buildVideoInfoArea(),
+            Padding(
+              padding: EdgeInsets.only(
+                  bottom: MediaQuery.of(context).viewInsets.bottom),
+              child: _buildVideoInfoArea(),
+            ),
           ],
         ),
       ),
@@ -62,6 +78,8 @@ class _UploadScreenState extends State<UploadScreen> {
 
   Column _buildVideoInfoArea() {
     return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -32,35 +32,9 @@ class _UploadScreenState extends State<UploadScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: const Text(
-          "미리보기",
-          style: TextStyle(
-              fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0.0,
-        leading: TextButton(
-          onPressed: () {
-            Navigator.pop(context);
-          },
-          child: const Text(
-            "취소",
-            style: TextStyle(color: Colors.grey, fontSize: 14),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {},
-            child: const Text(
-              "업로드",
-              style: TextStyle(color: Colors.blue, fontSize: 14),
-            ),
-          )
-        ],
-      ),
-      body: Container(
+      resizeToAvoidBottomInset: false,
+      appBar: _buildAppBar(context),
+      body: SafeArea(
         child: Column(
           children: [
             Container(
@@ -79,94 +53,129 @@ class _UploadScreenState extends State<UploadScreen> {
                 },
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
-              child: Row(
-                children: [
-                  const Text(
-                    "제목",
-                    style: TextStyle(fontSize: 14, color: Colors.black),
-                  ),
-                  const SizedBox(
-                    width: 18,
-                  ),
-                  Expanded(
-                    child: Container(
-                      height: 40,
-                      width: double.infinity,
-                      padding: const EdgeInsets.only(left: 14),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                          color: Colors.grey,
-                          width: 2.5,
-                        ),
-                      ),
-                      child: TextField(
-                        style:
-                            const TextStyle(color: Colors.black, fontSize: 14),
-                        controller: _titleController,
-                        cursorColor: Colors.grey,
-                        decoration: const InputDecoration(
-                          hintText: '포포와 함께 댄스 파티',
-                          hintStyle:
-                              TextStyle(color: Colors.grey, fontSize: 14),
-                          labelStyle: TextStyle(color: Colors.grey),
-                          border: InputBorder.none,
-                        ),
-                        textInputAction: TextInputAction.next,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
-              child: Row(
-                children: [
-                  const Text(
-                    "태그",
-                    style: TextStyle(fontSize: 14, color: Colors.black),
-                  ),
-                  const SizedBox(
-                    width: 18,
-                  ),
-                  Expanded(
-                    child: Container(
-                      height: 40,
-                      width: double.infinity,
-                      padding: const EdgeInsets.only(left: 14),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        color: Colors.transparent,
-                        border: Border.all(
-                          color: Colors.grey,
-                          width: 2.5,
-                        ),
-                      ),
-                      child: TextField(
-                        style:
-                            const TextStyle(color: Colors.black, fontSize: 14),
-                        controller: _tagController,
-                        cursorColor: Colors.grey,
-                        decoration: const InputDecoration(
-                          hintText: '#포포 #댄스챌린지',
-                          hintStyle:
-                              TextStyle(color: Colors.grey, fontSize: 14),
-                          labelStyle: TextStyle(color: Colors.grey),
-                          border: InputBorder.none,
-                        ),
-                        textInputAction: TextInputAction.next,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            _buildVideoInfoArea(),
           ],
         ),
       ),
+    );
+  }
+
+  Column _buildVideoInfoArea() {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
+          child: Row(
+            children: [
+              const Text(
+                "제목",
+                style: TextStyle(fontSize: 14, color: Colors.black),
+              ),
+              const SizedBox(
+                width: 18,
+              ),
+              Expanded(
+                child: Container(
+                  height: 40,
+                  width: double.infinity,
+                  padding: const EdgeInsets.only(left: 14),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(
+                      color: Colors.grey,
+                      width: 2.5,
+                    ),
+                  ),
+                  child: TextField(
+                    style: const TextStyle(color: Colors.black, fontSize: 14),
+                    controller: _titleController,
+                    cursorColor: Colors.grey,
+                    decoration: const InputDecoration(
+                      hintText: '포포와 함께 댄스 파티',
+                      hintStyle: TextStyle(color: Colors.grey, fontSize: 14),
+                      labelStyle: TextStyle(color: Colors.grey),
+                      border: InputBorder.none,
+                    ),
+                    textInputAction: TextInputAction.next,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
+          child: Row(
+            children: [
+              const Text(
+                "태그",
+                style: TextStyle(fontSize: 14, color: Colors.black),
+              ),
+              const SizedBox(
+                width: 18,
+              ),
+              Expanded(
+                child: Container(
+                  height: 40,
+                  width: double.infinity,
+                  padding: const EdgeInsets.only(left: 14),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10),
+                    color: Colors.transparent,
+                    border: Border.all(
+                      color: Colors.grey,
+                      width: 2.5,
+                    ),
+                  ),
+                  child: TextField(
+                    style: const TextStyle(color: Colors.black, fontSize: 14),
+                    controller: _tagController,
+                    cursorColor: Colors.grey,
+                    decoration: const InputDecoration(
+                      hintText: '#포포 #댄스챌린지',
+                      hintStyle: TextStyle(color: Colors.grey, fontSize: 14),
+                      labelStyle: TextStyle(color: Colors.grey),
+                      border: InputBorder.none,
+                    ),
+                    textInputAction: TextInputAction.next,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  AppBar _buildAppBar(BuildContext context) {
+    return AppBar(
+      centerTitle: true,
+      title: const Text(
+        "미리보기",
+        style: TextStyle(
+            fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black),
+      ),
+      backgroundColor: Colors.white,
+      elevation: 0.0,
+      leading: TextButton(
+        onPressed: () {
+          Navigator.pop(context);
+        },
+        child: const Text(
+          "취소",
+          style: TextStyle(color: Colors.grey, fontSize: 14),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {},
+          child: const Text(
+            "업로드",
+            style: TextStyle(color: Colors.blue, fontSize: 14),
+          ),
+        )
+      ],
     );
   }
 }

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -29,6 +29,7 @@ class _UploadScreenState extends State<UploadScreen> {
     _videoPlayProvider = Provider.of(context, listen: false);
     _videoPlayProvider.pauseVideo();
     _tagController = CustomTagTextFieldController(setIsTagsFillPutState);
+    _initVideoPlayer();
 
     super.initState();
   }
@@ -59,21 +60,12 @@ class _UploadScreenState extends State<UploadScreen> {
         child: Stack(
           children: [
             Container(
-              color: Colors.purple,
+              color: AppColor.purpleColor,
               height: 3,
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 3, 0, 134),
-              child: FutureBuilder(
-                future: _initVideoPlayer(),
-                builder: (context, state) {
-                  if (state.connectionState == ConnectionState.waiting) {
-                    return const Center(child: CircularProgressIndicator());
-                  } else {
-                    return VideoPlayer(_videoPlayerController!);
-                  }
-                },
-              ),
+              child: VideoPlayer(_videoPlayerController!),
             ),
             Padding(
               padding: EdgeInsets.only(
@@ -93,74 +85,84 @@ class _UploadScreenState extends State<UploadScreen> {
       children: [
         Container(
           color: Colors.white,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
-            child: Row(
-              children: [
-                Text(
-                  "제목",
-                  style: TextStyle(fontSize: 14, color: AppColor.blackColor),
-                ),
-                const SizedBox(
-                  width: 18,
-                ),
-                Expanded(
-                  child: Container(
-                    height: 40,
-                    width: double.infinity,
-                    padding: const EdgeInsets.only(left: 14),
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(10),
-                      border: Border.all(
-                        color: AppColor.grayColor2,
-                        width: 2.5,
+          child: Column(
+            children: [
+              Container(
+                color: Colors.white,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
+                  child: Row(
+                    children: [
+                      Text(
+                        "제목",
+                        style:
+                            TextStyle(fontSize: 14, color: AppColor.blackColor),
                       ),
-                    ),
-                    child: TextField(
-                      onChanged: (value) {
-                        setState(() {
-                          _isTitleFillOut = value.isNotEmpty;
-                        });
-                      },
-                      style: const TextStyle(color: Colors.black, fontSize: 14),
-                      controller: _titleTextController,
-                      cursorColor: Colors.grey,
-                      decoration: InputDecoration(
-                        hintText: '포포와 함께 댄스 파티',
-                        hintStyle: TextStyle(
-                            color: AppColor.blackColor,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w300),
-                        labelStyle: const TextStyle(color: Colors.grey),
-                        border: InputBorder.none,
+                      const SizedBox(
+                        width: 18,
                       ),
-                      textInputAction: TextInputAction.next,
-                    ),
+                      Expanded(
+                        child: Container(
+                          height: 40,
+                          width: double.infinity,
+                          padding: const EdgeInsets.only(left: 14),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
+                              color: AppColor.grayColor2,
+                              width: 2.5,
+                            ),
+                          ),
+                          child: TextField(
+                            onChanged: (value) {
+                              setState(() {
+                                _isTitleFillOut = value.isNotEmpty;
+                              });
+                            },
+                            style: const TextStyle(
+                                color: Colors.black, fontSize: 14),
+                            controller: _titleTextController,
+                            cursorColor: Colors.grey,
+                            decoration: InputDecoration(
+                              hintText: '포포와 함께 댄스 파티',
+                              hintStyle: TextStyle(
+                                  color: AppColor.blackColor,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w300),
+                              labelStyle: const TextStyle(color: Colors.grey),
+                              border: InputBorder.none,
+                            ),
+                            textInputAction: TextInputAction.next,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ],
-            ),
-          ),
-        ),
-        Container(
-          color: Colors.white,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
-            child: Row(
-              children: [
-                Text(
-                  "태그",
-                  style: TextStyle(fontSize: 14, color: AppColor.blackColor),
+              ),
+              Container(
+                color: Colors.white,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
+                  child: Row(
+                    children: [
+                      Text(
+                        "태그",
+                        style:
+                            TextStyle(fontSize: 14, color: AppColor.blackColor),
+                      ),
+                      const SizedBox(
+                        width: 18,
+                      ),
+                      UploadTagTextFieldWidget(
+                        tagController: _tagController,
+                        setIsTagsFillPutState: setIsTagsFillPutState,
+                      ),
+                    ],
+                  ),
                 ),
-                const SizedBox(
-                  width: 18,
-                ),
-                UploadTagTextFieldWidget(
-                  tagController: _tagController,
-                  setIsTagsFillPutState: setIsTagsFillPutState,
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ],

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
 
 class UploadScreen extends StatefulWidget {
   const UploadScreen({super.key, required this.uploadFile});
@@ -13,6 +14,20 @@ class UploadScreen extends StatefulWidget {
 class _UploadScreenState extends State<UploadScreen> {
   final TextEditingController _titleController = TextEditingController();
   final TextEditingController _tagController = TextEditingController();
+  late VideoPlayerController _videoPlayerController;
+
+  @override
+  void dispose() {
+    _videoPlayerController.dispose();
+    super.dispose();
+  }
+
+  Future _initVideoPlayer() async {
+    _videoPlayerController = VideoPlayerController.file(widget.uploadFile);
+    await _videoPlayerController.initialize();
+    await _videoPlayerController.setLooping(true);
+    await _videoPlayerController.play();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -48,14 +63,24 @@ class _UploadScreenState extends State<UploadScreen> {
       body: Container(
         child: Column(
           children: [
+            Container(
+              color: Colors.purple,
+              height: 3,
+            ),
             Expanded(
-              child: Text(
-                widget.uploadFile.toString(),
-                style: const TextStyle(fontSize: 14, color: Colors.black),
+              child: FutureBuilder(
+                future: _initVideoPlayer(),
+                builder: (context, state) {
+                  if (state.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  } else {
+                    return VideoPlayer(_videoPlayerController);
+                  }
+                },
               ),
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(18, 7, 18, 7),
+              padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
               child: Row(
                 children: [
                   const Text(

--- a/lib/ui/widget/upload/custom_tag_text_field_controller.dart
+++ b/lib/ui/widget/upload/custom_tag_text_field_controller.dart
@@ -1,0 +1,20 @@
+import 'package:textfield_tags/textfield_tags.dart';
+
+class CustomTagTextFieldController extends TextfieldTagsController {
+  Function setIsTagsFillPutState;
+
+  CustomTagTextFieldController(this.setIsTagsFillPutState) : super();
+
+  @override
+  set removeTag(String tag) {
+    super.removeTag = tag;
+    setIsTagsFillPutState(getTags!.isNotEmpty);
+  }
+
+  // 동작X, addTag(String tag)도, onSubmitted에도 동작 X...
+  // @override
+  // set addTag(String value) {
+  //   setIsTagsFillPutState(true);
+  //   super.addTag = value;
+  // }
+}

--- a/lib/ui/widget/upload/upload_tag_text_field_widget.dart
+++ b/lib/ui/widget/upload/upload_tag_text_field_widget.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/ui/widget/upload/custom_tag_text_field_controller.dart';
 import 'package:textfield_tags/textfield_tags.dart';
 
 class UploadTagTextFieldWidget extends StatefulWidget {
-  const UploadTagTextFieldWidget({super.key});
+  const UploadTagTextFieldWidget(
+      {super.key,
+      required this.tagController,
+      required this.setIsTagsFillPutState});
+  final CustomTagTextFieldController tagController;
+  final Function setIsTagsFillPutState;
 
   @override
   State<UploadTagTextFieldWidget> createState() =>
@@ -12,14 +18,6 @@ class UploadTagTextFieldWidget extends StatefulWidget {
 
 class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
   late double _distanceToField;
-  late TextfieldTagsController _tagController;
-
-  @override
-  void initState() {
-    _tagController = TextfieldTagsController();
-
-    super.initState();
-  }
 
   @override
   void didChangeDependencies() {
@@ -28,17 +26,15 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
   }
 
   @override
-  void dispose() {
-    _tagController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return TextFieldTags(
-      textfieldTagsController: _tagController,
+      textfieldTagsController: widget.tagController,
       textSeparators: const [' ', ','],
       letterCase: LetterCase.normal,
+      validator: (String tag) {
+        widget.setIsTagsFillPutState(true);
+        return null;
+      },
       inputfieldBuilder: (context, tec, fn, error, onChanged, onSubmitted) {
         return ((context, sc, tags, onTagDelete) {
           return Expanded(
@@ -59,7 +55,7 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
                 decoration: InputDecoration(
                   isDense: true,
                   border: InputBorder.none,
-                  hintText: _tagController.hasTags ? '' : "#포포 #댄스챌린지",
+                  hintText: widget.tagController.hasTags ? '' : "#포포 #댄스챌린지",
                   hintStyle: TextStyle(
                       color: AppColor.blackColor,
                       fontSize: 14,

--- a/lib/ui/widget/upload/upload_tag_text_field_widget.dart
+++ b/lib/ui/widget/upload/upload_tag_text_field_widget.dart
@@ -52,6 +52,7 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
               child: TextField(
                 controller: tec,
                 focusNode: fn,
+                style: const TextStyle(color: Colors.black, fontSize: 14),
                 decoration: InputDecoration(
                   isDense: true,
                   border: InputBorder.none,

--- a/lib/ui/widget/upload/upload_tag_text_field_widget.dart
+++ b/lib/ui/widget/upload/upload_tag_text_field_widget.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:textfield_tags/textfield_tags.dart';
+
+class UploadTagTextFieldWidget extends StatefulWidget {
+  const UploadTagTextFieldWidget({super.key});
+
+  @override
+  State<UploadTagTextFieldWidget> createState() =>
+      _UploadTagTextFieldWidgetState();
+}
+
+class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
+  late double _distanceToField;
+  late TextfieldTagsController _tagController;
+
+  @override
+  void initState() {
+    _tagController = TextfieldTagsController();
+
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _distanceToField = MediaQuery.of(context).size.width;
+  }
+
+  @override
+  void dispose() {
+    _tagController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFieldTags(
+      textfieldTagsController: _tagController,
+      textSeparators: const [' ', ','],
+      letterCase: LetterCase.normal,
+      inputfieldBuilder: (context, tec, fn, error, onChanged, onSubmitted) {
+        return ((context, sc, tags, onTagDelete) {
+          return Expanded(
+            child: Container(
+              height: 40,
+              width: double.infinity,
+              padding: const EdgeInsets.only(left: 14),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: Colors.grey,
+                  width: 2.5,
+                ),
+              ),
+              child: TextField(
+                controller: tec,
+                focusNode: fn,
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: InputBorder.none,
+                  hintText: _tagController.hasTags ? '' : "#포포 #댄스챌린지",
+                  hintStyle: const TextStyle(color: Colors.grey, fontSize: 14),
+                  errorText: error,
+                  prefixIconConstraints:
+                      BoxConstraints(maxWidth: _distanceToField * 0.54),
+                  prefixIcon: tags.isNotEmpty
+                      ? SingleChildScrollView(
+                          controller: sc,
+                          scrollDirection: Axis.horizontal,
+                          child: Row(
+                              children: tags.map((String tag) {
+                            return Container(
+                              decoration: const BoxDecoration(
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(20.0),
+                                ),
+                                color: Colors.grey,
+                              ),
+                              margin:
+                                  const EdgeInsets.symmetric(horizontal: 4.0),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8.0, vertical: 5.0),
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  InkWell(
+                                    child: Text(
+                                      '#$tag',
+                                      style: const TextStyle(
+                                          color: Colors.white, fontSize: 14),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 4.0),
+                                  InkWell(
+                                    child: const Icon(
+                                      Icons.cancel,
+                                      size: 14.0,
+                                      color: Colors.white,
+                                    ),
+                                    onTap: () {
+                                      onTagDelete(tag);
+                                    },
+                                  )
+                                ],
+                              ),
+                            );
+                          }).toList()),
+                        )
+                      : null,
+                ),
+                onChanged: onChanged,
+                onSubmitted: onSubmitted,
+              ),
+            ),
+          );
+        });
+      },
+    );
+  }
+}

--- a/lib/ui/widget/upload/upload_tag_text_field_widget.dart
+++ b/lib/ui/widget/upload/upload_tag_text_field_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pocket_pose/config/app_color.dart';
 import 'package:textfield_tags/textfield_tags.dart';
 
 class UploadTagTextFieldWidget extends StatefulWidget {
@@ -48,7 +49,7 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(10),
                 border: Border.all(
-                  color: Colors.grey,
+                  color: AppColor.grayColor2,
                   width: 2.5,
                 ),
               ),
@@ -59,7 +60,10 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
                   isDense: true,
                   border: InputBorder.none,
                   hintText: _tagController.hasTags ? '' : "#포포 #댄스챌린지",
-                  hintStyle: const TextStyle(color: Colors.grey, fontSize: 14),
+                  hintStyle: TextStyle(
+                      color: AppColor.blackColor,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w300),
                   errorText: error,
                   prefixIconConstraints:
                       BoxConstraints(maxWidth: _distanceToField * 0.54),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1109,6 +1109,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  textfield_tags:
+    dependency: "direct main"
+    description:
+      name: textfield_tags
+      sha256: c1d215f481e7e8da5c79719825e595db4f829bf1ad3fce4c7ce43d340aa72683
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   like_button: ^2.0.5
   semicircle_indicator: ^1.1.1
   image_picker: ^1.0.0
+  textfield_tags: ^2.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진 
1. 갤러리에서 선택한 영상 미리보기 + 영상 정보(제목, 태그) 작성
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/ee00b687-b039-4ea1-85ad-7f84632d443e

2. 촬영한 동영상 미리보기 + 영상 정보(제목, 태그) 작성
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/42710017-c833-4779-87e8-39fc45baf779

## 💬 작업 설명
- 선택한 혹은 촬영한 영상 미리보기 기능 추가했습니다.
- 제목, 태그 입력 ui를 만들었습니다.
- 제목, 태그 모두 입력해야 업로드 버튼이 활성화되도록 했습니다.

## ✅ 한 일
1. 영상 미리보기 기능 + 무한 반복
4. 제목, 태그 입력 ui 개발
5. 태그 자동 입력 라이브러리 적용
6. 제목, 태그 모두 입력 시 업로드 버튼 활성화

## 😥 어려웠던점
1. 태그 라이브러리 적용할 때, 원하는대로 커스텀하기 위해 처음으로 커스텀을 해 보았습니다! dart 언어가 익숙하지 않아서 이거저거 찾아보면서 했어서 적어봅니다,,ㅎㅎ 여기서 addTags 함수가 제대로 오버라이드 되지 않는 문제점이 있었는데, TextFieldTags 안의 validator 함수 안에 원하는 기능을 추가하는 방법으로 해결하였습니다. addTags가 제대로 오버라이드 된다면 코드가 쫌 더 깔끔해졌을텐데 아쉽습니다.

## 🤓 다음에 할 일
1. 스켈레톤 추출 후 파일화하는 코드 작성
2. 포포 스테이지 플레이 화면: 스켈레톤 색 변경
4. 채팅 ui 제작

