### PR TITLE
[feat] 스켈레톤 파일화 코드 추가 및 권한 설정 코드 추가 (HH-249)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -68,4 +68,8 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    implementation "androidx.lifecycle:lifecycle-runtime:2.0.0"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.0.0"
+    annotationProcessor "androidx.lifecycle:lifecycle-compiler:2.0.0"
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.pocketpose">
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+
    <application
         android:hardwareAccelerated="false"
         android:largeHeap="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -12,6 +12,15 @@
 				</array>
 			</dict>
 		</array>
+		<key>NSPhotoLibraryUsageDescription</key>
+		<string>$(PRODUCT_NAME) 사진첩 접근 권한</string>
+		<key>NSCameraUsageDescription</key>
+		<string>$(PRODUCT_NAME) 카메라 접근 권한</string>
+		<key>NSPhotoLibraryAddUsageDescription</key>
+		<string>$(PRODUCT_NAME) 사진첩 추가 권한</string>
+		<key>NSFileProtectionKey</key>
+		<string>$(PRODUCT_NAME) 파일 쓰기 권한</string>
+
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,4 +1,3 @@
-import 'package:audio_session/audio_session.dart';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:camera/camera.dart';
 import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
@@ -52,23 +51,23 @@ class AudioPlayerUtil {
   }
 
   // 외부 음악 들릴 때 반응 설정
-  _audioSessionConfigure() =>
-      AudioSession.instance.then((audioSession) async => await audioSession
-          .configure(const AudioSessionConfiguration(
-              avAudioSessionCategory: AVAudioSessionCategory.playback,
-              avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
-              avAudioSessionMode: AVAudioSessionMode.defaultMode,
-              avAudioSessionRouteSharingPolicy:
-                  AVAudioSessionRouteSharingPolicy.defaultPolicy,
-              avAudioSessionSetActiveOptions:
-                  AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
-              androidAudioAttributes: AndroidAudioAttributes(
-                contentType: AndroidAudioContentType.music,
-                flags: AndroidAudioFlags.none,
-                usage: AndroidAudioUsage.media,
-              ),
-              androidAudioFocusGainType:
-                  AndroidAudioFocusGainType.gainTransient,
-              androidWillPauseWhenDucked: true))
-          .then((_) => audioSession = audioSession));
+  // _audioSessionConfigure() =>
+  //     AudioSession.instance.then((audioSession) async => await audioSession
+  //         .configure(const AudioSessionConfiguration(
+  //             avAudioSessionCategory: AVAudioSessionCategory.playback,
+  //             avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
+  //             avAudioSessionMode: AVAudioSessionMode.defaultMode,
+  //             avAudioSessionRouteSharingPolicy:
+  //                 AVAudioSessionRouteSharingPolicy.defaultPolicy,
+  //             avAudioSessionSetActiveOptions:
+  //                 AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
+  //             androidAudioAttributes: AndroidAudioAttributes(
+  //               contentType: AndroidAudioContentType.music,
+  //               flags: AndroidAudioFlags.none,
+  //               usage: AndroidAudioUsage.media,
+  //             ),
+  //             androidAudioFocusGainType:
+  //                 AndroidAudioFocusGainType.gainTransient,
+  //             androidWillPauseWhenDucked: true))
+  //         .then((_) => audioSession = audioSession));
 }

--- a/lib/ui/screen/on_boarding_screen.dart
+++ b/lib/ui/screen/on_boarding_screen.dart
@@ -161,7 +161,6 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
                 child: Image.asset(
                   imgPath,
                   fit: BoxFit.fitHeight,
-                  height: 350,
                 ),
               ),
               const SizedBox(
@@ -232,7 +231,6 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
                     children: [
                       SvgPicture.asset(
                         'assets/images/charactor_on_boarding.svg',
-                        height: 300,
                         fit: BoxFit.contain,
                       ),
                       Container(

--- a/lib/ui/screen/on_boarding_screen.dart
+++ b/lib/ui/screen/on_boarding_screen.dart
@@ -16,11 +16,14 @@ class OnBoardingScreen extends StatefulWidget {
 
 class _OnBoardingScreenState extends State<OnBoardingScreen> {
   final _introKey = GlobalKey<IntroductionScreenState>();
+  late double screenHeightSize;
 
   bool _skipState = true;
 
   @override
   Widget build(BuildContext context) {
+    screenHeightSize = MediaQuery.of(context).size.height;
+
     return IntroductionScreen(
       onChange: (value) {
         if (value == 4) {
@@ -160,6 +163,7 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
               Expanded(
                 child: Image.asset(
                   imgPath,
+                  height: screenHeightSize * 0.5,
                   fit: BoxFit.fitHeight,
                 ),
               ),
@@ -232,6 +236,7 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
                       SvgPicture.asset(
                         'assets/images/charactor_on_boarding.svg',
                         fit: BoxFit.contain,
+                        height: screenHeightSize * 0.4,
                       ),
                       Container(
                         decoration: BoxDecoration(

--- a/lib/ui/screen/on_boarding_screen.dart
+++ b/lib/ui/screen/on_boarding_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:introduction_screen/introduction_screen.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/local_pref_provider.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
@@ -251,7 +253,7 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
                                 borderRadius: BorderRadius.circular(30)),
                           ),
                           onPressed: () {
-                            goHomepage();
+                            permission();
                           },
                           child: const Padding(
                             padding: EdgeInsets.all(8.0),
@@ -288,5 +290,18 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(builder: (_) => const MainScreen()),
     );
+  }
+
+  Future<bool> permission() async {
+    await [Permission.camera, Permission.storage].request();
+
+    if (await Permission.camera.isGranted &&
+        await Permission.storage.isGranted) {
+      goHomepage();
+      return Future.value(true);
+    } else {
+      Fluttertoast.showToast(msg: '포포 스테이지를 즐기기 위해 권한을 설정해주세요.');
+      return Future.value(false);
+    }
   }
 }

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -192,8 +192,11 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
 
         // 노래 끝나면 스켈레톤 서버에 보내기
         if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
-          // 스켈레톤 파일로 저장
-          skeletonToFile(_inputLists);
+          // 스켈레톤 파일로 저장: 실행 안 되도록 설정
+          if (1 > 2) {
+            skeletonToFile(_inputLists);
+          }
+
           // // ai 서버 오류로 잠시 주석처리
           _provider
               .postSkeletonList(_inputLists)

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -244,11 +244,17 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
   }
 
   Future<void> skeletonToFile(List<List<double>> inputLists) async {
-    var now = DateTime.now().toString().substring(0, 18);
+    var today = DateTime.now().toString().substring(0, 9);
+    var now = DateTime.now();
+
     final dir = await ExternalPath.getExternalStoragePublicDirectory(
         ExternalPath.DIRECTORY_DOCUMENTS);
-    final path = '$dir/popo-skeleton-$now.txt';
-    debugPrint("mmm: $path");
+    // 폴더 생성
+    String folderPath = '$dir/PoPo';
+    await Directory(folderPath).create(recursive: true);
+    // 파일 생성 및 저장
+    final path =
+        '$dir/PoPo/popo-skeleton-$today-${now.hour}-${now.minute}-${now.second}.txt';
     File(path).writeAsString(inputLists.toString());
   }
 }

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -245,8 +245,6 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
 
   Future<void> skeletonToFile(List<List<double>> inputLists) async {
     var now = DateTime.now().toString().substring(0, 18);
-    print("mmm: $now");
-
     final dir = await ExternalPath.getExternalStoragePublicDirectory(
         ExternalPath.DIRECTORY_DOCUMENTS);
     final path = '$dir/popo-skeleton-$now.txt';

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:external_path/external_path.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
@@ -189,6 +192,8 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
 
         // 노래 끝나면 스켈레톤 서버에 보내기
         if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
+          // 스켈레톤 파일로 저장
+          skeletonToFile(_inputLists);
           // // ai 서버 오류로 잠시 주석처리
           _provider
               .postSkeletonList(_inputLists)
@@ -236,5 +241,16 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
       entry[PoseLandmarkType.leftAnkle]!.x,
       entry[PoseLandmarkType.leftAnkle]!.y
     ];
+  }
+
+  Future<void> skeletonToFile(List<List<double>> inputLists) async {
+    var now = DateTime.now().toString().substring(0, 18);
+    print("mmm: $now");
+
+    final dir = await ExternalPath.getExternalStoragePublicDirectory(
+        ExternalPath.DIRECTORY_DOCUMENTS);
+    final path = '$dir/popo-skeleton-$now.txt';
+    debugPrint("mmm: $path");
+    File(path).writeAsString(inputLists.toString());
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
+  external_path:
+    dependency: "direct main"
+    description:
+      name: external_path
+      sha256: "2095c626fbbefe70d5a4afc9b1137172a68ee2c276e51c3c1283394485bea8f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -817,7 +825,7 @@ packages:
     source: hosted
     version: "1.0.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "3087813781ab814e4157b172f1a11c46be20179fcc9bea043e0fba36bc0acaa2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -872,6 +872,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.7"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "415af30ba76a84faccfe1eb251fe1e4fdc790f876924c65ad7d6ed7a1404bcd6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.4.2"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: c0c9754479a4c4b1c1f3862ddc11930c9b3f03bef2816bb4ea6eed1e13551d6f
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.2"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: "7a187b671a39919462af2b5e813148365b71a615979165a119868d667fe90c03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.3"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: "7c6b1500385dd1d2ca61bb89e2488ca178e274a69144d26bbd65e33eae7c02a9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.11.3"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1009,13 +1009,13 @@ packages:
     source: hosted
     version: "1.1.1"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "396f85b8afc6865182610c0a2fc470853d56499f75f7499e2a73a9f0539d23d0"
+      sha256: "0344316c947ffeb3a529eac929e1978fcd37c26be4e8468628bac399365a3ca1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -1044,10 +1044,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: fb5cf25c0235df2d0640ac1b1174f6466bd311f621574997ac59018a6664548d
+      sha256: "23b052f17a25b90ff2b61aad4cc962154da76fb62848a9ce088efe30d7c50ab1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   shared_preferences_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   google_mlkit_pose_detection: ^0.6.0
   fluttertoast: ^8.2.2
   camera: ^0.10.4
+  path_provider: ^2.0.15
+  external_path: ^1.0.3
   http: ^0.13.5
   dio: ^5.0.3
   audio_session: ^0.1.15

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   semicircle_indicator: ^1.1.1
   image_picker: ^1.0.0
   textfield_tags: ^2.0.2
+  permission_handler: ^10.4.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   image_picker: ^1.0.0
   textfield_tags: ^2.0.2
   permission_handler: ^10.4.2
+  shared_preferences: ^2.2.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   flutter_secure_storage_windows
+  permission_handler_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/859cc222-7f69-4540-8063-f397967ee5c5
- 온보딩 화면에 권한을 추가한 영상입니다.
- 권한을 모두 허용하기 전까지 포포 앱에 입장할 수 없습니다.

## 💬 작업 설명
- 스테이지 플레이 화면에서 노래가 끝나면 플레이어의 스켈레톤을 txt파일로 만드는 코드를 추가했습니다.
- 파일 저장 경로는 내 파일>내장 저장공간>Documents>PoPo>popo-skeleton-{todat}-{timeStamp}.txt입니다.
- 지금은 코드만 추가해둔 상태고 실제로 저장은 되지 않게 해두었습니다.
- 파일을 저장하기 위해 쓰기 권한이 필요한데, 이 권한 요청을 온보딩 마지막 페이지에 추가해두었습니다.
- 권한 요청하는 김에 카메라 권한 요청도 여기서 한꺼번에 받도록 수정하였습니다. 기존에는 스테이지 입장하고, 플레이어가 됐을 때 카메라 권한을 요청합니다(mlkit에서 설정한 것)

## ✅ 한 일
1. 스켈레톤 파일화 코드 추가
2. 온보딩 마지막 화면에 권한 요청 추가

## 😥 어려웠던점
1. 파일 저장할 때 경로 정하는 게 어려웠습니다. ㅎㅎ 어느 경로로 지정해야 제대로 저장되는지... 공식 문서나 블로그 참고했을때도 다 달라서 경우의 수만큼 테스트해봤습니다...

## 🤓 다음에 할 일
1. 스테이지 플레이 화면: 스켈레톤 색 변경
2. 채팅 ui
