### PR TITLE
[feat] 스테이지 플레이 화면 스켈레톤 색 3개로 변경 (HH-252)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -17,4 +17,6 @@ class AppColor {
   static Color yellowColor = const Color(0xFFEFE372);
   static Color yellowColor2 = const Color(0xFFFAFF00);
   static Color mintNeonColor = const Color.fromARGB(255, 104, 250, 241);
+  static Color yellowNeonColor = const Color(0xFFEDF156);
+  static Color greenNeonColor = const Color(0xFF41EF49);
 }

--- a/lib/config/ml_kit/custom_pose_painter.dart
+++ b/lib/config/ml_kit/custom_pose_painter.dart
@@ -2,11 +2,11 @@
 // translateX, translateY를 사용해 추출된 좌표를 휴대폰 화면 크기에 맞게 변형하여 그려줌
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
-import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/coordinates_translator.dart';
 
 class CustomPosePainter extends CustomPainter {
-  CustomPosePainter(this.poses, this.absoluteImageSize, this.rotation);
+  CustomPosePainter(
+      this.poses, this.absoluteImageSize, this.rotation, this.skeletonColor);
 
   // 추출된 포즈의 랜드마크 리스트
   final List<Pose> poses;
@@ -14,6 +14,8 @@ class CustomPosePainter extends CustomPainter {
   final Size absoluteImageSize;
   // 이미지 회전 정보
   final InputImageRotation rotation;
+  // 스켈레톤 색깔
+  final Color skeletonColor;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -22,7 +24,7 @@ class CustomPosePainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..strokeWidth = 8.0
       ..strokeCap = StrokeCap.round
-      ..color = AppColor.mintNeonColor
+      ..color = skeletonColor //AppColor.mintNeonColor
       ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3.0);
 
     // Inner 네온 효과
@@ -30,7 +32,7 @@ class CustomPosePainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..strokeWidth = 4.0
       ..strokeCap = StrokeCap.round
-      ..color = AppColor.mintNeonColor
+      ..color = skeletonColor //AppColor.mintNeonColor
       ..maskFilter = const MaskFilter.blur(BlurStyle.inner, 2.0);
 
     // 기본 라인

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -23,7 +23,9 @@ class CameraView extends StatefulWidget {
       {Key? key,
       required this.isResultState,
       required this.setIsSkeletonDetectMode,
-      required this.customPaint,
+      this.customPaintLeft,
+      required this.customPaintMid,
+      this.customPaintRight,
       required this.onImage,
       this.initialDirection = CameraLensDirection.back})
       : super(key: key);
@@ -31,7 +33,9 @@ class CameraView extends StatefulWidget {
   // skeleton 트리거
   Function setIsSkeletonDetectMode;
   // 스켈레톤을 그려주는 객체
-  final CustomPaint? customPaint;
+  final CustomPaint? customPaintLeft;
+  final CustomPaint? customPaintMid;
+  final CustomPaint? customPaintRight;
   // 이미지 받을 때마다 실행하는 함수
   final Function(InputImage inputImage) onImage;
   // 카메라 렌즈 방향 변수
@@ -178,8 +182,8 @@ class _CameraViewState extends State<CameraView> {
         Expanded(flex: 2, child: Container()),
         Expanded(
             flex: 4,
-            child: (widget.customPaint != null)
-                ? SizedBox(height: 300, child: widget.customPaint!)
+            child: (widget.customPaintMid != null)
+                ? SizedBox(height: 300, child: widget.customPaintMid!)
                 : Container()),
         Expanded(flex: 2, child: Container()),
       ],
@@ -192,18 +196,18 @@ class _CameraViewState extends State<CameraView> {
       children: [
         Expanded(
             flex: 3,
-            child: (widget.customPaint != null)
-                ? SizedBox(height: 150, child: widget.customPaint!)
+            child: (widget.customPaintLeft != null)
+                ? SizedBox(height: 150, child: widget.customPaintLeft!)
                 : Container()),
         Expanded(
             flex: 4,
-            child: (widget.customPaint != null)
-                ? SizedBox(height: 200, child: widget.customPaint!)
+            child: (widget.customPaintMid != null)
+                ? SizedBox(height: 200, child: widget.customPaintMid!)
                 : Container()),
         Expanded(
             flex: 3,
-            child: (widget.customPaint != null)
-                ? SizedBox(height: 150, child: widget.customPaint!)
+            child: (widget.customPaintRight != null)
+                ? SizedBox(height: 150, child: widget.customPaintRight!)
                 : Container()),
       ],
     );

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -31,7 +31,9 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
   bool _canProcess = true;
   bool _isBusy = false;
   // 스켈레톤 모양을 그려주는 변수
-  CustomPaint? _customPaint;
+  CustomPaint? _customPaintLeft;
+  CustomPaint? _customPaintMid;
+  CustomPaint? _customPaintRight;
   // 스켈레톤 추출할지 안할지, 추출한다면 배열에 저장할지 할지 관리하는 변수
   SkeletonDetectMode _skeletonDetectMode = SkeletonDetectMode.userMode;
   final bool _isPlayer = true;
@@ -64,7 +66,9 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
           isResultState: widget.isResultState,
           setIsSkeletonDetectMode: setIsSkeletonDetectMode,
           // 스켈레톤 그려주는 객체 전달
-          customPaint: _customPaint,
+          customPaintLeft: _customPaintLeft,
+          customPaintMid: _customPaintMid,
+          customPaintRight: _customPaintRight,
           // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
           onImage: (inputImage) {
             // user이거나 노래가 종료된 거 아닌 이상 항상 스켈레톤 추출
@@ -172,12 +176,29 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     if (inputImage.inputImageData?.size != null &&
         inputImage.inputImageData?.imageRotation != null) {
       // 여기만 2개만 수정 ! PosePainter -> CustomPosePainter
-      final painter = CustomPosePainter(poses, inputImage.inputImageData!.size,
-          inputImage.inputImageData!.imageRotation);
-      _customPaint = CustomPaint(painter: painter);
+      final painterLeft = CustomPosePainter(
+          poses,
+          inputImage.inputImageData!.size,
+          inputImage.inputImageData!.imageRotation,
+          AppColor.yellowNeonColor);
+      final painterMid = CustomPosePainter(
+          poses,
+          inputImage.inputImageData!.size,
+          inputImage.inputImageData!.imageRotation,
+          AppColor.mintNeonColor);
+      final painterRignt = CustomPosePainter(
+          poses,
+          inputImage.inputImageData!.size,
+          inputImage.inputImageData!.imageRotation,
+          AppColor.greenNeonColor);
+      _customPaintLeft = CustomPaint(painter: painterLeft);
+      _customPaintMid = CustomPaint(painter: painterMid);
+      _customPaintRight = CustomPaint(painter: painterRignt);
     } else {
       // 추출된 포즈 없음
-      _customPaint = null;
+      _customPaintLeft = null;
+      _customPaintMid = null;
+      _customPaintRight = null;
     }
     _isBusy = false;
     if (mounted) {

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -25,7 +25,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
   bool _canProcess = true;
   bool _isBusy = false;
   // 스켈레톤 모양을 그려주는 변수
-  CustomPaint? _customPaint;
+  CustomPaint? _customPaintMid;
   // 스켈레톤 추출할지 안할지, 추출한다면 배열에 저장할지 할지 관리하는 변수
   SkeletonDetectMode _skeletonDetectMode = SkeletonDetectMode.userMode;
   final bool _isPlayer = true;
@@ -52,7 +52,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
           isResultState: widget.isResultState,
           setIsSkeletonDetectMode: setIsSkeletonDetectMode,
           // 스켈레톤 그려주는 객체 전달
-          customPaint: _customPaint,
+          customPaintMid: _customPaintMid,
           // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
           onImage: (inputImage) {
             // player는 항상 스켈레톤 추출
@@ -157,11 +157,11 @@ class _PoPoResultViewState extends State<PoPoResultView> {
         inputImage.inputImageData?.imageRotation != null) {
       // 여기만 2개만 수정 ! PosePainter -> CustomPosePainter
       final painter = CustomPosePainter(poses, inputImage.inputImageData!.size,
-          inputImage.inputImageData!.imageRotation);
-      _customPaint = CustomPaint(painter: painter);
+          inputImage.inputImageData!.imageRotation, AppColor.mintNeonColor);
+      _customPaintMid = CustomPaint(painter: painter);
     } else {
       // 추출된 포즈 없음
-      _customPaint = null;
+      _customPaintMid = null;
     }
     _isBusy = false;
     if (mounted) {


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/f5506078-9d39-49eb-8a4d-28869cbf2290" width="200">
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/a1ccd8e5-d01e-4346-8338-85566e703fdd" width="200" >
1. 노-파-분: 원래는 이전에 정한 대로 노-파-분으로 개발할 예정이었으나, 보시는 것처럼 분홍색의 관절 꺾어지는 부분이 노랑, 파랑에 비해 눈에 띄는 것 같고, 배경색과 비슷한 거 같아 2번으로 바꾸었습니다.
2. 노-파-초(현재 상태). 

## 💬 작업 설명
- 스테이지 플레이 화면의 스켈레톤 3개의 색을 다르게 지정했습니다.(왼쪽: 노랑, 가운데: 파랑, 오른쪽: 초록)
- mvp화면엔 지금은 파랑으로 지정해두었습니다. 서버와 연결하면 이긴 사람의 스켈레톤 색이 보여지도록 개발할 예정입니다.

## ✅ 한 일
1. 스테이지 플레이화면 스켈레톤 위치에 따라 색 변경

## 💃 부탁 드립니다~
1. 스켈레톤 색은 이전에 피그마에서 보았던 사진을 참고로 하였습니다. 지금 색도 괜찮은지, 아니면 다른 색으로 바꾸었으면 좋겠는지 봐주세요!
<img width="486" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/0de756de-9c21-41c5-a476-1697a8a7d211">

## 🤓 다음에 할 일
1. 채팅 ui
