### PR TITLE
[fix] 스테이지 폰트 적용 및 폰트 크기 수정 (HH-256)

### DIFF
--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -105,41 +105,38 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   Widget build(BuildContext context) {
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
 
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: GestureDetector(
-        onTap: () {
-          FocusScope.of(context).unfocus();
-        },
-        child: Scaffold(
-          resizeToAvoidBottomInset: false,
-          body: Container(
-              // 플레이, 결과 상태에 따라 배경화면 변경
-              decoration: buildBackgroundImage(),
-              child: Scaffold(
-                resizeToAvoidBottomInset: false,
-                extendBodyBehindAppBar: true,
-                backgroundColor: Colors.transparent,
-                appBar: buildAppBar(context),
-                body: Stack(
-                  children: [
-                    _buildStageView(_stageStage),
-                    const Positioned(
-                      bottom: 68,
-                      left: 0,
-                      right: 0,
-                      child: StageLiveChatListWidget(),
-                    ),
-                    const Positioned(
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      child: StageLiveChatBarWidget(),
-                    ),
-                  ],
-                ),
-              )),
-        ),
+    return GestureDetector(
+      onTap: () {
+        FocusScope.of(context).unfocus();
+      },
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: Container(
+            // 플레이, 결과 상태에 따라 배경화면 변경
+            decoration: buildBackgroundImage(),
+            child: Scaffold(
+              resizeToAvoidBottomInset: false,
+              extendBodyBehindAppBar: true,
+              backgroundColor: Colors.transparent,
+              appBar: buildAppBar(context),
+              body: Stack(
+                children: [
+                  _buildStageView(_stageStage),
+                  const Positioned(
+                    bottom: 68,
+                    left: 0,
+                    right: 0,
+                    child: StageLiveChatListWidget(),
+                  ),
+                  const Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: StageLiveChatBarWidget(),
+                  ),
+                ],
+              ),
+            )),
       ),
     );
   }

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -104,7 +104,7 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
         ),
         Text(
           nickName,
-          style: const TextStyle(color: Colors.white, fontSize: 14),
+          style: const TextStyle(color: Colors.white, fontSize: 12),
         ),
         const SizedBox(
           height: 8,
@@ -147,7 +147,7 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
         textAlign: TextAlign.center,
         style: TextStyle(
           color: Colors.white,
-          fontSize: 20,
+          fontSize: 18,
           shadows: [
             for (double i = 1; i < 6; i++)
               Shadow(color: scoreNeonColor, blurRadius: 3 * i)

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -95,7 +95,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
             Text(
               'MVP',
               style: TextStyle(
-                fontSize: 25,
+                fontSize: 22,
                 color: Colors.white,
                 shadows: [
                   for (double i = 1; i < 6; i++)
@@ -132,7 +132,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
             ),
             Text(
               nickName,
-              style: const TextStyle(color: Colors.white, fontSize: 14),
+              style: const TextStyle(color: Colors.white, fontSize: 12),
             ),
           ],
         ),


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/166bc1b5-343e-4e89-b0f6-2979d40647cd" width="200" >
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/96baefb2-a184-486a-9660-4effa375d33e" width="200">


## 💬 작업 설명
- 스테이지 폰트를 다시 적용되도록 하였습니다.(stage_screen.dart에서 return되는 root를 MaterialApp이 아니게 함.)
- 폰트가 적용되면서 플레이화면의 점수 글자가 아래로 내려가는 경우가 생겨서 폰트 사이즈를 작게 조절했습니다.

## ✅ 한 일
1. 스테이지 폰트 적용
2. 스테이지 폰트 크기 작게 변경

## 💃 부탁 드립니다~
1. 바꾼 폰트 크기 괜찮은지 확인 부탁드립니다. 스테이지 플레이 화면, 결과 화면만 수정하였습니다.
2. 댓글 폰트 비율은 안 바꿨는데 이것도 작게 수정하는 게 좋을까요?

## 🤓 다음에 할 일
1. 채팅 ui 개발
2. 영상 업로드 ui 수정(영상 비율 맞춰서 개발)
