### PR TITLE
[ui] 팔로잉 팔로우 페이지 UI 개발 (HH-218)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -7,9 +7,11 @@ class AppColor {
   static Color purpleColor2 = const Color(0xFFBD00FF);
   static Color blackColor = const Color(0xFF414B5A);
   static Color grayColor = const Color(0xFF3F3F3F);
+  static Color grayColor1 = const Color(0xFFE7EBF0);
   static Color grayColor2 = const Color(0xFFC8C8C8);
   static Color grayColor3 = const Color(0x99999999);
   static Color blueColor = const Color(0xFF3959CD);
+  static Color blueColor1 = const Color(0xFF97C7FF);
   static Color blueColor2 = const Color(0xFF0057FF);
   static Color blueColor3 = const Color(0xFF565CEA);
   static Color blueColor4 = const Color(0xFFBAD6FF);

--- a/lib/ui/screen/profile/profile_follow_screen.dart
+++ b/lib/ui/screen/profile/profile_follow_screen.dart
@@ -1,0 +1,274 @@
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/ui/widget/profile/custom_simple_dialog.dart';
+import 'package:provider/provider.dart';
+
+class ProfileFollowScreen extends StatefulWidget {
+  const ProfileFollowScreen({Key? key, required this.index}) : super(key: key);
+
+  final int index;
+
+  @override
+  State<StatefulWidget> createState() => _ProfileFollowScreenState();
+}
+
+class _ProfileFollowScreenState extends State<ProfileFollowScreen>
+    with SingleTickerProviderStateMixin {
+  late VideoPlayProvider _videoPlayProvider;
+  late TabController _tabController;
+
+  List<String> followingProfileList = [
+    'assets/images/chat_user_1.png',
+    'assets/images/chat_user_2.png',
+    'assets/images/chat_user_3.png',
+    'assets/images/chat_user_4.png',
+    'assets/images/chat_user_5.png',
+    'assets/images/chat_user_6.png',
+  ];
+
+  List<String> followingNicknameList = [
+    'hello_kiti',
+    'pochako',
+    'pom_pom_pulin',
+    'kelo_kelo_kelopi',
+    'kogimyung_',
+    'teogsido_saem'
+  ];
+
+  List<String> followingIntroduceList = [
+    '안녕 난 키티야',
+    '',
+    '푸루루루푸우린',
+    '케로로 아님',
+    '',
+    ''
+  ];
+
+  List<bool> followingList = [
+    true,
+    true,
+    false,
+    true,
+    true,
+    true,
+  ];
+
+  List<String> followerProfileList = [
+    'assets/images/chat_user_4.png',
+    'assets/images/chat_user_5.png',
+    'assets/images/chat_user_6.png',
+  ];
+
+  List<String> followerNicknameList = [
+    'kelo_kelo_kelopi',
+    'kogimyung_',
+    'teogsido_saem'
+  ];
+
+  List<String> followerIntroduceList = ['케로로 아님', '', ''];
+
+  List<bool> followerList = [
+    false,
+    true,
+    true,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          _videoPlayProvider.nicknames[widget.index],
+          style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+        ),
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        leading: IconButton(
+          icon: Image.asset(
+            'assets/icons/ic_back.png',
+          ),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+        elevation: 0,
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: Colors.black,
+          unselectedLabelColor: AppColor.grayColor3,
+          indicatorColor: AppColor.purpleColor,
+          tabs: const [
+            Tab(text: '106  팔로워'),
+            Tab(text: '48.4k  팔로잉'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          FollowListViewWidget(
+              tabNum: 0,
+              isfollows: followerList,
+              profiles: followerProfileList,
+              nicknames: followerNicknameList,
+              introduces: followerIntroduceList),
+          FollowListViewWidget(
+              tabNum: 1,
+              isfollows: followingList,
+              profiles: followingProfileList,
+              nicknames: followingNicknameList,
+              introduces: followingIntroduceList),
+        ],
+      ),
+    );
+  }
+}
+
+class FollowListViewWidget extends StatefulWidget {
+  FollowListViewWidget({
+    Key? key,
+    required this.tabNum,
+    required this.isfollows,
+    required this.profiles,
+    required this.nicknames,
+    required this.introduces,
+  }) : super(key: key);
+
+  int tabNum;
+  List<bool> isfollows;
+  List<String> profiles;
+  List<String> nicknames;
+  List<String> introduces;
+
+  @override
+  State<StatefulWidget> createState() => _FollowListViewWidgetState();
+}
+
+class _FollowListViewWidgetState extends State<FollowListViewWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: widget.isfollows.length,
+      itemBuilder: (context, index) {
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(25, 20, 25, 10),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(50),
+                    child: Image.asset(
+                      widget.profiles[index],
+                      width: 35,
+                    ),
+                  ),
+                  const Padding(padding: EdgeInsets.only(left: 8)),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.nicknames[index],
+                        style: const TextStyle(fontSize: 12),
+                      ),
+                      if (widget.introduces[index].isNotEmpty)
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Padding(padding: EdgeInsets.only(bottom: 8)),
+                            Text(
+                              widget.introduces[index],
+                              style: const TextStyle(fontSize: 14),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+              widget.tabNum == 0 //팔로워일 경우
+                  ? widget.isfollows[index]
+                      ? InkWell(
+                          onTap: () => {
+                            showDialog(
+                                context: context,
+                                builder: (BuildContext context) {
+                                  return CustomSimpleDialog(
+                                    title: '팔로워를 삭제하시겠어요?',
+                                    message:
+                                        '${widget.nicknames[index]}님은 회원님의 팔로워 리스트에서 삭제된 사실을 알 수 없습니다.',
+                                    onCancel: () {
+                                      Navigator.pop(context);
+                                    },
+                                    onConfirm: () {
+                                      Fluttertoast.showToast(
+                                        msg: '삭제 되었습니다.',
+                                      );
+                                      //팔로워 삭제 api 호출
+                                      setState(() {
+                                        widget.isfollows[index] =
+                                            !widget.isfollows[index];
+                                      });
+                                      Navigator.pop(context);
+                                    },
+                                  );
+                                })
+                          },
+                          child: Material(
+                            borderRadius: BorderRadius.circular(5),
+                            color: widget.isfollows[index]
+                                ? AppColor.grayColor1
+                                : AppColor.blueColor1,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
+                              child: Text(
+                                '삭제',
+                                style: TextStyle(
+                                    fontSize: 10, color: AppColor.grayColor),
+                              ),
+                            ),
+                          ),
+                        )
+                      : Container()
+                  : //팔로우일 경우
+                  InkWell(
+                      onTap: () {
+                        setState(() {
+                          widget.isfollows[index] = !widget.isfollows[index];
+                        });
+                      },
+                      child: Material(
+                        borderRadius: BorderRadius.circular(5),
+                        color: widget.isfollows[index]
+                            ? AppColor.grayColor1
+                            : AppColor.blueColor1,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
+                          child: Text(
+                            widget.isfollows[index] ? '팔로잉' : '팔로우',
+                            style: TextStyle(
+                                fontSize: 10, color: AppColor.grayColor),
+                          ),
+                        ),
+                      ),
+                    )
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -8,7 +8,7 @@ import 'package:pocket_pose/ui/video_viewer/screen/video_my_screen.dart';
 import 'package:pocket_pose/ui/screen/profile/profile_setting_screen.dart';
 
 import 'package:pocket_pose/ui/widget/not_login_widget.dart';
-import 'package:pocket_pose/ui/widget/profile/profile_infomation_widget.dart';
+import 'package:pocket_pose/ui/widget/profile/profile_user_info_widget.dart';
 import 'package:provider/provider.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -122,7 +122,7 @@ class _ProfileScreenState extends State<ProfileScreen>
                           )
                         ],
                       ),
-                      ProfileInfomationWidget(),
+                      ProfileUserInfoWidget(index: 0), //사용자 index
                     ],
                   ),
                 ),

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -128,13 +128,6 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
           ),
         ),
       ]),
-      // Center(
-      //     child: TextButton(
-      //         onPressed: () {
-      //           authProvider.kakaoSignOut();
-      //           Navigator.pop(context);
-      //         },
-      //         child: const Text("로그아웃")))
     );
   }
 }

--- a/lib/ui/widget/profile/profile_user_info_widget.dart
+++ b/lib/ui/widget/profile/profile_user_info_widget.dart
@@ -1,10 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/ui/screen/profile/profile_follow_screen.dart';
+import 'package:provider/provider.dart';
 
-class ProfileInfomationWidget extends StatelessWidget {
-  ProfileInfomationWidget({
+class ProfileUserInfoWidget extends StatelessWidget {
+  ProfileUserInfoWidget({
     super.key,
+    required this.index,
   });
+
+  int index;
+
+  late VideoPlayProvider _videoPlayProvider;
 
   List<String> videoLinks = [
     'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
@@ -24,6 +32,8 @@ class ProfileInfomationWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context);
+
     return SizedBox(
       //color: Colors.yellow,
       height: 300,
@@ -37,47 +47,55 @@ class ProfileInfomationWidget extends StatelessWidget {
             child: ClipRRect(
               borderRadius: BorderRadius.circular(50),
               child: Image.asset(
-                'assets/images/profile_profile.png',
+                _videoPlayProvider.profiles[index],
                 fit: BoxFit.cover,
               ),
             ),
           ),
           Container(
             margin: const EdgeInsets.fromLTRB(0, 20, 0, 14),
-            child: const Text(
-              "cat_chur",
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            child: Text(
+              _videoPlayProvider.nicknames[index],
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
           ),
-          Container(
-            margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Container(
-                  margin: const EdgeInsets.fromLTRB(0, 0, 50, 0),
-                  child: Column(
+          GestureDetector(
+            child: Container(
+              margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Container(
+                    margin: const EdgeInsets.fromLTRB(0, 0, 50, 0),
+                    child: Column(
+                      mainAxisAlignment:
+                          MainAxisAlignment.center, // 위 아래 정렬을 중앙으로 설정
+                      children: [
+                        Container(
+                            margin: const EdgeInsets.fromLTRB(0, 0, 0, 8),
+                            child: const Text("161")),
+                        const Text("팔로잉"),
+                      ],
+                    ),
+                  ),
+                  Column(
                     mainAxisAlignment:
                         MainAxisAlignment.center, // 위 아래 정렬을 중앙으로 설정
                     children: [
                       Container(
                           margin: const EdgeInsets.fromLTRB(0, 0, 0, 8),
-                          child: const Text("161")),
-                      const Text("팔로잉"),
+                          child: const Text("48.4k")),
+                      const Text("팔로워"),
                     ],
                   ),
-                ),
-                Column(
-                  mainAxisAlignment:
-                      MainAxisAlignment.center, // 위 아래 정렬을 중앙으로 설정
-                  children: [
-                    Container(
-                        margin: const EdgeInsets.fromLTRB(0, 0, 0, 8),
-                        child: const Text("48.4k")),
-                    const Text("팔로워"),
-                  ],
-                ),
-              ],
+                ],
+              ),
+            ),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) =>
+                      ProfileFollowScreen(index: 0)), // 사용자 index 넘기기
             ),
           ),
           Container(


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/5542e2ad-a7f6-463f-9ee6-ef5bb307cff7


## 💬 작업 설명
팔로잉 팔로우 페이지 UI를 개발했습니다.

## ✅ 한 일
1. 프로필에서 팔로잉 또는 팔로우를 누르면 해당 페이지로 이동
2. 팔로잉 삭제를 누르면 다이얼로그로 한번 더 확인 후 팔로잉 삭제
3. 팔로잉을 누르면 팔로우로 바뀌며 팔로잉 해제

## 🔧 보완할 점
1. 지금 보니까 프로필에서 팔로잉을 누르면 팔로잉 탭이, 팔로우를 누르면 팔로우 탭이 활성화 된 상태로 해야겠네요. 수정하겠습니다

## 🤓 다음에 할 일
1. 팔로잉 팔로우 페이지 이동 수정
2. 검색 페이지 UI 개발
