### PR TITLE
[ui] 업로드 화면 미리보기 영상 비율 맞추도록 ui 수정 (HH-260)

### DIFF
--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -64,7 +64,7 @@ class _UploadScreenState extends State<UploadScreen> {
               height: 3,
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(0, 3, 0, 134),
+              padding: const EdgeInsets.fromLTRB(0, 3, 0, 0),
               child: VideoPlayer(_videoPlayerController!),
             ),
             Padding(
@@ -83,87 +83,76 @@ class _UploadScreenState extends State<UploadScreen> {
       mainAxisAlignment: MainAxisAlignment.end,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Container(
-          color: Colors.white,
-          child: Column(
-            children: [
-              Container(
-                color: Colors.white,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
-                  child: Row(
-                    children: [
-                      Text(
-                        "제목",
-                        style:
-                            TextStyle(fontSize: 14, color: AppColor.blackColor),
-                      ),
-                      const SizedBox(
-                        width: 18,
-                      ),
-                      Expanded(
-                        child: Container(
-                          height: 40,
-                          width: double.infinity,
-                          padding: const EdgeInsets.only(left: 14),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(10),
-                            border: Border.all(
-                              color: AppColor.grayColor2,
-                              width: 2.5,
-                            ),
-                          ),
-                          child: TextField(
-                            onChanged: (value) {
-                              setState(() {
-                                _isTitleFillOut = value.isNotEmpty;
-                              });
-                            },
-                            style: const TextStyle(
-                                color: Colors.black, fontSize: 14),
-                            controller: _titleTextController,
-                            cursorColor: Colors.grey,
-                            decoration: InputDecoration(
-                              hintText: '포포와 함께 댄스 파티',
-                              hintStyle: TextStyle(
-                                  color: AppColor.blackColor,
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w300),
-                              labelStyle: const TextStyle(color: Colors.grey),
-                              border: InputBorder.none,
-                            ),
-                            textInputAction: TextInputAction.next,
-                          ),
+        Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
+              child: Row(
+                children: [
+                  const Text(
+                    "제목",
+                    style: TextStyle(fontSize: 14, color: Colors.white),
+                  ),
+                  const SizedBox(
+                    width: 18,
+                  ),
+                  Expanded(
+                    child: Container(
+                      height: 40,
+                      width: double.infinity,
+                      padding: const EdgeInsets.only(left: 14),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(
+                          color: Colors.white,
+                          width: 2.5,
                         ),
                       ),
-                    ],
-                  ),
-                ),
-              ),
-              Container(
-                color: Colors.white,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
-                  child: Row(
-                    children: [
-                      Text(
-                        "태그",
+                      child: TextField(
+                        onChanged: (value) {
+                          setState(() {
+                            _isTitleFillOut = value.isNotEmpty;
+                          });
+                        },
                         style:
-                            TextStyle(fontSize: 14, color: AppColor.blackColor),
+                            const TextStyle(color: Colors.white, fontSize: 14),
+                        controller: _titleTextController,
+                        cursorColor: Colors.white,
+                        decoration: const InputDecoration(
+                          hintText: '포포와 함께 댄스 파티',
+                          hintStyle: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                              fontWeight: FontWeight.w300),
+                          labelStyle: TextStyle(color: Colors.white),
+                          border: InputBorder.none,
+                        ),
+                        textInputAction: TextInputAction.next,
                       ),
-                      const SizedBox(
-                        width: 18,
-                      ),
-                      UploadTagTextFieldWidget(
-                        tagController: _tagController,
-                        setIsTagsFillPutState: setIsTagsFillPutState,
-                      ),
-                    ],
+                    ),
                   ),
-                ),
+                ],
               ),
-            ],
-          ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
+              child: Row(
+                children: [
+                  const Text(
+                    "태그",
+                    style: TextStyle(fontSize: 14, color: Colors.white),
+                  ),
+                  const SizedBox(
+                    width: 18,
+                  ),
+                  UploadTagTextFieldWidget(
+                    tagController: _tagController,
+                    setIsTagsFillPutState: setIsTagsFillPutState,
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -83,76 +83,88 @@ class _UploadScreenState extends State<UploadScreen> {
       mainAxisAlignment: MainAxisAlignment.end,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
-              child: Row(
-                children: [
-                  const Text(
-                    "제목",
-                    style: TextStyle(fontSize: 14, color: Colors.white),
-                  ),
-                  const SizedBox(
-                    width: 18,
-                  ),
-                  Expanded(
-                    child: Container(
-                      height: 40,
-                      width: double.infinity,
-                      padding: const EdgeInsets.only(left: 14),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                          color: Colors.white,
-                          width: 2.5,
+        Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                Colors.transparent,
+                Colors.black,
+              ],
+            ),
+          ),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(18, 20, 18, 7),
+                child: Row(
+                  children: [
+                    const Text(
+                      "제목",
+                      style: TextStyle(fontSize: 14, color: Colors.white),
+                    ),
+                    const SizedBox(
+                      width: 18,
+                    ),
+                    Expanded(
+                      child: Container(
+                        height: 40,
+                        width: double.infinity,
+                        padding: const EdgeInsets.only(left: 14),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: Colors.white,
+                            width: 2.5,
+                          ),
                         ),
-                      ),
-                      child: TextField(
-                        onChanged: (value) {
-                          setState(() {
-                            _isTitleFillOut = value.isNotEmpty;
-                          });
-                        },
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 14),
-                        controller: _titleTextController,
-                        cursorColor: Colors.white,
-                        decoration: const InputDecoration(
-                          hintText: '포포와 함께 댄스 파티',
-                          hintStyle: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w300),
-                          labelStyle: TextStyle(color: Colors.white),
-                          border: InputBorder.none,
+                        child: TextField(
+                          onChanged: (value) {
+                            setState(() {
+                              _isTitleFillOut = value.isNotEmpty;
+                            });
+                          },
+                          style: const TextStyle(
+                              color: Colors.white, fontSize: 14),
+                          controller: _titleTextController,
+                          cursorColor: Colors.white,
+                          decoration: const InputDecoration(
+                            hintText: '포포와 함께 댄스 파티',
+                            hintStyle: TextStyle(
+                                color: Colors.white,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w300),
+                            labelStyle: TextStyle(color: Colors.white),
+                            border: InputBorder.none,
+                          ),
+                          textInputAction: TextInputAction.next,
                         ),
-                        textInputAction: TextInputAction.next,
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
-              child: Row(
-                children: [
-                  const Text(
-                    "태그",
-                    style: TextStyle(fontSize: 14, color: Colors.white),
-                  ),
-                  const SizedBox(
-                    width: 18,
-                  ),
-                  UploadTagTextFieldWidget(
-                    tagController: _tagController,
-                    setIsTagsFillPutState: setIsTagsFillPutState,
-                  ),
-                ],
+              Padding(
+                padding: const EdgeInsets.fromLTRB(18, 7, 18, 20),
+                child: Row(
+                  children: [
+                    const Text(
+                      "태그",
+                      style: TextStyle(fontSize: 14, color: Colors.white),
+                    ),
+                    const SizedBox(
+                      width: 18,
+                    ),
+                    UploadTagTextFieldWidget(
+                      tagController: _tagController,
+                      setIsTagsFillPutState: setIsTagsFillPutState,
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ],
     );

--- a/lib/ui/widget/upload/upload_tag_text_field_widget.dart
+++ b/lib/ui/widget/upload/upload_tag_text_field_widget.dart
@@ -45,20 +45,21 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(10),
                 border: Border.all(
-                  color: AppColor.grayColor2,
+                  color: Colors.white,
                   width: 2.5,
                 ),
               ),
               child: TextField(
+                cursorColor: Colors.white,
                 controller: tec,
                 focusNode: fn,
-                style: const TextStyle(color: Colors.black, fontSize: 14),
+                style: const TextStyle(color: Colors.white, fontSize: 14),
                 decoration: InputDecoration(
                   isDense: true,
                   border: InputBorder.none,
                   hintText: widget.tagController.hasTags ? '' : "#포포 #댄스챌린지",
-                  hintStyle: TextStyle(
-                      color: AppColor.blackColor,
+                  hintStyle: const TextStyle(
+                      color: Colors.white,
                       fontSize: 14,
                       fontWeight: FontWeight.w300),
                   errorText: error,
@@ -71,11 +72,11 @@ class _UploadTagTextFieldWidgetState extends State<UploadTagTextFieldWidget> {
                           child: Row(
                               children: tags.map((String tag) {
                             return Container(
-                              decoration: const BoxDecoration(
-                                borderRadius: BorderRadius.all(
+                              decoration: BoxDecoration(
+                                borderRadius: const BorderRadius.all(
                                   Radius.circular(20.0),
                                 ),
-                                color: Colors.grey,
+                                color: AppColor.purpleColor,
                               ),
                               margin:
                                   const EdgeInsets.symmetric(horizontal: 4.0),


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/12819739-5676-4f0e-be4f-3be501c5a6ea" width="200">
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/38f55728-5795-4a83-b680-5ed5e6c4912d" width="200">

## 💬 작업 설명
- 업로드 화면의 미리보기 영상 비율이 맞게 보이도록 ui를 수정했습니다.

## ✅ 한 일
1. 제목, 태그 입력 부분에도 영상 보이도록 수정
2. 제목, 태그 부분 뒷배경에 검정 그라데이션 추가 

## ☝️ 참고 하세요~
1. 기존엔 태그 배경색이 회색이었는데, 글씨색을 모두 흰 색으로 바꾸니까 회색이 눈에 잘 안보여서 앱 메인 컬러 중 하나인 보라색으로 수정했습니다. 어떤가요!?

## 🤓 다음에 할 일
1. 채팅 ui 개발
