### PR TITLE
[bug] 프로필에서 팔로워, 팔로잉 페이지 이동시 탭 선택 버그 수정 (HH-218)

### DIFF
--- a/lib/ui/screen/profile/profile_follow_screen.dart
+++ b/lib/ui/screen/profile/profile_follow_screen.dart
@@ -6,8 +6,10 @@ import 'package:pocket_pose/ui/widget/profile/custom_simple_dialog.dart';
 import 'package:provider/provider.dart';
 
 class ProfileFollowScreen extends StatefulWidget {
-  const ProfileFollowScreen({Key? key, required this.index}) : super(key: key);
+  ProfileFollowScreen({Key? key, required this.tapNum, required this.index})
+      : super(key: key);
 
+  int tapNum;
   final int index;
 
   @override
@@ -79,7 +81,8 @@ class _ProfileFollowScreenState extends State<ProfileFollowScreen>
   void initState() {
     super.initState();
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController =
+        TabController(length: 2, vsync: this, initialIndex: widget.tapNum);
   }
 
   @override

--- a/lib/ui/widget/profile/profile_user_info_widget.dart
+++ b/lib/ui/widget/profile/profile_user_info_widget.dart
@@ -59,13 +59,13 @@ class ProfileUserInfoWidget extends StatelessWidget {
               style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
           ),
-          GestureDetector(
-            child: Container(
-              margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Container(
+          Container(
+            margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                GestureDetector(
+                  child: Container(
                     margin: const EdgeInsets.fromLTRB(0, 0, 50, 0),
                     child: Column(
                       mainAxisAlignment:
@@ -74,28 +74,36 @@ class ProfileUserInfoWidget extends StatelessWidget {
                         Container(
                             margin: const EdgeInsets.fromLTRB(0, 0, 0, 8),
                             child: const Text("161")),
-                        const Text("팔로잉"),
+                        const Text("팔로워"),
                       ],
                     ),
                   ),
-                  Column(
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => ProfileFollowScreen(
+                            tapNum: 0, index: 0)), // 사용자 index 넘기기
+                  ),
+                ),
+                GestureDetector(
+                  child: Column(
                     mainAxisAlignment:
                         MainAxisAlignment.center, // 위 아래 정렬을 중앙으로 설정
                     children: [
                       Container(
                           margin: const EdgeInsets.fromLTRB(0, 0, 0, 8),
                           child: const Text("48.4k")),
-                      const Text("팔로워"),
+                      const Text("팔로잉"),
                     ],
                   ),
-                ],
-              ),
-            ),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                  builder: (context) =>
-                      ProfileFollowScreen(index: 0)), // 사용자 index 넘기기
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => ProfileFollowScreen(
+                            tapNum: 1, index: 0)), // 사용자 index 넘기기
+                  ),
+                ),
+              ],
             ),
           ),
           Container(


### PR DESCRIPTION
## 📱 작업 사진 
[untitled.webm](https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/de4068a8-f4f0-45a8-9168-926b89131251)

## 💬 작업 설명
프로필 페이지에서 팔로워 누르면 팔로워 탭, 팔로잉 누르면 팔로잉 탭이 선택되어 있도록 수정했습니다~

## 🤓 다음에 할 일
1. 검색 페이지 UI 개발
