### PR TITLE
[Bug] #45에서 발견한 채팅 및 비디오 화면 오류 해결 (HH-176/HH-218)

### DIFF
--- a/lib/ui/video_viewer/screen/video_my_screen.dart
+++ b/lib/ui/video_viewer/screen/video_my_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/ui/video_viewer/video_view.dart';
 import 'package:pocket_pose/ui/widget/profile/custom_simple_dialog.dart';
+import 'package:provider/provider.dart';
 
 class VideoMyScreen extends StatefulWidget {
   VideoMyScreen({Key? key, required this.index}) : super(key: key);
@@ -15,12 +17,21 @@ class VideoMyScreen extends StatefulWidget {
 }
 
 class _VideoMyScreenState extends State<VideoMyScreen> {
+  late VideoPlayProvider _videoPlayProvider;
   final TextEditingController _textController = TextEditingController();
 
   @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+  }
+
+  @override
   void dispose() {
-    _textController.dispose();
     super.dispose();
+    _textController.dispose();
+    _videoPlayProvider.pauseVideo();
   }
 
   @override

--- a/lib/ui/video_viewer/screen/video_my_screen.dart
+++ b/lib/ui/video_viewer/screen/video_my_screen.dart
@@ -70,7 +70,7 @@ class _VideoMyScreenState extends State<VideoMyScreen> {
         ],
       ),
       extendBodyBehindAppBar: true, //body 위에 appbar
-      resizeToAvoidBottomInset: true,
+      resizeToAvoidBottomInset: false,
       body: const VideoView(),
       bottomSheet: Container(
         height: 65,

--- a/lib/ui/video_viewer/screen/video_someone_screen.dart
+++ b/lib/ui/video_viewer/screen/video_someone_screen.dart
@@ -20,15 +20,21 @@ class _VideoSomeoneScreenState extends State<VideoSomeoneScreen> {
   final TextEditingController _textController = TextEditingController();
 
   @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+  }
+
+  @override
   void dispose() {
-    _textController.dispose();
     super.dispose();
+    _textController.dispose();
+    _videoPlayProvider.pauseVideo();
   }
 
   @override
   Widget build(BuildContext context) {
-    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
-
     return Scaffold(
         appBar: AppBar(
           //centerTitle: true, //Title text 가운데 정렬

--- a/lib/ui/video_viewer/screen/video_someone_screen.dart
+++ b/lib/ui/video_viewer/screen/video_someone_screen.dart
@@ -48,7 +48,7 @@ class _VideoSomeoneScreenState extends State<VideoSomeoneScreen> {
           ),
         ),
         extendBodyBehindAppBar: true, //body 위에 appbar
-        resizeToAvoidBottomInset: true,
+        resizeToAvoidBottomInset: false,
         body: const VideoView(),
         bottomSheet: Container(
           height: 65,

--- a/lib/ui/video_viewer/widget/chat_button_widget.dart
+++ b/lib/ui/video_viewer/widget/chat_button_widget.dart
@@ -169,11 +169,11 @@ class _ChatButtonWidgetState extends State<ChatButtonWidget> {
                             ),
                           ),
                           bottomSheet: SizedBox(
-                            height: 110,
+                            height: 90,
                             child: Column(
                               children: [
                                 Container(
-                                  height: 45,
+                                  height: 25,
                                   color: Colors.white,
                                   child: Row(
                                     mainAxisAlignment:
@@ -203,7 +203,7 @@ class _ChatButtonWidgetState extends State<ChatButtonWidget> {
                                           child: Text(
                                             emojiList[i],
                                             style:
-                                                const TextStyle(fontSize: 24),
+                                                const TextStyle(fontSize: 20),
                                           ),
                                         ),
                                     ],


### PR DESCRIPTION
## 💬 작업 설명
#45에서 발견한 채팅 및 비디오 화면 오류를 해결했습니다.

## ✅ 한 일
1. 내 영상 화면, 다른 사용자의 영상 화면에서 댓글 입력시 뒤의 영상 작아지는 현상 제거

<img width="186" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/708a4097-f4ef-4a2f-9fba-e112cd371ab8">
<img width="186" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/463dd772-2c10-41c7-99a6-ed8800e04d7f">

2. 일본어 입력시 댓글 화면 오버플로우 조정
Scaffold의 bottomsheet로 해서 오류가 난게 아니라 키보드가 길어질 때 댓글 화면을 넘어가서 발생하는 오류라 높이를 조절했습니다.
애뮬레이터가 느려서 일본어 자판을 직접 켜서 확인해보진 못했습니다.
확인 부탁드립니다.

3. 내가 업로드한 영상, 다른 사용자가 업로드한 영상 페이지 벗어날 때 영상 계속 멈추지 않는 오류 수정
개발할 때 음소거 해놓고 개발했어서 발견하지 못했었습니다. 대신 찾아주셔서 감사합니다(꾸벅)

## ✔️ 참고하세요
충돌 오류 해결하다가 앱컬러 이름이 겹쳐서 수정했더니 채팅 화면의 채팅 내용 색이 바뀐 것 같습니다 🥲
grayColor4가 두개여서 하나를 grayColor5로 바꾸었더니 민영님 화면의 색이 바뀐 것 같습니다.
번거롭겠지만 .. 수정 부탁드리겠습니다! 🙂👍

<img width="375" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/51523009-5dca-4126-b347-1cdb6017ddd6">

<img width="281" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/41b83ac5-256a-4f73-ade9-c6251214b9b5">

## 🤓 다음에 할 일
1. 홈 화면 서버 API 연결