### PR TITLE
[feat] 스테이지 채팅 목록 조회 api 연결 (HH-278)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -11,6 +11,7 @@ class AppUrl {
 
   // 포포 스테이지
   static const stageAccuracyUrl = "$_stageUrl/similarity";
+  static const stageTalkUrl = "$_stageUrl/talks/messages";
 
   // 스켈레톤 정확도 확인
   static const skeletonAccuracyUrl = "$_aiBaseUrl/api/similarity/test";

--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -5,13 +5,14 @@ class AppUrl {
   static const _aiBaseUrl = "http://43.200.133.86:5000";
 
   static const _stageUrl = "$_apiBaseUrl/stages";
+  static const _talkUrl = "$_apiBaseUrl/talks";
 
   // 로그인 & 회원가입
   static const signInSignUpUrl = "$_apiBaseUrl/auth/login?type=kakao";
 
   // 포포 스테이지
   static const stageAccuracyUrl = "$_stageUrl/similarity";
-  static const stageTalkUrl = "$_stageUrl/talks/messages";
+  static const stageTalkUrl = "$_talkUrl/messages";
 
   // 스켈레톤 정확도 확인
   static const skeletonAccuracyUrl = "$_aiBaseUrl/api/similarity/test";

--- a/lib/data/entity/base_object.dart
+++ b/lib/data/entity/base_object.dart
@@ -1,0 +1,3 @@
+abstract class BaseObject<T> {
+  T fromJson(json);
+}

--- a/lib/data/entity/base_response.dart
+++ b/lib/data/entity/base_response.dart
@@ -1,0 +1,23 @@
+import 'package:pocket_pose/data/entity/base_object.dart';
+
+class BaseResponse<T> {
+  String timeStamp;
+  String code;
+  String message;
+  T data;
+
+  BaseResponse(
+      {required this.timeStamp,
+      required this.code,
+      required this.message,
+      required this.data});
+
+  factory BaseResponse.fromJson(Map<String, dynamic> json, BaseObject target) {
+    return BaseResponse(
+      timeStamp: json['timeStamp'],
+      code: json['code'],
+      message: json['message'],
+      data: target.fromJson(json['data']),
+    );
+  }
+}

--- a/lib/data/entity/request/stage_talk_message_request.dart
+++ b/lib/data/entity/request/stage_talk_message_request.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'stage_talk_message_request.g.dart';
+
+@JsonSerializable()
+class StageTalkMessageRequest {
+  int page;
+  int size;
+
+  StageTalkMessageRequest({
+    required this.page,
+    required this.size,
+  });
+
+  factory StageTalkMessageRequest.fromJson(Map<String, dynamic> json) =>
+      _$StageTalkMessageRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageTalkMessageRequestToJson(this);
+}

--- a/lib/data/entity/request/stage_talk_message_request.g.dart
+++ b/lib/data/entity/request/stage_talk_message_request.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_talk_message_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageTalkMessageRequest _$StageTalkMessageRequestFromJson(
+        Map<String, dynamic> json) =>
+    StageTalkMessageRequest(
+      page: json['page'] as int,
+      size: json['size'] as int,
+    );
+
+Map<String, dynamic> _$StageTalkMessageRequestToJson(
+        StageTalkMessageRequest instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'size': instance.size,
+    };

--- a/lib/data/entity/response/stage_talk_message_response.dart
+++ b/lib/data/entity/response/stage_talk_message_response.dart
@@ -1,22 +1,28 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
 
 part 'stage_talk_message_response.g.dart';
 
 @JsonSerializable()
-class StageTalkMessageResponse {
+class StageTalkMessageResponse extends BaseObject<StageTalkMessageResponse> {
   int page;
   int size;
-  List<StageTalkListItem> messeges;
+  List<StageTalkListItem>? messages;
 
   StageTalkMessageResponse({
     required this.page,
     required this.size,
-    required this.messeges,
+    required this.messages,
   });
 
   factory StageTalkMessageResponse.fromJson(Map<String, dynamic> json) =>
       _$StageTalkMessageResponseFromJson(json);
 
   Map<String, dynamic> toJson() => _$StageTalkMessageResponseToJson(this);
+
+  @override
+  StageTalkMessageResponse fromJson(json) {
+    return StageTalkMessageResponse.fromJson(json);
+  }
 }

--- a/lib/data/entity/response/stage_talk_message_response.dart
+++ b/lib/data/entity/response/stage_talk_message_response.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
+
+part 'stage_talk_message_response.g.dart';
+
+@JsonSerializable()
+class StageTalkMessageResponse {
+  int page;
+  int size;
+  List<StageTalkListItem> messeges;
+
+  StageTalkMessageResponse({
+    required this.page,
+    required this.size,
+    required this.messeges,
+  });
+
+  factory StageTalkMessageResponse.fromJson(Map<String, dynamic> json) =>
+      _$StageTalkMessageResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageTalkMessageResponseToJson(this);
+}

--- a/lib/data/entity/response/stage_talk_message_response.g.dart
+++ b/lib/data/entity/response/stage_talk_message_response.g.dart
@@ -11,8 +11,8 @@ StageTalkMessageResponse _$StageTalkMessageResponseFromJson(
     StageTalkMessageResponse(
       page: json['page'] as int,
       size: json['size'] as int,
-      messeges: (json['messeges'] as List<dynamic>)
-          .map((e) => StageTalkListItem.fromJson(e as Map<String, dynamic>))
+      messages: (json['messages'] as List<dynamic>?)
+          ?.map((e) => StageTalkListItem.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
@@ -21,5 +21,5 @@ Map<String, dynamic> _$StageTalkMessageResponseToJson(
     <String, dynamic>{
       'page': instance.page,
       'size': instance.size,
-      'messeges': instance.messeges,
+      'messages': instance.messages,
     };

--- a/lib/data/entity/response/stage_talk_message_response.g.dart
+++ b/lib/data/entity/response/stage_talk_message_response.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_talk_message_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageTalkMessageResponse _$StageTalkMessageResponseFromJson(
+        Map<String, dynamic> json) =>
+    StageTalkMessageResponse(
+      page: json['page'] as int,
+      size: json['size'] as int,
+      messeges: (json['messeges'] as List<dynamic>)
+          .map((e) => StageTalkListItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$StageTalkMessageResponseToJson(
+        StageTalkMessageResponse instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'size': instance.size,
+      'messeges': instance.messeges,
+    };

--- a/lib/data/remote/provider/stage_talk_provider_impl.dart
+++ b/lib/data/remote/provider/stage_talk_provider_impl.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pocket_pose/config/api_url.dart';
+import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/request/stage_talk_message_request.dart';
+import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+import 'package:pocket_pose/domain/provider/stage_talk_provider.dart';
+
+class StageTalkProviderImpl implements StageTalkProvider {
+  @override
+  Future<BaseResponse<StageTalkMessageResponse>> getTalkMessages(
+      StageTalkMessageRequest request) async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    const refreshTokenKey = 'kakaoRefreshToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+
+    var dio = Dio();
+    try {
+      print("mmmm response: mmmmm");
+      dio.options.headers = {
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+      };
+      dio.options.contentType = "application/json";
+      var response = await dio.get(
+          '${AppUrl.stageTalkUrl}?page=${request.page}&size=${request.size}');
+      print("mmmm response: ${response.data['data']}");
+
+      return BaseResponse<StageTalkMessageResponse>.fromJson(response.data,
+          StageTalkMessageResponse.fromJson(response.data['data']));
+    } catch (e) {
+      debugPrint("mmm StageTalkProviderImpl catch: ${e.toString()}");
+    }
+    return throw UnimplementedError();
+  }
+}

--- a/lib/domain/entity/stage_talk_list_item.dart
+++ b/lib/domain/entity/stage_talk_list_item.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/domain/entity/chat_user_list_item.dart';
+
+part 'stage_talk_list_item.g.dart';
+
+@JsonSerializable()
+class StageTalkListItem {
+  late String messageId;
+  late String content;
+  late String createdAt;
+  late ChatUserListItem sender;
+
+  StageTalkListItem(
+      {required this.content, required this.sender, required this.createdAt});
+
+  factory StageTalkListItem.fromJson(Map<String, dynamic> json) =>
+      _$StageTalkListItemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageTalkListItemToJson(this);
+}

--- a/lib/domain/entity/stage_talk_list_item.g.dart
+++ b/lib/domain/entity/stage_talk_list_item.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_talk_list_item.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageTalkListItem _$StageTalkListItemFromJson(Map<String, dynamic> json) =>
+    StageTalkListItem(
+      content: json['content'] as String,
+      sender: ChatUserListItem.fromJson(json['sender'] as Map<String, dynamic>),
+      createdAt: json['createdAt'] as String,
+    )..messageId = json['messageId'] as String;
+
+Map<String, dynamic> _$StageTalkListItemToJson(StageTalkListItem instance) =>
+    <String, dynamic>{
+      'messageId': instance.messageId,
+      'content': instance.content,
+      'createdAt': instance.createdAt,
+      'sender': instance.sender,
+    };

--- a/lib/domain/provider/stage_talk_provider.dart
+++ b/lib/domain/provider/stage_talk_provider.dart
@@ -1,0 +1,8 @@
+import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/request/stage_talk_message_request.dart';
+import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+
+abstract class StageTalkProvider {
+  Future<BaseResponse<StageTalkMessageResponse>> getTalkMessages(
+      StageTalkMessageRequest request);
+}

--- a/lib/ui/widget/stage/stage_live_chat_list.widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_list.widget.dart
@@ -1,65 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+import 'package:pocket_pose/data/entity/request/stage_talk_message_request.dart';
+import 'package:pocket_pose/data/remote/provider/stage_talk_provider_impl.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
 import 'package:pocket_pose/ui/widget/stage/talk_list_item_widget.dart';
-
-final talkListString = {
-  "page": 0,
-  "size": 5,
-  "messeges": [
-    {
-      "messageId": "1",
-      "content": "야~~",
-      "sender": {
-        "userId": "22",
-        "profileImg": "assets/images/chat_user_2.png",
-        "nickname": "pochako"
-      },
-      "createdAt": "2023-07-23 11:58:20.551705"
-    },
-    {
-      "messageId": "2",
-      "content": "우와~~",
-      "sender": {
-        "userId": "22",
-        "profileImg": "assets/images/chat_user_2.png",
-        "nickname": "pochako"
-      },
-      "createdAt": "2023-07-23 11:58:20.551705"
-    },
-    {
-      "messageId": "3",
-      "content": "야~~",
-      "sender": {
-        "userId": "22",
-        "profileImg": "assets/images/chat_user_2.png",
-        "nickname": "pochako"
-      },
-      "createdAt": "2023-07-23 11:58:20.551705"
-    },
-    {
-      "messageId": "4",
-      "content": "멋지다아~~",
-      "sender": {
-        "userId": "22",
-        "profileImg": "assets/images/chat_user_2.png",
-        "nickname": "pochako"
-      },
-      "createdAt": "2023-07-23 11:58:20.551705"
-    },
-    {
-      "messageId": "5",
-      "content": "굿~~",
-      "sender": {
-        "userId": "22",
-        // "profileImg": "assets/images/chat_user_2.png",
-        "nickname": "pochako"
-      },
-      "createdAt": "2023-07-23 11:58:20.551705"
-    },
-  ]
-};
 
 class StageLiveChatListWidget extends StatefulWidget {
   const StageLiveChatListWidget({super.key});
@@ -72,17 +16,19 @@ class StageLiveChatListWidget extends StatefulWidget {
 class _StageLiveChatListWidgetState extends State<StageLiveChatListWidget> {
   List<StageTalkListItem> _messageList = [];
   final ScrollController _scrollController = ScrollController();
+  final _provider = StageTalkProviderImpl();
 
   @override
   void initState() {
     super.initState();
+    getTalkMessage();
+  }
 
-    //이전 채팅 목록 가져오기
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        var talkListJson = StageTalkMessageResponse.fromJson(talkListString);
-        _messageList = talkListJson.messeges;
-      });
+  void getTalkMessage() async {
+    var result = await _provider
+        .getTalkMessages(StageTalkMessageRequest(page: 0, size: 3));
+    setState(() {
+      _messageList = result.data.messages ?? [];
     });
   }
 

--- a/lib/ui/widget/stage/stage_live_chat_list.widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_list.widget.dart
@@ -1,5 +1,65 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
+import 'package:pocket_pose/ui/widget/stage/talk_list_item_widget.dart';
+
+final talkListString = {
+  "page": 0,
+  "size": 5,
+  "messeges": [
+    {
+      "messageId": "1",
+      "content": "야~~",
+      "sender": {
+        "userId": "22",
+        "profileImg": "assets/images/chat_user_2.png",
+        "nickname": "pochako"
+      },
+      "createdAt": "2023-07-23 11:58:20.551705"
+    },
+    {
+      "messageId": "2",
+      "content": "우와~~",
+      "sender": {
+        "userId": "22",
+        "profileImg": "assets/images/chat_user_2.png",
+        "nickname": "pochako"
+      },
+      "createdAt": "2023-07-23 11:58:20.551705"
+    },
+    {
+      "messageId": "3",
+      "content": "야~~",
+      "sender": {
+        "userId": "22",
+        "profileImg": "assets/images/chat_user_2.png",
+        "nickname": "pochako"
+      },
+      "createdAt": "2023-07-23 11:58:20.551705"
+    },
+    {
+      "messageId": "4",
+      "content": "멋지다아~~",
+      "sender": {
+        "userId": "22",
+        "profileImg": "assets/images/chat_user_2.png",
+        "nickname": "pochako"
+      },
+      "createdAt": "2023-07-23 11:58:20.551705"
+    },
+    {
+      "messageId": "5",
+      "content": "굿~~",
+      "sender": {
+        "userId": "22",
+        // "profileImg": "assets/images/chat_user_2.png",
+        "nickname": "pochako"
+      },
+      "createdAt": "2023-07-23 11:58:20.551705"
+    },
+  ]
+};
 
 class StageLiveChatListWidget extends StatefulWidget {
   const StageLiveChatListWidget({super.key});
@@ -10,7 +70,7 @@ class StageLiveChatListWidget extends StatefulWidget {
 }
 
 class _StageLiveChatListWidgetState extends State<StageLiveChatListWidget> {
-  final List<String> _messageList = [];
+  List<StageTalkListItem> _messageList = [];
   final ScrollController _scrollController = ScrollController();
 
   @override
@@ -20,7 +80,8 @@ class _StageLiveChatListWidgetState extends State<StageLiveChatListWidget> {
     //이전 채팅 목록 가져오기
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {
-        _messageList.addAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', '1', '2', '3']);
+        var talkListJson = StageTalkMessageResponse.fromJson(talkListString);
+        _messageList = talkListJson.messeges;
       });
     });
   }
@@ -48,7 +109,7 @@ class _StageLiveChatListWidgetState extends State<StageLiveChatListWidget> {
     return _buildStageChatList(_messageList);
   }
 
-  SingleChildScrollView _buildStageChatList(List<String> entries) {
+  SingleChildScrollView _buildStageChatList(List<StageTalkListItem> entries) {
     return SingleChildScrollView(
       child: Container(
         decoration: BoxDecoration(
@@ -80,37 +141,7 @@ class _StageLiveChatListWidgetState extends State<StageLiveChatListWidget> {
                 return const SizedBox(height: 12);
               },
               itemBuilder: (BuildContext context, int index) {
-                return Row(
-                  children: [
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(50),
-                      child: Image.asset(
-                        'assets/images/home_profile_1.jpg',
-                        width: 35,
-                        height: 35,
-                      ),
-                    ),
-                    const SizedBox(
-                      width: 12,
-                    ),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'nickname ${entries[index]}',
-                          style: const TextStyle(color: Colors.white),
-                        ),
-                        const SizedBox(
-                          height: 4,
-                        ),
-                        Text(
-                          'content ${entries[index]}',
-                          style: const TextStyle(color: Colors.white),
-                        )
-                      ],
-                    )
-                  ],
-                );
+                return TalkListItemWidget(talk: entries[index]);
               }),
         ),
       ),

--- a/lib/ui/widget/stage/talk_list_item_widget.dart
+++ b/lib/ui/widget/stage/talk_list_item_widget.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
+
+class TalkListItemWidget extends StatelessWidget {
+  final StageTalkListItem talk;
+
+  const TalkListItemWidget({super.key, required this.talk});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(50),
+          child: Image.asset(
+            (talk.sender.profileImg == null)
+                ? 'assets/images/charactor_popo_default.png'
+                : talk.sender.profileImg!,
+            width: 35,
+            height: 35,
+          ),
+        ),
+        const SizedBox(
+          width: 12,
+        ),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              talk.sender.nickname,
+              style: const TextStyle(color: Colors.white),
+            ),
+            const SizedBox(
+              height: 4,
+            ),
+            Text(
+              talk.content,
+              style: const TextStyle(color: Colors.white),
+            )
+          ],
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/213fdb82-5d3d-4c56-845d-7a35d385b8d9" width="200">

## 💬 작업 설명
- base response를 사용해 스테이지 채팅 목록을 조회하는 api를 연결하였습니다!!

## ✅ 한 일
1. 스테이지 채팅 목록 조회 api 연결

## 😥 어려웠던점
1. base response를 사용하는 법이 여러가지더라구요,, 당근 때도 시도해보다가 말았는데 이번에 다시 도전해봤습니다! 잘 됩니다아...ㅎㅎ (+이번엔 오류코드를 백에서 지정해서 쓸 일이 있을 거 같아 base response로 오류코드, 메시지까지 받도록 해보았습니다)

## ☝️ 참고 하세요~
1. [base response](https://gist.github.com/thanhniencung/7c2b9f3d24bf80d964ec7f8157050ebc) 이 코드 참고하여 base response 구현했습니다.

## 🤓 다음에 할 일
1. 업로드 api 연결
2. 스테이지 Talk 소켓 연결
