### PR TITLE
[feat] 영상 업로드 api 연결 (HH-276)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -6,6 +6,7 @@ class AppUrl {
 
   static const _stageUrl = "$_apiBaseUrl/stages";
   static const _talkUrl = "$_apiBaseUrl/talks";
+  static const videoUrl = "$_apiBaseUrl/videos";
 
   // 로그인 & 회원가입
   static const signInSignUpUrl = "$_apiBaseUrl/auth/login?type=kakao";

--- a/lib/data/entity/request/video_upload_request.dart
+++ b/lib/data/entity/request/video_upload_request.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'video_upload_request.g.dart';
+
+@JsonSerializable()
+class VideoUploadResuest {
+  String title;
+  String tags;
+
+  VideoUploadResuest({
+    required this.title,
+    required this.tags,
+  });
+
+  factory VideoUploadResuest.fromJson(Map<String, dynamic> json) =>
+      _$VideoUploadResuestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VideoUploadResuestToJson(this);
+}

--- a/lib/data/entity/request/video_upload_request.dart
+++ b/lib/data/entity/request/video_upload_request.dart
@@ -3,17 +3,19 @@ import 'package:json_annotation/json_annotation.dart';
 part 'video_upload_request.g.dart';
 
 @JsonSerializable()
-class VideoUploadResuest {
+class VideoUploadRequest {
   String title;
   String tags;
+  String videoPath;
 
-  VideoUploadResuest({
+  VideoUploadRequest({
     required this.title,
     required this.tags,
+    required this.videoPath,
   });
 
-  factory VideoUploadResuest.fromJson(Map<String, dynamic> json) =>
-      _$VideoUploadResuestFromJson(json);
+  factory VideoUploadRequest.fromJson(Map<String, dynamic> json) =>
+      _$VideoUploadRequestFromJson(json);
 
-  Map<String, dynamic> toJson() => _$VideoUploadResuestToJson(this);
+  Map<String, dynamic> toJson() => _$VideoUploadRequestToJson(this);
 }

--- a/lib/data/entity/request/video_upload_request.g.dart
+++ b/lib/data/entity/request/video_upload_request.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'video_upload_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VideoUploadResuest _$VideoUploadResuestFromJson(Map<String, dynamic> json) =>
+    VideoUploadResuest(
+      title: json['title'] as String,
+      tags: json['tags'] as String,
+    );
+
+Map<String, dynamic> _$VideoUploadResuestToJson(VideoUploadResuest instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'tags': instance.tags,
+    };

--- a/lib/data/entity/request/video_upload_request.g.dart
+++ b/lib/data/entity/request/video_upload_request.g.dart
@@ -6,14 +6,16 @@ part of 'video_upload_request.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-VideoUploadResuest _$VideoUploadResuestFromJson(Map<String, dynamic> json) =>
-    VideoUploadResuest(
+VideoUploadRequest _$VideoUploadRequestFromJson(Map<String, dynamic> json) =>
+    VideoUploadRequest(
       title: json['title'] as String,
       tags: json['tags'] as String,
+      videoPath: json['videoPath'] as String,
     );
 
-Map<String, dynamic> _$VideoUploadResuestToJson(VideoUploadResuest instance) =>
+Map<String, dynamic> _$VideoUploadRequestToJson(VideoUploadRequest instance) =>
     <String, dynamic>{
       'title': instance.title,
       'tags': instance.tags,
+      'videoPath': instance.videoPath,
     };

--- a/lib/data/entity/response/video_upload_response.dart
+++ b/lib/data/entity/response/video_upload_response.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+
+part 'video_upload_response.g.dart';
+
+@JsonSerializable()
+class VideoUploadResponse extends BaseObject<VideoUploadResponse> {
+  String uuid;
+
+  VideoUploadResponse({
+    required this.uuid,
+  });
+
+  factory VideoUploadResponse.fromJson(Map<String, dynamic> json) =>
+      _$VideoUploadResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$VideoUploadResponseToJson(this);
+
+  @override
+  VideoUploadResponse fromJson(json) {
+    return VideoUploadResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/response/video_upload_response.g.dart
+++ b/lib/data/entity/response/video_upload_response.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'video_upload_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+VideoUploadResponse _$VideoUploadResponseFromJson(Map<String, dynamic> json) =>
+    VideoUploadResponse(
+      uuid: json['uuid'] as String,
+    );
+
+Map<String, dynamic> _$VideoUploadResponseToJson(
+        VideoUploadResponse instance) =>
+    <String, dynamic>{
+      'uuid': instance.uuid,
+    };

--- a/lib/data/remote/provider/stage_talk_provider_impl.dart
+++ b/lib/data/remote/provider/stage_talk_provider_impl.dart
@@ -21,14 +21,12 @@ class StageTalkProviderImpl implements StageTalkProvider {
 
     var dio = Dio();
     try {
-      print("mmmm response: mmmmm");
       dio.options.headers = {
         "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
       };
       dio.options.contentType = "application/json";
       var response = await dio.get(
           '${AppUrl.stageTalkUrl}?page=${request.page}&size=${request.size}');
-      print("mmmm response: ${response.data['data']}");
 
       return BaseResponse<StageTalkMessageResponse>.fromJson(response.data,
           StageTalkMessageResponse.fromJson(response.data['data']));

--- a/lib/data/remote/provider/video_upload_provider_impl.dart
+++ b/lib/data/remote/provider/video_upload_provider_impl.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pocket_pose/config/api_url.dart';
+import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/request/video_upload_request.dart';
+import 'package:pocket_pose/data/entity/response/video_upload_response.dart';
+import 'package:pocket_pose/domain/provider/video_upload_provider.dart';
+
+class VideoUploadProviderImpl implements VideoUploadProvider {
+  @override
+  Future<BaseResponse<VideoUploadResponse>> postVideoUpload(
+      VideoUploadRequest request) async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    const refreshTokenKey = 'kakaoRefreshToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+
+    var dio = Dio();
+    try {
+      dio.options.headers = {
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+      };
+      dio.options.contentType = "application/json";
+      FormData formData = FormData.fromMap({
+        "video": await MultipartFile.fromFile(request.videoPath),
+      });
+      var response = await dio.post(
+          '${AppUrl.videoUrl}?title=${request.title}&tag=${request.tags}',
+          data: formData);
+
+      return BaseResponse<VideoUploadResponse>.fromJson(
+          response.data, VideoUploadResponse.fromJson(response.data['data']));
+    } catch (e) {
+      debugPrint("mmm VideoUploadProviderImpl catch: ${e.toString()}");
+    }
+    return throw UnimplementedError();
+  }
+}

--- a/lib/domain/provider/video_upload_provider.dart
+++ b/lib/domain/provider/video_upload_provider.dart
@@ -1,0 +1,8 @@
+import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/request/video_upload_request.dart';
+import 'package:pocket_pose/data/entity/response/video_upload_response.dart';
+
+abstract class VideoUploadProvider {
+  Future<BaseResponse<VideoUploadResponse>> postVideoUpload(
+      VideoUploadRequest request);
+}

--- a/lib/ui/screen/upload_screen.dart
+++ b/lib/ui/screen/upload_screen.dart
@@ -1,8 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/entity/request/video_upload_request.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/data/remote/provider/video_upload_provider_impl.dart';
 import 'package:pocket_pose/ui/widget/upload/custom_tag_text_field_controller.dart';
 import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
 import 'package:provider/provider.dart';
@@ -21,8 +24,10 @@ class _UploadScreenState extends State<UploadScreen> {
   VideoPlayerController? _videoPlayerController;
   late VideoPlayProvider _videoPlayProvider;
   late CustomTagTextFieldController _tagController;
+  final _provider = VideoUploadProviderImpl();
   bool _isTitleFillOut = false;
   bool _isTagsFillOut = false;
+  bool _isLoading = false;
 
   @override
   void initState() {
@@ -51,6 +56,22 @@ class _UploadScreenState extends State<UploadScreen> {
     }
   }
 
+  void postVideo(VideoUploadRequest request) async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    FocusScope.of(context).unfocus();
+
+    await _provider.postVideoUpload(request).then((value) {
+      if (value.code == 'VIDEO-2001') {
+        Fluttertoast.showToast(msg: '영상이 성공적으로 업로드 되었습니다.');
+        _isLoading = false;
+        Navigator.pop(context);
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -71,6 +92,26 @@ class _UploadScreenState extends State<UploadScreen> {
               padding: EdgeInsets.only(
                   bottom: MediaQuery.of(context).viewInsets.bottom),
               child: _buildVideoInfoArea(),
+            ),
+            Visibility(
+              visible: _isLoading,
+              child: const ModalBarrier(
+                color: Colors.black54,
+                dismissible: false,
+              ),
+            ),
+            Visibility(
+              visible: _isLoading,
+              child: const Positioned(
+                left: 0,
+                top: 0,
+                bottom: 0,
+                right: 0,
+                child: SizedBox(
+                    width: 50,
+                    height: 50,
+                    child: Center(child: CircularProgressIndicator())),
+              ),
             ),
           ],
         ),
@@ -198,8 +239,19 @@ class _UploadScreenState extends State<UploadScreen> {
       actions: [
         TextButton(
           onPressed: () {
-            // var title = _titleTextController.value.text;
-            // var tags = _tagController.getTags;
+            if (_isTitleFillOut && _isTagsFillOut) {
+              var title = _titleTextController.value.text;
+              var tags = _tagController.getTags!;
+              var tagsString = tags.map((tag) => '%23$tag').toList().join(' ');
+              if (_isLoading == false) {
+                postVideo(VideoUploadRequest(
+                    title: title,
+                    tags: tagsString,
+                    videoPath: widget.uploadFile.path));
+              } else {
+                Fluttertoast.showToast(msg: '영상을 업로드 중입니다.');
+              }
+            }
           },
           child: Text(
             "업로드",


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/3ae7a57d-e7aa-4497-8dc2-235020e0f5ab

## 💬 작업 설명
- 영상 업로드 api를 연결했습니다.
- 영상 업로드 요청 시작하고 응답하기까지 시간이 오래 걸립니다..! (10초정도 소요)
- 영상 업로드 버튼 누를 때: 로딩 화면 출력
- 업로드 버튼 누른 후 다시 영상 업로드 버튼을 누를 때: `영상을 업로드 중입니다.`라는 토스트 출력
- 영상 업로드 완료: `영상이 성공적으로 업로드 되었습니다.`라는 토스트 출력 후 뒤로가기

## ✅ 한 일
1. 영상 업로드 api 연결

## ☝️ 참고 하세요~
1. 영상 업로드 시 확장자가 .mp4가 아닌 영상을 업로드하면 500에러가 뜹니다!

## 🤓 다음에 할 일
1. 스테이지 Talk 웹 소켓 연결 시작