### PR TITLE
[feat] 스테이지 사용자 목록 api 연결 (HH-281)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -4,7 +4,7 @@ class AppUrl {
   // 인공지능 서버
   static const _aiBaseUrl = "http://43.200.133.86:5000";
 
-  static const _stageUrl = "$_apiBaseUrl/stages";
+  static const _stageUrl = "$_apiBaseUrl/stage";
   static const _talkUrl = "$_apiBaseUrl/talks";
   static const videoUrl = "$_apiBaseUrl/videos";
 
@@ -13,6 +13,7 @@ class AppUrl {
 
   // 포포 스테이지
   static const stageAccuracyUrl = "$_stageUrl/similarity";
+  static const stageUserListUrl = "$_stageUrl/users";
   static const stageTalkUrl = "$_talkUrl/messages";
 
   // 스켈레톤 정확도 확인

--- a/lib/data/entity/response/stage_user_list_response.dart
+++ b/lib/data/entity/response/stage_user_list_response.dart
@@ -1,18 +1,24 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
 import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
 
 part 'stage_user_list_response.g.dart';
 
 @JsonSerializable()
-class StageUserListResponse {
+class StageUserListResponse extends BaseObject<StageUserListResponse> {
   List<StageUserListItem>? list;
 
-  StageUserListResponse({
-    required this.list,
-  });
-
-  factory StageUserListResponse.fromJson(Map<String, dynamic> json) =>
-      _$StageUserListResponseFromJson(json);
+  StageUserListResponse(
+    this.list,
+  );
+  factory StageUserListResponse.fromJson(List<dynamic> json) =>
+      StageUserListResponse(
+          json.map((e) => StageUserListItem.fromJson(e)).toList());
 
   Map<String, dynamic> toJson() => _$StageUserListResponseToJson(this);
+
+  @override
+  StageUserListResponse fromJson(json) {
+    return StageUserListResponse.fromJson(json);
+  }
 }

--- a/lib/data/entity/response/stage_user_list_response.g.dart
+++ b/lib/data/entity/response/stage_user_list_response.g.dart
@@ -9,7 +9,7 @@ part of 'stage_user_list_response.dart';
 StageUserListResponse _$StageUserListResponseFromJson(
         Map<String, dynamic> json) =>
     StageUserListResponse(
-      list: (json['list'] as List<dynamic>?)
+      (json['list'] as List<dynamic>?)
           ?.map((e) => StageUserListItem.fromJson(e as Map<String, dynamic>))
           .toList(),
     );

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pocket_pose/config/api_url.dart';
+import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
+import 'package:pocket_pose/domain/provider/stage_provider.dart';
+
+class StageProviderImpl implements StageProvider {
+  @override
+  Future<BaseResponse<StageUserListResponse>> getUserList() async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    const refreshTokenKey = 'kakaoRefreshToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+
+    var dio = Dio();
+    try {
+      dio.options.headers = {
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+      };
+      dio.options.contentType = "application/json";
+      var response = await dio.get(AppUrl.stageUserListUrl);
+
+      print('mmm resp: ${response.data}');
+
+      return BaseResponse<StageUserListResponse>.fromJson(
+          response.data, StageUserListResponse.fromJson(response.data['data']));
+    } catch (e) {
+      debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
+    }
+    return throw UnimplementedError();
+  }
+}

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -25,8 +25,6 @@ class StageProviderImpl implements StageProvider {
       dio.options.contentType = "application/json";
       var response = await dio.get(AppUrl.stageUserListUrl);
 
-      print('mmm resp: ${response.data}');
-
       return BaseResponse<StageUserListResponse>.fromJson(
           response.data, StageUserListResponse.fromJson(response.data['data']));
     } catch (e) {

--- a/lib/domain/entity/stage_user_list_item.dart
+++ b/lib/domain/entity/stage_user_list_item.dart
@@ -1,18 +1,23 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
 
 part 'stage_user_list_item.g.dart';
 
 @JsonSerializable()
-class StageUserListItem {
+class StageUserListItem extends BaseObject<StageUserListItem> {
   String userId = "";
   String nickname = "";
   String? profileImg;
 
-  StageUserListItem(
-      {required this.userId, required this.nickname, this.profileImg});
+  StageUserListItem(this.userId, this.nickname, this.profileImg);
 
   factory StageUserListItem.fromJson(Map<String, dynamic> json) =>
-      _$StageUserListItemFromJson(json);
+      StageUserListItem(json['userId'], json['nickname'], json['profileImg']);
 
   Map<String, dynamic> toJson() => _$StageUserListItemToJson(this);
+
+  @override
+  StageUserListItem fromJson(json) {
+    return StageUserListItem.fromJson(json);
+  }
 }

--- a/lib/domain/entity/stage_user_list_item.g.dart
+++ b/lib/domain/entity/stage_user_list_item.g.dart
@@ -8,9 +8,9 @@ part of 'stage_user_list_item.dart';
 
 StageUserListItem _$StageUserListItemFromJson(Map<String, dynamic> json) =>
     StageUserListItem(
-      userId: json['userId'] as String,
-      nickname: json['nickname'] as String,
-      profileImg: json['profileImg'] as String?,
+      json['userId'] as String,
+      json['nickname'] as String,
+      json['profileImg'] as String?,
     );
 
 Map<String, dynamic> _$StageUserListItemToJson(StageUserListItem instance) =>

--- a/lib/domain/provider/stage_provider.dart
+++ b/lib/domain/provider/stage_provider.dart
@@ -1,0 +1,6 @@
+import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
+
+abstract class StageProvider {
+  Future<BaseResponse<StageUserListResponse>> getUserList();
+}

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -199,84 +199,85 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
           return BackdropFilter(
             filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
             child: AlertDialog(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10.0),
-                side: const BorderSide(
-                  color: Colors.white,
-                  width: 1.0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10.0),
+                  side: const BorderSide(
+                    color: Colors.white,
+                    width: 1.0,
+                  ),
                 ),
-              ),
-              backgroundColor: Colors.white.withOpacity(0.3),
-              title: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Expanded(child: Container()),
-                  const Padding(
-                    padding: EdgeInsets.only(left: 20),
-                    child: Text(
-                      '참여자 목록',
-                      style: TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
+                backgroundColor: Colors.white.withOpacity(0.3),
+                title: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Expanded(child: Container()),
+                    const Padding(
+                      padding: EdgeInsets.only(left: 20),
+                      child: Text(
+                        '참여자 목록',
+                        style: TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    Expanded(child: Container()),
+                    GestureDetector(
+                      onTap: () {
+                        Navigator.of(context).pop();
+                      },
+                      child: const Icon(
+                        Icons.close,
+                        size: 20,
                         color: Colors.white,
                       ),
-                      textAlign: TextAlign.center,
                     ),
-                  ),
-                  Expanded(child: Container()),
-                  GestureDetector(
-                    onTap: () {
-                      Navigator.of(context).pop();
-                    },
-                    child: const Icon(
-                      Icons.close,
-                      size: 20,
-                      color: Colors.white,
-                    ),
-                  ),
-                ],
-              ),
-              content: SizedBox(
-                width: 265,
-                height: 365,
-                child: GridView.builder(
-                  itemCount: userList.length,
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3,
-                  ),
-                  itemBuilder: (BuildContext context, int index) {
-                    return Column(
-                      children: [
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(50),
-                          child: (userList.elementAt(index).profileImg == null)
-                              ? Image.asset(
-                                  'assets/images/charactor_popo_default.png',
-                                  width: 58,
-                                  height: 58,
-                                )
-                              : Image.network(
-                                  userList.elementAt(index).profileImg!,
-                                  fit: BoxFit.cover,
-                                  width: 58,
-                                  height: 58,
-                                ),
-                        ),
-                        const SizedBox(
-                          height: 4,
-                        ),
-                        Text(
-                          userList.elementAt(index).nickname,
-                          style: const TextStyle(
-                            fontSize: 12,
-                          ),
-                        ),
-                      ],
-                    );
-                  },
+                  ],
                 ),
-              ),
-            ),
+                content: SizedBox(
+                  width: 265,
+                  height: 365,
+                  child: GridView.builder(
+                    itemCount: userList.length,
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 3,
+                    ),
+                    itemBuilder: (BuildContext context, int index) {
+                      return Column(
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(50),
+                            child:
+                                (userList.elementAt(index).profileImg == null)
+                                    ? Image.asset(
+                                        'assets/images/charactor_popo_default.png',
+                                        width: 58,
+                                        height: 58,
+                                      )
+                                    : Image.network(
+                                        userList.elementAt(index).profileImg!,
+                                        fit: BoxFit.cover,
+                                        width: 58,
+                                        height: 58,
+                                      ),
+                          ),
+                          const SizedBox(
+                            height: 4,
+                          ),
+                          Text(
+                            userList.elementAt(index).nickname,
+                            style: const TextStyle(
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                )),
           );
         });
   }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -3,8 +3,10 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
-import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
+import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
+import 'package:pocket_pose/domain/provider/stage_provider.dart';
 import 'package:pocket_pose/ui/view/popo_play_view.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_result_view.dart';
@@ -12,77 +14,6 @@ import 'package:pocket_pose/ui/view/popo_wait_view.dart';
 import 'package:pocket_pose/ui/widget/stage/stage_live_chat_bar_widget.dart';
 import 'package:pocket_pose/ui/widget/stage/stage_live_chat_list.widget.dart';
 import 'package:provider/provider.dart';
-
-final userListItem = {
-  "list": [
-    {
-      "userId": "1",
-      "profileImg": "assets/images/home_profile_1.jpg",
-      "nickname": "나비"
-    },
-    {
-      "userId": "2",
-      "profileImg": "assets/images/home_profile_2.jpg",
-      "nickname": "고양이"
-    },
-    {
-      "userId": "3",
-      "profileImg": "assets/images/home_profile_3.jpg",
-      "nickname": "네코"
-    },
-    {
-      "userId": "4",
-      "profileImg": "assets/images/home_profile_4.jpg",
-      "nickname": "냥코"
-    },
-    {
-      "userId": "5",
-      "profileImg": "assets/images/home_profile_5.jpg",
-      "nickname": "멍멍이"
-    },
-    {
-      "userId": "6",
-      "profileImg": "assets/images/home_profile_1.jpg",
-      "nickname": "강아지"
-    },
-    {
-      "userId": "7",
-      "profileImg": "assets/images/home_profile_2.jpg",
-      "nickname": "개"
-    },
-    {
-      "userId": "8",
-      "profileImg": "assets/images/home_profile_3.jpg",
-      "nickname": "포챠코"
-    },
-    {
-      "userId": "9",
-      "profileImg": "assets/images/home_profile_4.jpg",
-      "nickname": "왕왕이"
-    },
-    {
-      "userId": "10",
-      "profileImg": "assets/images/home_profile_5.jpg",
-      "nickname": "컹컹이"
-    },
-    {
-      "userId": "11",
-      "profileImg": "assets/images/home_profile_1.jpg",
-      "nickname": "왈왈이"
-    },
-    {
-      "userId": "12",
-      "profileImg": "assets/images/home_profile_2.jpg",
-      "nickname": "바둑이"
-    },
-    {
-      "userId": "13",
-      "profileImg": "assets/images/home_profile_3.jpg",
-      "nickname": "마리"
-    },
-  ]
-};
-StageUserListResponse? userList;
 
 enum StageStage { waitState, catchState, playState, resultState }
 
@@ -99,6 +30,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   int _count = 1;
   late Timer _timer;
   late VideoPlayProvider _videoPlayProvider;
+  final StageProvider _stageProvider = StageProviderImpl();
   StageStage _stageStage = StageStage.waitState;
 
   @override
@@ -233,8 +165,11 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     return Container(
       margin: const EdgeInsets.only(right: 16.0, top: 10.0, bottom: 10.0),
       child: OutlinedButton.icon(
-        onPressed: () {
-          _showUserListDialog();
+        onPressed: () async {
+          var response = await _stageProvider.getUserList();
+          print("mmm rrrr: ${response.data}");
+
+          _showUserListDialog(response.data.list ?? []);
         },
         style: OutlinedButton.styleFrom(
           shape: RoundedRectangleBorder(
@@ -256,9 +191,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     );
   }
 
-  Future<dynamic> _showUserListDialog() {
-    userList = StageUserListResponse.fromJson(userListItem);
-
+  Future<dynamic> _showUserListDialog(List<StageUserListItem> userList) {
     return showDialog(
         context: context,
         barrierColor: Colors.transparent,
@@ -275,7 +208,9 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
               ),
               backgroundColor: Colors.white.withOpacity(0.3),
               title: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
+                  Expanded(child: Container()),
                   const Padding(
                     padding: EdgeInsets.only(left: 20),
                     child: Text(
@@ -288,6 +223,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                       textAlign: TextAlign.center,
                     ),
                   ),
+                  Expanded(child: Container()),
                   GestureDetector(
                     onTap: () {
                       Navigator.of(context).pop();
@@ -304,7 +240,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 width: 265,
                 height: 365,
                 child: GridView.builder(
-                  itemCount: userList!.list!.length,
+                  itemCount: userList.length,
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 3,
                   ),
@@ -313,18 +249,24 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                       children: [
                         ClipRRect(
                           borderRadius: BorderRadius.circular(50),
-                          child: Image.asset(
-                            userList!.list!.elementAt(index).profileImg!,
-                            width: 58,
-                            height: 58,
-                            fit: BoxFit.cover,
-                          ),
+                          child: (userList.elementAt(index).profileImg == null)
+                              ? Image.asset(
+                                  'assets/images/charactor_popo_default.png',
+                                  width: 58,
+                                  height: 58,
+                                )
+                              : Image.network(
+                                  userList.elementAt(index).profileImg!,
+                                  fit: BoxFit.cover,
+                                  width: 58,
+                                  height: 58,
+                                ),
                         ),
                         const SizedBox(
                           height: 4,
                         ),
                         Text(
-                          userList!.list!.elementAt(index).nickname,
+                          userList.elementAt(index).nickname,
                           style: const TextStyle(
                             fontSize: 12,
                           ),

--- a/lib/ui/widget/stage/talk_list_item_widget.dart
+++ b/lib/ui/widget/stage/talk_list_item_widget.dart
@@ -12,13 +12,18 @@ class TalkListItemWidget extends StatelessWidget {
       children: [
         ClipRRect(
           borderRadius: BorderRadius.circular(50),
-          child: Image.asset(
-            (talk.sender.profileImg == null)
-                ? 'assets/images/charactor_popo_default.png'
-                : talk.sender.profileImg!,
-            width: 35,
-            height: 35,
-          ),
+          child: (talk.sender.profileImg == null)
+              ? Image.asset(
+                  'assets/images/charactor_popo_default.png',
+                  width: 35,
+                  height: 35,
+                )
+              : Image.network(
+                  talk.sender.profileImg!,
+                  fit: BoxFit.cover,
+                  width: 35,
+                  height: 35,
+                ),
         ),
         const SizedBox(
           width: 12,


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/90643e9c-6fa7-40ed-8ef5-4ca71ef1125b" width="200">

## 💬 작업 설명
- 스테이지의 사용자 숫자 버튼 클릭하면 다이얼로그에 현재 입장해있는 유저의 정보가 나오도록 하였습니다.
- 지금 보이는 5명의 사용자는 백도어로 로그인한 가짜 유저입니다.
- 아직 소켓 연결 전이라 실시간으로 사용자 숫자가 달라지진 않습니다.

## ✅ 한 일
1. 스테이지 사용자 목록 api 연결

## 😥 어려웠던점
1. 그동안 json 파싱할 때 key가 있는 값을 받아왔는데, 이번 데이터는 key가 없는 데이터였습니다. (Map<String, dynamic>이 아닌 List<T>를 받아옴.) 이런 json을 처음 파싱해봐서 어려움을 많이 겪었습니다.😢 아래 포스트 보고 겨우 완성했습니다
    - [How to parse JSON without key in flutter](https://stackoverflow.com/questions/56917114/how-to-parse-json-without-key-in-flutter) 

## 🤓 다음에 할 일
1. 소켓 연결!!(연결 > 구독 > 메시지, 반응 보내기 > ...)
