### PR TITLE
[feat] 스테이지 소켓 연결, 구독 api 연결 및 대기>캐치>플레이>결과 루틴 반복 (HH-280)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -3,6 +3,8 @@ class AppUrl {
   static const _apiBaseUrl = "http://3.37.178.56:8080/api/v1";
   // 인공지능 서버
   static const _aiBaseUrl = "http://43.200.133.86:5000";
+  // web socket 서버
+  static const webSocketUrl = "ws://3.37.178.56:8080/ws-popo";
 
   static const _stageUrl = "$_apiBaseUrl/stage";
   static const _talkUrl = "$_apiBaseUrl/talks";
@@ -18,4 +20,7 @@ class AppUrl {
 
   // 스켈레톤 정확도 확인
   static const skeletonAccuracyUrl = "$_aiBaseUrl/api/similarity/test";
+
+  // web socket
+  static const subscribeStageUrl = "/topic/stage";
 }

--- a/lib/data/entity/base_socket_response.dart
+++ b/lib/data/entity/base_socket_response.dart
@@ -1,0 +1,27 @@
+import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
+
+class BaseSocketResponse<T> {
+  String timeStamp;
+  StageType type;
+  String message;
+  // T? data;
+
+  BaseSocketResponse({
+    required this.timeStamp,
+    required this.type,
+    required this.message,
+    // this.data
+  });
+
+  factory BaseSocketResponse.fromJson(
+    Map<String, dynamic> json,
+    // BaseObject target
+  ) {
+    return BaseSocketResponse(
+      timeStamp: json['timeStamp'],
+      type: StageType.values.byName(json['type'].toString()),
+      message: json['message'],
+      // data: target.fromJson(json['data']),
+    );
+  }
+}

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -1,7 +1,9 @@
 import 'package:animated_bottom_navigation_bar/animated_bottom_navigation_bar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/auth_provider.dart';
@@ -58,9 +60,26 @@ class _MainScreenState extends State<MainScreen> {
     }
   }
 
-  void _onFloatingButtonClicked() {
-    _videoPlayProvider.pauseVideo();
+  void _onFloatingButtonClicked() async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    if (accessToken != "") {
+      _videoPlayProvider.pauseVideo();
+      _showPoPoStageScreen();
+    } else {
+      Fluttertoast.showToast(
+        msg: "로그인 해주세요.",
+        toastLength: Toast.LENGTH_SHORT,
+        timeInSecForIosWeb: 1,
+        backgroundColor: Colors.black,
+        textColor: Colors.white,
+        fontSize: 16.0,
+      );
+    }
+  }
 
+  void _showPoPoStageScreen() {
     Navigator.push(
       context,
       MaterialPageRoute(

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -100,41 +100,25 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     const storage = FlutterSecureStorage();
     const storageKey = 'kakaoAccessToken';
     String token = await storage.read(key: storageKey) ?? "";
-    print("mmm key: $token");
 
     stompClient = StompClient(
-      config: StompConfig(
-        url: AppUrl.webSocketUrl,
-        onConnect: (frame) {
-          _onConnect(frame, token);
-        },
-        stompConnectHeaders: {'x-access-token': token},
-        webSocketConnectHeaders: {'x-access-token': token},
-        onWebSocketError: (e) => print("mmm: $e"),
-        onStompError: (d) => print('mmm error stomp ${d.body}'),
-        onDisconnect: (f) => print('mmm 포포 퇴장'),
-      ),
-    );
-    stompClient?.activate();
+        config: StompConfig(
+      url: AppUrl.webSocketUrl,
+      onConnect: (frame) {
+        _onConnect(frame, token);
+      },
+      stompConnectHeaders: {'x-access-token': token},
+      webSocketConnectHeaders: {'x-access-token': token},
+    ));
+    stompClient!.activate();
   }
 
   void _onConnect(StompFrame frame, String token) {
-    print("mmm 포포 입장");
-    print("mmm ${frame.headers}");
-    print("mmm ${frame.binaryBody}");
-    print("mmm ${frame.body}");
-    print("mmm ${frame.command}");
-    print("mmm ${frame.hashCode}");
-
-    stompClient!.subscribe(
-        destination: '/topic/stage',
-        callback: (_) => {print("mmm print...tq")});
     stompClient?.subscribe(
-        destination: '/topic/stage', //AppUrl.subscribeStageUrl,
+        destination: AppUrl.subscribeStageUrl,
         callback: (StompFrame frame) {
-          print("mmm sbbbbb");
           if (frame.body != null) {
-            print("mmm suv");
+            print("mmm socket 구독!!! ${frame.body}");
             setState(() {});
           }
         });
@@ -207,7 +191,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       child: OutlinedButton.icon(
         onPressed: () async {
           var response = await _stageProvider.getUserList();
-          print("mmm rrrr: ${response.data}");
 
           _showUserListDialog(response.data.list ?? []);
         },

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -97,22 +97,22 @@ class _CameraViewState extends State<CameraView> {
     }
 
     // AudioPlayer 초기화
-    AudioPlayerUtil().setPlayerCompletion(widget.setIsSkeletonDetectMode);
-    AudioPlayerUtil().setCameraController(_controller);
+    // AudioPlayerUtil().setPlayerCompletion(widget.setIsSkeletonDetectMode);
+    // AudioPlayerUtil().setCameraController(_controller);
 
     // 결과 상태인 경우
     if (widget.isResultState) {
-      AudioPlayerUtil().play(
-          "https://popo2023.s3.ap-northeast-2.amazonaws.com/effect/Happyhappy.mp3",
-          widget.setIsSkeletonDetectMode);
+      // AudioPlayerUtil().play(
+      //     "https://popo2023.s3.ap-northeast-2.amazonaws.com/effect/Happyhappy.mp3",
+      //     widget.setIsSkeletonDetectMode);
     }
     // 플레이 상태인 경우
     else {
       // 카운트다운 시작 후 노래 재생
-      setState(() {
-        _countdownVisibility = true;
-      });
-      _startTimer();
+      // setState(() {
+      //   _countdownVisibility = true;
+      // });
+      // _startTimer();
     }
   }
 
@@ -146,7 +146,7 @@ class _CameraViewState extends State<CameraView> {
   @override
   void dispose() {
     if (widget.isResultState) {
-      AudioPlayerUtil().stop();
+      // AudioPlayerUtil().stop();
     }
     super.dispose();
   }

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -4,14 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
-import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
 import 'package:semicircle_indicator/semicircle_indicator.dart';
 import 'dart:math' as math;
 
 class PoPoCatchView extends StatefulWidget {
-  const PoPoCatchView({Key? key, required this.setStageState})
-      : super(key: key);
-  final Function setStageState;
+  const PoPoCatchView({Key? key}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _PoPoCatchViewState();
@@ -119,7 +116,6 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
       if (_milliseconds >= 3000) {
         _stopTimer();
         Fluttertoast.showToast(msg: '캐치 성공!');
-        widget.setStageState(StageStage.playState);
       } else {
         if (mounted) {
           setState(() {

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -7,17 +7,13 @@ import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/custom_pose_painter.dart';
 import 'package:pocket_pose/data/remote/provider/popo_skeleton_provider_impl.dart';
-import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
 import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
 
 enum StagePlayScore { bad, good, great, excellent, perfect }
 
 // ml_kit_skeleton_custom_view
 class PoPoPlayView extends StatefulWidget {
-  const PoPoPlayView(
-      {Key? key, required this.setStageState, required this.isResultState})
-      : super(key: key);
-  final Function setStageState;
+  const PoPoPlayView({Key? key, required this.isResultState}) : super(key: key);
   final bool isResultState;
 
   @override
@@ -229,8 +225,7 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
                     textColor: Colors.white,
                     fontSize: 16.0,
                   ))
-              .then((_) => _inputLists.clear())
-              .then((_) => widget.setStageState(StageStage.resultState));
+              .then((_) => _inputLists.clear());
         }
       });
     }

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -3,15 +3,12 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/custom_pose_painter.dart';
-import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
 import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
 
 // ml_kit_skeleton_custom_view
 class PoPoResultView extends StatefulWidget {
-  const PoPoResultView(
-      {Key? key, required this.setStageState, required this.isResultState})
+  const PoPoResultView({Key? key, required this.isResultState})
       : super(key: key);
-  final Function setStageState;
   final bool isResultState;
 
   @override
@@ -177,7 +174,6 @@ class _PoPoResultViewState extends State<PoPoResultView> {
         // 노래 끝나면 대기 화면으로 이동
         if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
           _inputLists.clear();
-          widget.setStageState(StageStage.waitState);
         }
       });
     }

--- a/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:stomp_dart_client/stomp.dart';
 
 class StageLiveChatBarWidget extends StatefulWidget {
-  const StageLiveChatBarWidget({super.key});
+  const StageLiveChatBarWidget({super.key, required this.stompClient});
+  final StompClient? stompClient;
 
   @override
   State<StageLiveChatBarWidget> createState() => _StageLiveChatBarWidgetState();
@@ -42,6 +44,12 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
   @override
   Widget build(BuildContext context) {
     return _buildInputArea(context);
+  }
+
+  _sendMessage() {
+    // widget.stompClient?.send(
+    //     destination: '/app/talks/messages',
+    //     body: json.encode({"content": "test"}));
   }
 
   Widget _buildInputArea(BuildContext context) {
@@ -88,6 +96,7 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
                       border: InputBorder.none,
                     ),
                     textInputAction: TextInputAction.next,
+                    onSubmitted: _sendMessage(),
                   ),
                 ),
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1286,7 +1286,7 @@ packages:
     source: hosted
     version: "1.1.0"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1133,6 +1133,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  stomp_dart_client:
+    dependency: "direct main"
+    description:
+      name: stomp_dart_client
+      sha256: "8779d1383f0a6faa0623af27ab6d4b228ab76c75020d9a83ade5ee204eac5153"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.4"
   stream_channel:
     dependency: transitive
     description:
@@ -1286,7 +1294,7 @@ packages:
     source: hosted
     version: "1.1.0"
   web_socket_channel:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   permission_handler: ^10.4.2
   shared_preferences: ^2.2.0
   flutter_typeahead: ^4.6.2
+  web_socket_channel: ^2.4.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   permission_handler: ^10.4.2
   shared_preferences: ^2.2.0
   flutter_typeahead: ^4.6.2
-  web_socket_channel: ^2.4.0
+  stomp_dart_client: ^0.4.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/ea26bb78-f85e-43d4-9345-e5345189925c

## 💬 작업 설명
- 소켓 연결을 성공했습니다!!!
- 스테이지에 입장한 인원 수가 3명 이상이면 대기>캐치>플레이>결과 루틴이 반복됩니다.
- 서버에서 노래를 전해받지 못해서 플레이, 결과 화면 둘 다 노래가 안 나옵니다.

## ✅ 한 일
1. 스테이지 소켓 연결, 구독 
2. 소켓에서 전해주는 데이터로 대기>캐치>플레이>결과 루틴 반복

## 🤓 다음에 할 일
1. 입장 api 연결
2. 스테이지 실시간 채팅 소켓 연결
