### PR TITLE
[feat] 스테이지 입장/퇴장 api 연결 (HH-285)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -16,6 +16,7 @@ class AppUrl {
   // 포포 스테이지
   static const stageAccuracyUrl = "$_stageUrl/similarity";
   static const stageUserListUrl = "$_stageUrl/users";
+  static const stageEnterUrl = "$_stageUrl/enter";
   static const stageTalkUrl = "$_talkUrl/messages";
 
   // 스켈레톤 정확도 확인

--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -17,6 +17,7 @@ class AppUrl {
   static const stageAccuracyUrl = "$_stageUrl/similarity";
   static const stageUserListUrl = "$_stageUrl/users";
   static const stageEnterUrl = "$_stageUrl/enter";
+  static const stageExitUrl = "$_stageUrl/exit"; // 임시 url
   static const stageTalkUrl = "$_talkUrl/messages";
 
   // 스켈레톤 정확도 확인

--- a/lib/data/entity/base_response.dart
+++ b/lib/data/entity/base_response.dart
@@ -12,12 +12,12 @@ class BaseResponse<T> {
       required this.message,
       required this.data});
 
-  factory BaseResponse.fromJson(Map<String, dynamic> json, BaseObject target) {
+  factory BaseResponse.fromJson(Map<String, dynamic> json, BaseObject? target) {
     return BaseResponse(
       timeStamp: json['timeStamp'],
       code: json['code'],
       message: json['message'],
-      data: target.fromJson(json['data']),
+      data: target?.fromJson(json['data']),
     );
   }
 }

--- a/lib/data/entity/base_socket_response.dart
+++ b/lib/data/entity/base_socket_response.dart
@@ -1,27 +1,25 @@
+import 'package:pocket_pose/data/entity/base_object.dart';
 import 'package:pocket_pose/ui/screen/popo_stage_screen.dart';
 
 class BaseSocketResponse<T> {
   String timeStamp;
   StageType type;
   String message;
-  // T? data;
+  T? data;
 
-  BaseSocketResponse({
-    required this.timeStamp,
-    required this.type,
-    required this.message,
-    // this.data
-  });
+  BaseSocketResponse(
+      {required this.timeStamp,
+      required this.type,
+      required this.message,
+      this.data});
 
   factory BaseSocketResponse.fromJson(
-    Map<String, dynamic> json,
-    // BaseObject target
-  ) {
+      Map<String, dynamic> json, BaseObject? target) {
     return BaseSocketResponse(
       timeStamp: json['timeStamp'],
       type: StageType.values.byName(json['type'].toString()),
       message: json['message'],
-      // data: target.fromJson(json['data']),
+      data: target?.fromJson(json['data']),
     );
   }
 }

--- a/lib/data/entity/request/stage_enter_request.dart
+++ b/lib/data/entity/request/stage_enter_request.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'stage_enter_request.g.dart';
+
+@JsonSerializable()
+class StageEnterRequest {
+  int page;
+  int size;
+
+  StageEnterRequest({
+    required this.page,
+    required this.size,
+  });
+
+  factory StageEnterRequest.fromJson(Map<String, dynamic> json) =>
+      _$StageEnterRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageEnterRequestToJson(this);
+}

--- a/lib/data/entity/request/stage_enter_request.g.dart
+++ b/lib/data/entity/request/stage_enter_request.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_enter_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageEnterRequest _$StageEnterRequestFromJson(Map<String, dynamic> json) =>
+    StageEnterRequest(
+      page: json['page'] as int,
+      size: json['size'] as int,
+    );
+
+Map<String, dynamic> _$StageEnterRequestToJson(StageEnterRequest instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'size': instance.size,
+    };

--- a/lib/data/entity/response/stage_enter_response.dart
+++ b/lib/data/entity/response/stage_enter_response.dart
@@ -1,0 +1,28 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+
+part 'stage_enter_response.g.dart';
+
+@JsonSerializable()
+class StageEnterResponse extends BaseObject<StageEnterResponse> {
+  String stageStatus;
+  int userCount;
+  StageTalkMessageResponse talkMessageData;
+
+  StageEnterResponse({
+    required this.stageStatus,
+    required this.userCount,
+    required this.talkMessageData,
+  });
+
+  factory StageEnterResponse.fromJson(Map<String, dynamic> json) =>
+      _$StageEnterResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageEnterResponseToJson(this);
+
+  @override
+  StageEnterResponse fromJson(json) {
+    return StageEnterResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/response/stage_enter_response.g.dart
+++ b/lib/data/entity/response/stage_enter_response.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_enter_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageEnterResponse _$StageEnterResponseFromJson(Map<String, dynamic> json) =>
+    StageEnterResponse(
+      stageStatus: json['stageStatus'] as String,
+      userCount: json['userCount'] as int,
+      talkMessageData: StageTalkMessageResponse.fromJson(
+          json['talkMessageData'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$StageEnterResponseToJson(StageEnterResponse instance) =>
+    <String, dynamic>{
+      'stageStatus': instance.stageStatus,
+      'userCount': instance.userCount,
+      'talkMessageData': instance.talkMessageData,
+    };

--- a/lib/data/entity/socket_response/user_count_response.dart
+++ b/lib/data/entity/socket_response/user_count_response.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+
+part 'user_count_response.g.dart';
+
+@JsonSerializable()
+class UserCountResponse extends BaseObject {
+  int userCount;
+
+  UserCountResponse({
+    required this.userCount,
+  });
+
+  factory UserCountResponse.fromJson(Map<String, dynamic> json) =>
+      _$UserCountResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserCountResponseToJson(this);
+
+  @override
+  fromJson(json) {
+    return UserCountResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/socket_response/user_count_response.g.dart
+++ b/lib/data/entity/socket_response/user_count_response.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_count_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+UserCountResponse _$UserCountResponseFromJson(Map<String, dynamic> json) =>
+    UserCountResponse(
+      userCount: json['userCount'] as int,
+    );
+
+Map<String, dynamic> _$UserCountResponseToJson(UserCountResponse instance) =>
+    <String, dynamic>{
+      'userCount': instance.userCount,
+    };

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -60,4 +60,27 @@ class StageProviderImpl implements StageProvider {
     }
     throw UnimplementedError();
   }
+
+  @override
+  Future<BaseResponse> getStageExit() async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    const refreshTokenKey = 'kakaoRefreshToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+
+    var dio = Dio();
+    try {
+      dio.options.headers = {
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+      };
+      dio.options.contentType = "application/json";
+      var response = await dio.get(AppUrl.stageExitUrl);
+
+      return BaseResponse.fromJson(response.data, null);
+    } catch (e) {
+      debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
+    }
+    throw UnimplementedError();
+  }
 }

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
+import 'package:pocket_pose/data/entity/response/stage_enter_response.dart';
 import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
 import 'package:pocket_pose/domain/provider/stage_provider.dart';
 
@@ -31,5 +33,31 @@ class StageProviderImpl implements StageProvider {
       debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
     }
     return throw UnimplementedError();
+  }
+
+  @override
+  Future<BaseResponse<StageEnterResponse>> getStageEnter(
+      StageEnterRequest request) async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    const refreshTokenKey = 'kakaoRefreshToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+
+    var dio = Dio();
+    try {
+      dio.options.headers = {
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+      };
+      dio.options.contentType = "application/json";
+      var response = await dio.get(
+          '${AppUrl.stageEnterUrl}?page=${request.page}&size=${request.size}');
+
+      return BaseResponse<StageEnterResponse>.fromJson(
+          response.data, StageEnterResponse.fromJson(response.data['data']));
+    } catch (e) {
+      debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
+    }
+    throw UnimplementedError();
   }
 }

--- a/lib/domain/provider/stage_provider.dart
+++ b/lib/domain/provider/stage_provider.dart
@@ -1,6 +1,10 @@
 import 'package:pocket_pose/data/entity/base_response.dart';
+import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
+import 'package:pocket_pose/data/entity/response/stage_enter_response.dart';
 import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
 
 abstract class StageProvider {
   Future<BaseResponse<StageUserListResponse>> getUserList();
+  Future<BaseResponse<StageEnterResponse>> getStageEnter(
+      StageEnterRequest request);
 }

--- a/lib/domain/provider/stage_provider.dart
+++ b/lib/domain/provider/stage_provider.dart
@@ -7,4 +7,5 @@ abstract class StageProvider {
   Future<BaseResponse<StageUserListResponse>> getUserList();
   Future<BaseResponse<StageEnterResponse>> getStageEnter(
       StageEnterRequest request);
+  Future<BaseResponse> getStageExit();
 }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
 import 'package:pocket_pose/data/entity/base_socket_response.dart';
+import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
@@ -42,6 +43,7 @@ class PoPoStageScreen extends StatefulWidget {
 
 class _PoPoStageScreenState extends State<PoPoStageScreen> {
   final int _userCount = 1;
+  bool _isEnter = false;
   late VideoPlayProvider _videoPlayProvider;
   final StageProvider _stageProvider = StageProviderImpl();
   StageType _stageType = StageType.WAIT;
@@ -124,14 +126,21 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   }
 
   void _onConnect(StompFrame frame, String token) {
+    // 연결 되면 구독
     stompClient?.subscribe(
         destination: AppUrl.subscribeStageUrl,
         callback: (StompFrame frame) {
           if (frame.body != null) {
+            // 입장 요청
+            if (!_isEnter) {
+              _stageProvider
+                  .getStageEnter(StageEnterRequest(page: 0, size: 10));
+              _isEnter = true;
+            }
+            // stage 상태 변경
             var socketResponse =
                 BaseSocketResponse.fromJson(jsonDecode(frame.body.toString()));
             setStageType(socketResponse.type);
-            print("mmm socket base: ${socketResponse.type}");
           }
         });
   }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -8,6 +8,7 @@ import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
 import 'package:pocket_pose/data/entity/base_socket_response.dart';
 import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
+import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
@@ -144,9 +145,9 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         callback: (StompFrame frame) {
           if (frame.body != null) {
             // stage 상태 변경
-            var socketResponse =
-                BaseSocketResponse.fromJson(jsonDecode(frame.body.toString()));
-            setStageType(socketResponse.type);
+            var socketResponse = BaseSocketResponse.fromJson(
+                jsonDecode(frame.body.toString()), null);
+            setStageType(socketResponse, frame);
           }
         });
   }
@@ -202,11 +203,24 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     );
   }
 
-  void setStageType(StageType newStageType) {
-    if (mounted) {
-      setState(() {
-        _stageType = newStageType;
-      });
+  void setStageType(BaseSocketResponse response, StompFrame frame) {
+    switch (response.type) {
+      case StageType.USER_COUNT:
+        var socketResponse = BaseSocketResponse<UserCountResponse>.fromJson(
+            jsonDecode(frame.body.toString()),
+            UserCountResponse.fromJson(
+                jsonDecode(frame.body.toString())['data']));
+        setState(() {
+          _userCount = socketResponse.data!.userCount;
+        });
+
+        break;
+      default:
+        if (mounted) {
+          setState(() {
+            _stageType = response.type;
+          });
+        }
     }
   }
 

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -104,6 +104,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       _videoPlayProvider.playVideo();
     }
     stompClient?.deactivate();
+    _stageProvider.getStageExit();
 
     super.dispose();
   }


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/5c3d797b-a332-4db6-a4f3-010e5d7c26dc

## 💬 작업 설명
- 스테이지 입장/퇴장 api를 연결하였습니다.
- 오른쪽 상단의 유저 위젯에 실시간으로 스테이지에 있는 사람 수와 목록을 확인할 수 있습니다.

## ✅ 한 일
1. 스테이지 입장/퇴장 api 연결
2. 실시간 user count 연동

## ☝️ 참고 하세요~
1. 만약 스테이지 동작이 이상하다면... 로그아웃 후 다시 로그인 해주세요!

## 🤓 다음에 할 일
1. 스테이지 실시간 채팅 api 연결
