### PR TITLE
[feat] 스테이지 실시간 반응 전송 소켓 연결 (HH-287)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -27,5 +27,7 @@ class AppUrl {
   static const skeletonAccuracyUrl = "$_aiBaseUrl/api/similarity/test";
 
   // web socket
-  static const subscribeStageUrl = "/topic/stage";
+  static const socketSubscribeStageUrl = "/topic/stage";
+  static const socketTalkUrl = "/app/talks/messages";
+  static const socketReactionUrl = "/app/talks/reactions";
 }

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -13,8 +13,16 @@ import 'package:pocket_pose/domain/provider/stage_provider.dart';
 
 class StageProviderImpl extends ChangeNotifier implements StageProvider {
   final List<StageTalkListItem> _talkList = [];
+  bool _isClicked = false;
 
   List<StageTalkListItem> get talkList => _talkList;
+
+  bool get isClicked => _isClicked;
+  setIsClicked(bool value) => _isClicked = value;
+
+  void toggleIsLeft() {
+    if (isClicked) notifyListeners();
+  }
 
   void addTalkList(List<StageTalkListItem> list) {
     _talkList.addAll(list);

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -146,7 +146,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     }
     // 연결 되면 구독
     _stompClient?.subscribe(
-        destination: AppUrl.subscribeStageUrl,
+        destination: AppUrl.socketSubscribeStageUrl,
         callback: (StompFrame frame) {
           if (frame.body != null) {
             // stage 상태 변경
@@ -164,7 +164,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
     if (_stompClient != null) {
       _stompClient?.send(
-          destination: '/app/talks/messages',
+          destination: AppUrl.socketTalkUrl,
           headers: {'x-access-token': token},
           body: json.encode({"content": message}));
     }
@@ -177,7 +177,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
     if (_stompClient != null) {
       _stompClient?.send(
-        destination: '/app/talks/reactions',
+        destination: AppUrl.socketReactionUrl,
         headers: {'x-access-token': token},
       );
     }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -34,7 +34,8 @@ enum StageType {
   MVP_START,
   USER_COUNT,
   STAGE_ROUTINE_STOP,
-  TALK_MESSAGE
+  TALK_MESSAGE,
+  TALK_REACTION
 }
 
 class PoPoStageScreen extends StatefulWidget {
@@ -84,7 +85,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                     bottom: 0,
                     left: 0,
                     right: 0,
-                    child: StageLiveChatBarWidget(sendMessage: _sendMessage),
+                    child: StageLiveChatBarWidget(
+                        sendMessage: _sendMessage, sendReaction: _sendReaction),
                   ),
                 ],
               ),
@@ -168,6 +170,19 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     }
   }
 
+  void _sendReaction() async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    String token = await storage.read(key: storageKey) ?? "";
+
+    if (_stompClient != null) {
+      _stompClient?.send(
+        destination: '/app/talks/reactions',
+        headers: {'x-access-token': token},
+      );
+    }
+  }
+
   BoxDecoration _buildBackgroundImage() {
     return BoxDecoration(
       image: DecorationImage(
@@ -229,6 +244,10 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
             content: socketResponse.data!.content,
             sender: socketResponse.data!.sender);
         _stageProvider.addTalk(talk);
+        break;
+      case StageType.TALK_REACTION:
+        _stageProvider.setIsClicked(true);
+        _stageProvider.toggleIsLeft();
         break;
       default:
         if (mounted) {

--- a/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
+import 'package:provider/provider.dart';
 
 class StageLiveChatBarWidget extends StatefulWidget {
-  const StageLiveChatBarWidget({super.key, required this.sendMessage});
+  const StageLiveChatBarWidget(
+      {super.key, required this.sendMessage, required this.sendReaction});
   final Function sendMessage;
+  final Function sendReaction;
 
   @override
   State<StageLiveChatBarWidget> createState() => _StageLiveChatBarWidgetState();
@@ -14,11 +18,13 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
   final TextEditingController _textController = TextEditingController();
   final FocusNode _inputFieldFocusNode = FocusNode();
   bool _isFireIconVisible = true;
+  bool _isLeft = true;
 
   List<Widget> selectWidgets = [];
   final List<AnimationController> _animationControllers = [];
   final List<Animation<Offset>> _animations = [];
-  bool isLeft = true;
+
+  late StageProviderImpl _provider;
 
   @override
   void initState() {
@@ -42,10 +48,18 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
 
   @override
   Widget build(BuildContext context) {
+    _provider = Provider.of<StageProviderImpl>(context, listen: true);
+
+    if (_provider.isClicked) {
+      _provider.setIsClicked(false);
+      _handleIconClick();
+    }
+
     return _buildInputArea(context);
   }
 
   Widget _buildInputArea(BuildContext context) {
+    // _handleIconClick();
     return Stack(
       children: [
         _buildLiveChatBar(context),
@@ -92,7 +106,6 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
                     onSubmitted: (value) {
                       widget.sendMessage(value);
                       _textController.clear();
-                      //_textController.clear();
                     },
                   ),
                 ),
@@ -106,7 +119,7 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
                 child: InkWell(
                   highlightColor: Colors.transparent,
                   splashColor: Colors.transparent,
-                  onTap: _handleIconClick,
+                  onTap: () => widget.sendReaction(), //_handleIconClick,
                   child: SvgPicture.asset(
                       'assets/icons/ic_popo_fire_unselect.svg'),
                 ),
@@ -117,11 +130,10 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
               width: _isFireIconVisible ? 14 : 0,
               child: Visibility(
                 visible: _isFireIconVisible,
-                child: InkWell(
+                child: const InkWell(
                     highlightColor: Colors.transparent,
                     splashColor: Colors.transparent,
-                    onTap: _handleIconClick,
-                    child: const SizedBox(
+                    child: SizedBox(
                       width: 14,
                     )),
               ),
@@ -134,7 +146,7 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
 
   void _handleIconClick() {
     setState(() {
-      isLeft = !isLeft;
+      _isLeft = !_isLeft;
 
       final animationController = AnimationController(
         duration: const Duration(milliseconds: 4000),
@@ -143,7 +155,7 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
 
       const beginOffset = Offset(0.0, 0.0);
       final middleOffset =
-          isLeft ? const Offset(-8.0, -100.0) : const Offset(8.0, -100.0);
+          _isLeft ? const Offset(-8.0, -100.0) : const Offset(8.0, -100.0);
       const endOffset = Offset(0.0, -200.0);
 
       final animation = TweenSequence([

--- a/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
@@ -59,7 +59,6 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
   }
 
   Widget _buildInputArea(BuildContext context) {
-    // _handleIconClick();
     return Stack(
       children: [
         _buildLiveChatBar(context),


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/688a947f-ba96-4e0c-8e7d-3a7da09bd259

## 💬 작업 설명
- 스테이지 실시간 반응 소켓을 연결했습니다.

## ✅ 한 일
1. 스테이지 실시간 반응 소켓 연결

## 😥 어려웠던점
1. Provider를 사용해서 값을 받을 때 Widget을 초기화하는 건 해봤지만, 함수(불꽃 반응 나오는 함수)를 사용한 것은 처음이라 로직 적용이 어려웠습니다. 

## 🔧 보완할 점
1. Provider에서 noti 받을 때 불꽃 애니메이션 보이는 로직 refactor가 필요할 것 같습니다.🤔

## ☝️ 참고 하세요~
1. 불꽃 아이콘 눌렀을 때 불꽃이 바로 나타나지 않는 건 아이콘이 안 눌려서 입니다! 빨간 불꽃에 하얀 불꽃 아이콘이 가려진 경우 하얀 불꽃 아이콘이 잘 안눌립니다~

## 🤓 다음에 할 일
1. 스테이지 실시간 유저 변동 다이얼로그에 반영
2. 스테이지 실시간 채팅 페이지네이션
3. 스테이지 1인 캐치 소켓 연결
