### PR TITLE
[feat] 스테이지 사용자 목록 다이얼로그 실시간 변동사항 반영 (HH-288)

### DIFF
--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -9,13 +9,16 @@ import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
 import 'package:pocket_pose/data/entity/response/stage_enter_response.dart';
 import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
+import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
 import 'package:pocket_pose/domain/provider/stage_provider.dart';
 
 class StageProviderImpl extends ChangeNotifier implements StageProvider {
   final List<StageTalkListItem> _talkList = [];
+  final List<StageUserListItem> _userList = [];
   bool _isClicked = false;
 
   List<StageTalkListItem> get talkList => _talkList;
+  List<StageUserListItem> get userList => _userList;
 
   bool get isClicked => _isClicked;
   setIsClicked(bool value) => _isClicked = value;
@@ -49,9 +52,13 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
       };
       dio.options.contentType = "application/json";
       var response = await dio.get(AppUrl.stageUserListUrl);
-
-      return BaseResponse<StageUserListResponse>.fromJson(
+      var responseJson = BaseResponse<StageUserListResponse>.fromJson(
           response.data, StageUserListResponse.fromJson(response.data['data']));
+      _userList.clear();
+      _userList.addAll(responseJson.data.list ?? []);
+
+      notifyListeners();
+      return responseJson;
     } catch (e) {
       debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
     }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -58,6 +58,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   Widget build(BuildContext context) {
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
     _stageProvider = Provider.of<StageProviderImpl>(context, listen: true);
+
     return GestureDetector(
       onTap: () {
         FocusScope.of(context).unfocus();
@@ -231,6 +232,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                 jsonDecode(frame.body.toString())['data']));
         setState(() {
           _userCount = socketResponse.data!.userCount;
+          _stageProvider.getUserList();
         });
 
         break;
@@ -265,9 +267,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       margin: const EdgeInsets.only(right: 16.0, top: 10.0, bottom: 10.0),
       child: OutlinedButton.icon(
         onPressed: () async {
-          var response = await _stageProvider.getUserList();
-
-          _showUserListDialog(response.data.list ?? []);
+          await _stageProvider.getUserList();
+          _showUserListDialog(_stageProvider.userList);
         },
         style: OutlinedButton.styleFrom(
           shape: RoundedRectangleBorder(
@@ -291,65 +292,67 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
   Future<dynamic> _showUserListDialog(List<StageUserListItem> userList) {
     return showDialog(
-        context: context,
-        barrierColor: Colors.transparent,
-        builder: (BuildContext context) {
-          return BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-            child: AlertDialog(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                  side: const BorderSide(
+      context: context,
+      barrierColor: Colors.transparent,
+      builder: (BuildContext context) {
+        return BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+          child: AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10.0),
+              side: const BorderSide(
+                color: Colors.white,
+                width: 1.0,
+              ),
+            ),
+            backgroundColor: Colors.white.withOpacity(0.3),
+            title: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(child: Container()),
+                const Padding(
+                  padding: EdgeInsets.only(left: 20),
+                  child: Text(
+                    '참여자 목록',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                Expanded(child: Container()),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Icon(
+                    Icons.close,
+                    size: 20,
                     color: Colors.white,
-                    width: 1.0,
                   ),
                 ),
-                backgroundColor: Colors.white.withOpacity(0.3),
-                title: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Expanded(child: Container()),
-                    const Padding(
-                      padding: EdgeInsets.only(left: 20),
-                      child: Text(
-                        '참여자 목록',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                    Expanded(child: Container()),
-                    GestureDetector(
-                      onTap: () {
-                        Navigator.of(context).pop();
-                      },
-                      child: const Icon(
-                        Icons.close,
-                        size: 20,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
+              ],
+            ),
+            content: SizedBox(
+              width: 265,
+              height: 365,
+              child: GridView.builder(
+                itemCount: context.watch<StageProviderImpl>().userList.length,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
                 ),
-                content: SizedBox(
-                  width: 265,
-                  height: 365,
-                  child: GridView.builder(
-                    itemCount: userList.length,
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 3,
-                    ),
-                    itemBuilder: (BuildContext context, int index) {
-                      return UserListItemWidget(user: userList[index]);
-                    },
-                  ),
-                )),
-          );
-        });
+                itemBuilder: (BuildContext context, int index) {
+                  return UserListItemWidget(
+                      user: context.watch<StageProviderImpl>().userList[index]);
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Widget _buildStageView(StageType type) {


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/d7fd6eb4-1097-4eb6-ac17-71d3fd83ef47

## 💬 작업 설명
- 스테이지 사용자 목록 다이얼로그에 사용자가 입장/퇴장한 정보가 실시간으로 반영되도록 하였습니다.

## ✅ 한 일
1. 스테이지 사용자 목록 다이얼로그 실시간 변동사항 반영

## 🤓 다음에 할 일
1. 스테이지 실시간 채팅 페이지네이션
2. 스테이지 1인 캐치 소켓 연결
3. 스테이지 플레이어 플레이 시 스켈레톤 소켓 전송
