### PR TITLE
[bug] #63 홈 새로고침 후 발생하는 dispose 오류 해결 (HH-274)

### DIFF
--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -30,7 +30,12 @@ class VideoPlayProvider with ChangeNotifier {
 
   void addVideos(List<VideoData> newVideoList) {
     int num = videoList.length;
+
     videoList.addAll(newVideoList);
+
+    for (final video in videoList) {
+      debugPrint(video.videoUrl);
+    }
 
     // Add VideoPlayer Controller
     controllers.addAll(List<VideoPlayerController>.generate(
@@ -68,8 +73,6 @@ class VideoPlayProvider with ChangeNotifier {
   }
 
   void resetVideoPlayer() {
-    dispose();
-
     controllers = [];
     videoPlayerFutures = [];
     videoList = [];
@@ -82,12 +85,12 @@ class VideoPlayProvider with ChangeNotifier {
 
   @override
   void dispose() {
+    super.dispose();
+
     for (final controller in controllers) {
       controller.dispose();
     }
 
     pageController.dispose();
-
-    super.dispose();
   }
 }

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -139,7 +139,6 @@ class _VideoViewState extends State<VideoView>
                       _videoPlayProvider.loading = true;
                       return buildVideoPlayer(index); // 비디오 플레이어 생성
                     } else {
-                      _videoPlayProvider.loading = false;
                       return const MusicSpinner(); // 비디오 로딩 중
                     }
                   },


### PR DESCRIPTION
## 💬 작업 설명
#63 이후로 홈 화면 새로고침 후 발생하는 dispose 오류를 해결했습니다.
provider를 dispose 한 후에 provider의 값들을 수정해서 난 간단한 오류였습니다.

이외에 다음의 작은 버그를 민영님과 이야기했고, 해결하려고 했는데 크게 거슬리지 않아 그냥 두기로 했습니다.
1. 불러온 마지막 영상이 아니다? -> 다시 보니까 마지막 영상이었습니다.
2. 마지막 영상으로 갈 때 로딩 화면 잠깐 보이는 것 -> 고칠 수는 있는데 고치면 다른 부분에서 잠깐의 로딩에 흰 화면이 나오고 더 복잡해지길래 그냥 뒀습니다. 크게 신경쓰이는 부분은 아닌 것 같아요.
3. 마지막 화면에서 popo text 눌러서 위로 올라갈 때 로딩 화면 보이는 것 -> 2와 같은 이유로 그냥 두기로 했습니다.


## 🥲 부탁드립니다.
영상 업로드에서 오류가 났습니다.
영상 찍고 제목, 태그 쓴 뒤에 '업로드' 버튼 누르면 이렇게 오류나고 계속 로딩에에서 멈춰있습니다.. 잘 되다가 갑자기 왜이럴까요.. 확인 부탁드립니다!

<img width="279" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/dc5fa10f-8f9b-42ba-b6a1-0324763574d8">

<img width="1214" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/013f10d2-95a8-4f4a-ba80-f456f59fb7d8">

`I/flutter (11246): mmm VideoUploadProviderImpl catch: DioException [bad response]: The request returned an invalid status code of 403.`

`E/flutter (11246): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: UnimplementedError`

`E/flutter (11246): #0      VideoUploadProviderImpl.postVideoUpload`


