### PR TITLE
[feat] 스테이지 캐치 기능 추가 (HH-280)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -21,6 +21,7 @@ class AppUrl {
   static const stageUserListUrl = "$_stageUrl/users";
   static const stageEnterUrl = "$_stageUrl/enter";
   static const stageExitUrl = "$_stageUrl/exit"; // 임시 url
+  static const stageCatchUrl = "$_stageUrl/catch"; // 1인 catch
   static const stageTalkUrl = "$_talkUrl/messages";
 
   // 스켈레톤 정확도 확인

--- a/lib/data/entity/socket_response/catch_end_response.dart
+++ b/lib/data/entity/socket_response/catch_end_response.dart
@@ -1,0 +1,24 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
+
+part 'catch_end_response.g.dart';
+
+@JsonSerializable()
+class CatchEndResponse extends BaseObject {
+  List<StagePlayerListItem> players;
+
+  CatchEndResponse({
+    required this.players,
+  });
+
+  factory CatchEndResponse.fromJson(Map<String, dynamic> json) =>
+      _$CatchEndResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CatchEndResponseToJson(this);
+
+  @override
+  fromJson(json) {
+    return CatchEndResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/socket_response/catch_end_response.g.dart
+++ b/lib/data/entity/socket_response/catch_end_response.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'catch_end_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CatchEndResponse _$CatchEndResponseFromJson(Map<String, dynamic> json) =>
+    CatchEndResponse(
+      players: (json['players'] as List<dynamic>)
+          .map((e) => StagePlayerListItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$CatchEndResponseToJson(CatchEndResponse instance) =>
+    <String, dynamic>{
+      'players': instance.players,
+    };

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -117,4 +117,27 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
     }
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> getStageCatch() async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    const refreshTokenKey = 'kakaoRefreshToken';
+    String accessToken = await storage.read(key: storageKey) ?? "";
+    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+
+    var dio = Dio();
+    try {
+      dio.options.headers = {
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+      };
+      dio.options.contentType = "application/json";
+      await dio.get(AppUrl.stageCatchUrl);
+
+      return;
+    } catch (e) {
+      debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
+    }
+    throw UnimplementedError();
+  }
 }

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -137,6 +137,7 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
       return;
     } catch (e) {
       debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
+      if (e.toString().contains("500")) return;
     }
     throw UnimplementedError();
   }

--- a/lib/domain/entity/stage_player_list_item.dart
+++ b/lib/domain/entity/stage_player_list_item.dart
@@ -1,0 +1,28 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+
+part 'stage_player_list_item.g.dart';
+
+@JsonSerializable()
+class StagePlayerListItem extends BaseObject<StagePlayerListItem> {
+  int? playerNum;
+  String userId = "";
+  String nickname = "";
+  String? profileImg;
+
+  StagePlayerListItem(
+      {this.playerNum,
+      required this.userId,
+      required this.nickname,
+      required this.profileImg});
+
+  factory StagePlayerListItem.fromJson(Map<String, dynamic> json) =>
+      _$StagePlayerListItemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StagePlayerListItemToJson(this);
+
+  @override
+  StagePlayerListItem fromJson(json) {
+    return StagePlayerListItem.fromJson(json);
+  }
+}

--- a/lib/domain/entity/stage_player_list_item.g.dart
+++ b/lib/domain/entity/stage_player_list_item.g.dart
@@ -1,21 +1,24 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'user_data.dart';
+part of 'stage_player_list_item.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-UserData _$UserDataFromJson(Map<String, dynamic> json) => UserData(
-      uuid: json['uuid'] as String,
+StagePlayerListItem _$StagePlayerListItemFromJson(Map<String, dynamic> json) =>
+    StagePlayerListItem(
+      playerNum: json['playerNum'] as int?,
+      userId: json['userId'] as String,
       nickname: json['nickname'] as String,
       profileImg: json['profileImg'] as String?,
-      email: json['email'] as String?,
     );
 
-Map<String, dynamic> _$UserDataToJson(UserData instance) => <String, dynamic>{
-      'uuid': instance.uuid,
+Map<String, dynamic> _$StagePlayerListItemToJson(
+        StagePlayerListItem instance) =>
+    <String, dynamic>{
+      'playerNum': instance.playerNum,
+      'userId': instance.userId,
       'nickname': instance.nickname,
       'profileImg': instance.profileImg,
-      'email': instance.email,
     };

--- a/lib/domain/provider/stage_provider.dart
+++ b/lib/domain/provider/stage_provider.dart
@@ -8,4 +8,5 @@ abstract class StageProvider {
   Future<BaseResponse<StageEnterResponse>> getStageEnter(
       StageEnterRequest request);
   Future<BaseResponse> getStageExit();
+  Future<void> getStageCatch();
 }

--- a/lib/ui/screen/home/home_screen.dart
+++ b/lib/ui/screen/home/home_screen.dart
@@ -46,7 +46,7 @@ class _HomeScreenState extends State<HomeScreen> {
           backgroundColor: Colors.transparent, //appBar 투명색
           elevation: 0.0, //appBar 그림자 농도 설정 (값 0으로 제거)
           actions: [
-            InkWell(
+            GestureDetector(
                 onTap: () {
                   Navigator.push(
                     context,

--- a/lib/ui/screen/home/home_upload_screen.dart
+++ b/lib/ui/screen/home/home_upload_screen.dart
@@ -12,15 +12,15 @@ import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
-class UploadScreen extends StatefulWidget {
-  const UploadScreen({super.key, required this.uploadFile});
+class HomeUploadScreen extends StatefulWidget {
+  const HomeUploadScreen({super.key, required this.uploadFile});
   final File uploadFile;
 
   @override
-  State<UploadScreen> createState() => _UploadScreenState();
+  State<HomeUploadScreen> createState() => _HomeUploadScreenState();
 }
 
-class _UploadScreenState extends State<UploadScreen> {
+class _HomeUploadScreenState extends State<HomeUploadScreen> {
   final TextEditingController _titleTextController = TextEditingController();
   VideoPlayerController? _videoPlayerController;
   late VideoPlayProvider _videoPlayProvider;

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -13,6 +13,7 @@ import 'package:pocket_pose/data/entity/socket_response/talk_message_response.da
 import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
+import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
 import 'package:pocket_pose/ui/view/popo_play_view.dart';
@@ -54,6 +55,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   late StageProviderImpl _stageProvider;
   StageType _stageType = StageType.WAIT;
   StompClient? _stompClient;
+  final List<StagePlayerListItem> _players = [];
 
   @override
   Widget build(BuildContext context) {
@@ -257,8 +259,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
             jsonDecode(frame.body.toString()),
             CatchEndResponse.fromJson(
                 jsonDecode(frame.body.toString())['data']));
-        print("mmm catch end: $socketResponse");
-        print("mmm catch end: ${socketResponse.data!.players.length}");
+        _players.clear();
+        _players.addAll(socketResponse.data?.players ?? []);
         break;
       default:
         if (mounted) {
@@ -372,7 +374,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       case StageType.CATCH_START:
         return const PoPoCatchView();
       case StageType.PLAY_START:
-        return PoPoPlayView(isResultState: _getIsResultState());
+        return PoPoPlayView(
+            isResultState: _getIsResultState(), players: _players);
       case StageType.MVP_START:
         return PoPoResultView(isResultState: _getIsResultState());
       default:

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -8,6 +8,7 @@ import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
 import 'package:pocket_pose/data/entity/base_socket_response.dart';
 import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
+import 'package:pocket_pose/data/entity/socket_response/catch_end_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/talk_message_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
@@ -250,6 +251,14 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       case StageType.TALK_REACTION:
         _stageProvider.setIsClicked(true);
         _stageProvider.toggleIsLeft();
+        break;
+      case StageType.CATCH_END:
+        var socketResponse = BaseSocketResponse<CatchEndResponse>.fromJson(
+            jsonDecode(frame.body.toString()),
+            CatchEndResponse.fromJson(
+                jsonDecode(frame.body.toString())['data']));
+        print("mmm catch end: $socketResponse");
+        print("mmm catch end: ${socketResponse.data!.players.length}");
         break;
       default:
         if (mounted) {

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
+import 'package:provider/provider.dart';
 import 'package:semicircle_indicator/semicircle_indicator.dart';
 import 'dart:math' as math;
 
@@ -22,8 +24,12 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   late AnimationController _animationController;
   late Animation<double> _opacityAnimation;
 
+  late StageProviderImpl _stageProvider;
+
   @override
   Widget build(BuildContext context) {
+    _stageProvider = Provider.of<StageProviderImpl>(context, listen: true);
+
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -74,7 +80,9 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
         strokeWidth: 2,
         backgroundColor: Colors.transparent,
         child: InkWell(
-          onTap: () {},
+          onTap: () {
+            _stageProvider.getStageCatch();
+          },
           borderRadius: const BorderRadius.all(
             Radius.circular(20.0),
           ),

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -7,13 +7,17 @@ import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/custom_pose_painter.dart';
 import 'package:pocket_pose/data/remote/provider/popo_skeleton_provider_impl.dart';
+import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
 
-enum StagePlayScore { bad, good, great, excellent, perfect }
+enum StagePlayScore { bad, good, great, excellent, perfect, none }
 
 // ml_kit_skeleton_custom_view
 class PoPoPlayView extends StatefulWidget {
-  const PoPoPlayView({Key? key, required this.isResultState}) : super(key: key);
+  final List<StagePlayerListItem> players;
+  const PoPoPlayView(
+      {Key? key, required this.isResultState, required this.players})
+      : super(key: key);
   final bool isResultState;
 
   @override
@@ -49,12 +53,36 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              getProfile('assets/images/home_profile_1.jpg', 'okoi2202',
-                  StagePlayScore.good),
-              getProfile('assets/images/home_profile_2.jpg', 'ONEUS',
-                  StagePlayScore.bad),
-              getProfile('assets/images/home_profile_3.jpg', 'joyseoworld',
-                  StagePlayScore.excellent),
+              if (widget.players.length > 1)
+                getProfile(widget.players[1].profileImg,
+                    widget.players[1].nickname, StagePlayScore.good)
+              else
+                Visibility(
+                    visible: false,
+                    maintainSize: true,
+                    maintainAnimation: true,
+                    maintainState: true,
+                    child: getProfile(null, "", StagePlayScore.none)),
+              if (widget.players.isNotEmpty)
+                getProfile(widget.players[0].profileImg,
+                    widget.players[0].nickname, StagePlayScore.bad)
+              else
+                Visibility(
+                    visible: false,
+                    maintainSize: true,
+                    maintainAnimation: true,
+                    maintainState: true,
+                    child: getProfile(null, "", StagePlayScore.none)),
+              if (widget.players.length > 2)
+                getProfile(widget.players[2].profileImg,
+                    widget.players[2].nickname, StagePlayScore.excellent)
+              else
+                Visibility(
+                    visible: false,
+                    maintainSize: true,
+                    maintainAnimation: true,
+                    maintainState: true,
+                    child: getProfile(null, "", StagePlayScore.none)),
             ],
           ),
         ),
@@ -85,16 +113,24 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     super.dispose();
   }
 
-  Column getProfile(String profileImg, String nickName, StagePlayScore score) {
+  Column getProfile(String? profileImg, String nickName, StagePlayScore score) {
     return Column(
       children: [
         ClipRRect(
-            borderRadius: BorderRadius.circular(50),
-            child: Image.asset(
-              profileImg,
-              width: 50,
-              height: 50,
-            )),
+          borderRadius: BorderRadius.circular(50),
+          child: (profileImg == null)
+              ? Image.asset(
+                  'assets/images/charactor_popo_default.png',
+                  width: 50,
+                  height: 50,
+                )
+              : Image.network(
+                  profileImg,
+                  fit: BoxFit.cover,
+                  width: 50,
+                  height: 50,
+                ),
+        ),
         const SizedBox(
           height: 8,
         ),
@@ -133,6 +169,9 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
       case StagePlayScore.perfect:
         scoreText = "Perfect";
         scoreNeonColor = AppColor.yellowColor2;
+        break;
+      case StagePlayScore.none:
+        scoreText = "";
         break;
     }
 

--- a/lib/ui/widget/home/upload_button_widget.dart
+++ b/lib/ui/widget/home/upload_button_widget.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:pocket_pose/config/app_color.dart';
-import 'package:pocket_pose/ui/screen/upload_screen.dart';
+import 'package:pocket_pose/ui/screen/home/home_upload_screen.dart';
 
 class UploadButtonWidget extends StatefulWidget {
   const UploadButtonWidget({
@@ -39,7 +39,8 @@ class _UploadButtonWidgetState extends State<UploadButtonWidget> {
             Navigator.push(
               context,
               MaterialPageRoute(
-                  builder: (context) => UploadScreen(uploadFile: videoFile!)),
+                  builder: (context) =>
+                      HomeUploadScreen(uploadFile: videoFile!)),
             );
           } else {
             ScaffoldMessenger.of(widget.context).showSnackBar(

--- a/lib/ui/widget/home/upload_button_widget.dart
+++ b/lib/ui/widget/home/upload_button_widget.dart
@@ -50,7 +50,7 @@ class _UploadButtonWidgetState extends State<UploadButtonWidget> {
       );
     }
 
-    return InkWell(
+    return GestureDetector(
       onTap: () => {
         showModalBottomSheet(
           context: context,
@@ -148,9 +148,6 @@ class _UploadButtonWidgetState extends State<UploadButtonWidget> {
           },
         ),
       },
-      borderRadius: const BorderRadius.all(
-        Radius.circular(90.0),
-      ),
       child: Container(
           padding: const EdgeInsets.all(14),
           child: SvgPicture.asset('assets/icons/ic_home_upload.svg')),


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/2dcfb7d0-f3bc-492a-b5b2-710c8c09e0ec" width="200">
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/983662b4-59d7-4fc3-ac31-9ea88e2a94a5" width="200">

## 💬 작업 설명
- 캐치 버튼을 누르고, 캐치에 성공한 사람의 정보가 플레이 화면에 출력되도록 개발했습니다.
- upload_screen.dart를 home 패키지 안에 두고 이름도 home_upload_screen.dart로 변경하였습니다.
- 홈 화면의 채팅, 업로드 버튼의 ripple 효과를 제거하였습니다.

## ✅ 한 일
1. 캐치 요청 api 연결
2. 캐치 성공한 사람의 정보를 플레이 화면에 출력
3. upload_screen 파일명, 경로명 변경
4. 홈 화면의 채팅, 업로드 버튼의 ripple 효과 제거

## 🧐 궁금한점
1. 지금 플레이 화면이 3인 기준이라 2명이 캐치했을 때 맨 오른쪽이 비어보이는데... 괜찮나요? 1명/2명에 특화된 ui를 만드는 게 나을까요?

## ☝️ 참고 하세요~
1. 캐치 기능만 추가한 거고 스켈레톤 추출/전송 기능은 다음에 추가할 예정입니다. 캡쳐본에 스켈레톤 3개 있는 거는 무시해주시길 바랍니다!

## 💃 부탁 드립니다~
1. 캐치 성공 시 캐치 성공한 사람에게 캐치 성공 토스트 띄우는 기능, 캐치 성공한 사람의 스켈레톤을 추출하기 위해서는 uuid가 필요합니다! uuid 저장 로직 다 짜시면 알림 주시길 바랍니다!

## 🤓 다음에 할 일
1. 스테이지 플레이 화면: 스켈레톤 전송/수신
2. 스테이지 mvp 화면: mvp 스켈레톤 전송/수신
3. 스테이지 실시간 채팅 페이지네이션
