### PR TITLE
[feat] 댓글 목록 조회 api, 댓글 등록 api, 댓글 삭제 api 연결 (HH-305)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -19,6 +19,9 @@ class AppUrl {
   // 좋아요
   static const likeUrl = "$_apiBaseUrl/likes";
 
+  // 댓글
+  static const commentUrl = "$_apiBaseUrl/comments";
+
   // 포포 스테이지
   static const stageAccuracyUrl = "$_stageUrl/similarity";
   static const stageUserListUrl = "$_stageUrl/users";

--- a/lib/data/entity/response/comment_list_response.dart
+++ b/lib/data/entity/response/comment_list_response.dart
@@ -1,20 +1,14 @@
 import 'package:json_annotation/json_annotation.dart';
-import 'package:pocket_pose/domain/entity/user_data.dart';
+import 'package:pocket_pose/domain/entity/comment_data.dart';
 
 part 'comment_list_response.g.dart';
 
 @JsonSerializable()
 class CommentListResponse {
-  final String uuid;
-  final String content;
-  final UserData user;
-  final DateTime createdAt;
+  final List<CommentData> commentList;
 
   const CommentListResponse({
-    required this.uuid,
-    required this.content,
-    required this.user,
-    required this.createdAt,
+    required this.commentList,
   });
 
   factory CommentListResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/data/entity/response/comment_list_response.dart
+++ b/lib/data/entity/response/comment_list_response.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/domain/entity/user_data.dart';
+
+part 'comment_list_response.g.dart';
+
+@JsonSerializable()
+class CommentListResponse {
+  final String uuid;
+  final String content;
+  final UserData user;
+  final DateTime createdAt;
+
+  const CommentListResponse({
+    required this.uuid,
+    required this.content,
+    required this.user,
+    required this.createdAt,
+  });
+
+  factory CommentListResponse.fromJson(Map<String, dynamic> json) =>
+      _$CommentListResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$CommentListResponseToJson(this);
+}

--- a/lib/data/entity/response/comment_list_response.g.dart
+++ b/lib/data/entity/response/comment_list_response.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'comment_list_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CommentListResponse _$CommentListResponseFromJson(Map<String, dynamic> json) =>
+    CommentListResponse(
+      uuid: json['uuid'] as String,
+      content: json['content'] as String,
+      user: UserData.fromJson(json['user'] as Map<String, dynamic>),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+
+Map<String, dynamic> _$CommentListResponseToJson(
+        CommentListResponse instance) =>
+    <String, dynamic>{
+      'uuid': instance.uuid,
+      'content': instance.content,
+      'user': instance.user,
+      'createdAt': instance.createdAt.toIso8601String(),
+    };

--- a/lib/data/entity/response/comment_list_response.g.dart
+++ b/lib/data/entity/response/comment_list_response.g.dart
@@ -8,17 +8,13 @@ part of 'comment_list_response.dart';
 
 CommentListResponse _$CommentListResponseFromJson(Map<String, dynamic> json) =>
     CommentListResponse(
-      uuid: json['uuid'] as String,
-      content: json['content'] as String,
-      user: UserData.fromJson(json['user'] as Map<String, dynamic>),
-      createdAt: DateTime.parse(json['createdAt'] as String),
+      commentList: (json['commentList'] as List<dynamic>)
+          .map((e) => CommentData.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$CommentListResponseToJson(
         CommentListResponse instance) =>
     <String, dynamic>{
-      'uuid': instance.uuid,
-      'content': instance.content,
-      'user': instance.user,
-      'createdAt': instance.createdAt.toIso8601String(),
+      'commentList': instance.commentList,
     };

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -48,8 +48,6 @@ class VideoPlayProvider with ChangeNotifier {
         PAGESIZE, (index) => controllers[num + index].initialize()));
 
     playVideo();
-    currentPage++;
-
     WidgetsBinding.instance.addPostFrameCallback((_) => notifyListeners());
   }
 

--- a/lib/data/local/provider/video_play_provider.dart
+++ b/lib/data/local/provider/video_play_provider.dart
@@ -75,7 +75,7 @@ class VideoPlayProvider with ChangeNotifier {
     videoPlayerFutures = [];
     videoList = [];
     currentIndex = 0;
-    currentPage = 0;
+    currentPage = -1;
     isLast = false;
 
     WidgetsBinding.instance.addPostFrameCallback((_) => notifyListeners());

--- a/lib/data/remote/provider/comment_provider.dart
+++ b/lib/data/remote/provider/comment_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:pocket_pose/data/entity/response/comment_list_response.dart';
+import 'package:pocket_pose/data/remote/repository/comment_repository.dart';
+
+class CommentProvider extends ChangeNotifier {
+  CommentListResponse? _response;
+
+  CommentListResponse? get response => _response;
+
+  Future<void> getComments(String videoId) async {
+    try {
+      final repositoryResponse = await CommentRepository().getComments(videoId);
+      _response = repositoryResponse;
+
+      notifyListeners();
+    } catch (e) {
+      debugPrint('CommentRepository getComments 에러: $e');
+    }
+  }
+}

--- a/lib/data/remote/provider/comment_provider.dart
+++ b/lib/data/remote/provider/comment_provider.dart
@@ -32,4 +32,14 @@ class CommentProvider extends ChangeNotifier {
       debugPrint('CommentRepository postComment 에러: $e');
     }
   }
+
+  Future<void> deleteComment(String commentId) async {
+    try {
+      _isDeleteSuccess = await CommentRepository().deleteComment(commentId);
+
+      notifyListeners();
+    } catch (e) {
+      debugPrint('CommentRepository deleteComment 에러: $e');
+    }
+  }
 }

--- a/lib/data/remote/provider/comment_provider.dart
+++ b/lib/data/remote/provider/comment_provider.dart
@@ -4,6 +4,11 @@ import 'package:pocket_pose/data/remote/repository/comment_repository.dart';
 
 class CommentProvider extends ChangeNotifier {
   CommentListResponse? _response;
+  bool? _isPostSuccess;
+  bool? _isDeleteSuccess;
+
+  bool? get isPostSuccess => _isPostSuccess;
+  bool? get isDeleteSuccess => _isDeleteSuccess;
 
   CommentListResponse? get response => _response;
 
@@ -15,6 +20,16 @@ class CommentProvider extends ChangeNotifier {
       notifyListeners();
     } catch (e) {
       debugPrint('CommentRepository getComments 에러: $e');
+    }
+  }
+
+  Future<void> postComment(String videoId, String content) async {
+    try {
+      _isPostSuccess = await CommentRepository().postComment(videoId, content);
+
+      notifyListeners();
+    } catch (e) {
+      debugPrint('LikeRepository postLike 에러: $e');
     }
   }
 }

--- a/lib/data/remote/provider/comment_provider.dart
+++ b/lib/data/remote/provider/comment_provider.dart
@@ -29,7 +29,7 @@ class CommentProvider extends ChangeNotifier {
 
       notifyListeners();
     } catch (e) {
-      debugPrint('LikeRepository postLike 에러: $e');
+      debugPrint('CommentRepository postComment 에러: $e');
     }
   }
 }

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -20,7 +20,6 @@ const _userEmailKey = 'userEmail';
 class KaKaoLoginProvider extends ChangeNotifier {
   String? _accessToken;
   String? _refreshToken;
-  UserData? _user;
   KaKaoLoginResponse? _response;
 
   String get accessTokenKey => _accessTokenKey;
@@ -42,11 +41,6 @@ class KaKaoLoginProvider extends ChangeNotifier {
       debugPrint('카카오톡 로그인 성공! accessToken: ${token.accessToken}');
 
       _login(token.accessToken);
-
-      MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
-        MaterialPageRoute(builder: (context) => const MainScreen()),
-        (route) => false,
-      );
 
       Fluttertoast.showToast(
         msg: '성공적으로 로그인 되었습니다.',

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -4,6 +4,8 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/data/entity/response/kakao_login_response.dart';
 import 'package:pocket_pose/data/remote/repository/kakao_login_repository.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
+import 'package:pocket_pose/main.dart';
+import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/login_modal_content_widget.dart';
 
 const _storage = FlutterSecureStorage();
@@ -39,6 +41,11 @@ class KaKaoLoginProvider extends ChangeNotifier {
       debugPrint('카카오톡 로그인 성공! accessToken: ${token.accessToken}');
 
       _login(token.accessToken);
+
+      MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const MainScreen()),
+        (route) => false,
+      );
     } catch (error) {
       debugPrint('카카오톡으로 로그인 실패: $error');
     }
@@ -124,7 +131,9 @@ class KaKaoLoginProvider extends ChangeNotifier {
           top: Radius.circular(30.0),
         ),
       ),
-      builder: (BuildContext context) {
+      builder: (
+        BuildContext context,
+      ) {
         return const LoginModalContent();
       },
     );

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -42,21 +42,20 @@ class KaKaoLoginProvider extends ChangeNotifier {
 
       debugPrint('카카오톡 로그인 성공! accessToken: ${token.accessToken}');
 
-      _login(token.accessToken);
+      _login(token.accessToken).then((value) {
+        Fluttertoast.showToast(
+          msg: '성공적으로 로그인 되었습니다.',
+        );
+        final videoPlayProvider =
+            Provider.of<VideoPlayProvider>(mainContext, listen: false);
 
-      Fluttertoast.showToast(
-        msg: '성공적으로 로그인 되었습니다.',
-      );
+        videoPlayProvider.resetVideoPlayer();
 
-      MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
-        MaterialPageRoute(builder: (context) => const MainScreen()),
-        (route) => false,
-      );
-
-      final videoPlayProvider =
-          Provider.of<VideoPlayProvider>(mainContext, listen: false);
-
-      videoPlayProvider.resetVideoPlayer();
+        MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
+          MaterialPageRoute(builder: (context) => const MainScreen()),
+          (route) => false,
+        );
+      });
     } catch (error) {
       debugPrint('카카오톡으로 로그인 실패: $error');
     }

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -3,15 +3,21 @@ import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/data/entity/response/kakao_login_response.dart';
 import 'package:pocket_pose/data/remote/repository/kakao_login_repository.dart';
+import 'package:pocket_pose/domain/entity/user_data.dart';
 import 'package:pocket_pose/ui/widget/login_modal_content_widget.dart';
 
 const _storage = FlutterSecureStorage();
 const _accessTokenKey = 'kakaoAccessToken';
 const _refreshTokenKey = 'kakaoRefreshToken';
+const _userUserIdKey = 'userUserId';
+const _userNicknameKey = 'userNickname';
+const _userProfileImgKey = 'userProfileImg';
+const _userEmailKey = 'userEmail';
 
 class KaKaoLoginProvider extends ChangeNotifier {
   String? _accessToken;
   String? _refreshToken;
+  UserData? _user;
   KaKaoLoginResponse? _response;
 
   String get accessTokenKey => _accessTokenKey;
@@ -51,7 +57,7 @@ class KaKaoLoginProvider extends ChangeNotifier {
 
       storeAccessToken(
           repositoryResponse.accessToken, repositoryResponse.refreshToken);
-
+      storeUser(repositoryResponse.user);
       notifyListeners();
     } catch (e) {
       debugPrint('Error logging in: $e');
@@ -78,6 +84,28 @@ class KaKaoLoginProvider extends ChangeNotifier {
     _accessToken = accessToken;
     _refreshToken = refreshToken;
     notifyListeners();
+  }
+
+  Future<void> storeUser(UserData user) async {
+    await _storage.write(key: _userUserIdKey, value: user.userId);
+    await _storage.write(key: _userNicknameKey, value: user.nickname);
+    await _storage.write(key: _userProfileImgKey, value: user.profileImg);
+    await _storage.write(key: _userEmailKey, value: user.email);
+
+    notifyListeners();
+  }
+
+  Future<UserData> getUser() async {
+    final userId = await _storage.read(key: _userUserIdKey);
+    final nickname = await _storage.read(key: _userNicknameKey);
+    final profileImg = await _storage.read(key: _userProfileImgKey);
+    final email = await _storage.read(key: _userEmailKey);
+
+    return UserData(
+        userId: userId ?? '',
+        nickname: nickname ?? '',
+        profileImg: profileImg ?? '',
+        email: email ?? '');
   }
 
   Future<void> removeAccessToken() async {

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -3,11 +3,13 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/data/entity/response/kakao_login_response.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/repository/kakao_login_repository.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
 import 'package:pocket_pose/main.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/login_modal_content_widget.dart';
+import 'package:provider/provider.dart';
 
 const _storage = FlutterSecureStorage();
 const _accessTokenKey = 'kakaoAccessToken';
@@ -45,6 +47,16 @@ class KaKaoLoginProvider extends ChangeNotifier {
       Fluttertoast.showToast(
         msg: '성공적으로 로그인 되었습니다.',
       );
+
+      MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const MainScreen()),
+        (route) => false,
+      );
+
+      final videoPlayProvider =
+          Provider.of<VideoPlayProvider>(mainContext, listen: false);
+
+      videoPlayProvider.resetVideoPlayer();
     } catch (error) {
       debugPrint('카카오톡으로 로그인 실패: $error');
     }
@@ -54,13 +66,19 @@ class KaKaoLoginProvider extends ChangeNotifier {
     debugPrint('카카오톡 로그아웃');
     removeAccessToken();
 
+    Fluttertoast.showToast(
+      msg: '성공적으로 로그아웃 되었습니다.',
+    );
+
     MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
       MaterialPageRoute(builder: (context) => const MainScreen()),
       (route) => false,
     );
-    Fluttertoast.showToast(
-      msg: '성공적으로 로그아웃 되었습니다.',
-    );
+
+    final videoPlayProvider =
+        Provider.of<VideoPlayProvider>(mainContext, listen: false);
+
+    videoPlayProvider.resetVideoPlayer();
   }
 
   Future<void> _login(String kakaoAccessToken) async {

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/data/entity/response/kakao_login_response.dart';
@@ -46,6 +47,10 @@ class KaKaoLoginProvider extends ChangeNotifier {
         MaterialPageRoute(builder: (context) => const MainScreen()),
         (route) => false,
       );
+
+      Fluttertoast.showToast(
+        msg: '성공적으로 로그인 되었습니다.',
+      );
     } catch (error) {
       debugPrint('카카오톡으로 로그인 실패: $error');
     }
@@ -54,6 +59,14 @@ class KaKaoLoginProvider extends ChangeNotifier {
   void signOut() async {
     debugPrint('카카오톡 로그아웃');
     removeAccessToken();
+
+    MyApp.navigatorKey.currentState?.pushAndRemoveUntil(
+      MaterialPageRoute(builder: (context) => const MainScreen()),
+      (route) => false,
+    );
+    Fluttertoast.showToast(
+      msg: '성공적으로 로그아웃 되었습니다.',
+    );
   }
 
   Future<void> _login(String kakaoAccessToken) async {

--- a/lib/data/remote/repository/comment_repository.dart
+++ b/lib/data/remote/repository/comment_repository.dart
@@ -37,4 +37,33 @@ class CommentRepository {
       throw Exception('댓글 목록 조회 실패');
     }
   }
+
+  Future<bool> postComment(String videoId, String content) async {
+    final url = Uri.parse('${AppUrl.commentUrl}/$videoId');
+
+    final accessToken = await _storage.read(key: _accessTokenKey);
+    final refreshToken = await _storage.read(key: _refreshTokenKey);
+
+    final headers = <String, String>{
+      'Content-Type': 'application/json;charset=UTF-8',
+      if (accessToken != null && refreshToken != null)
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+    };
+
+    final Map<String, dynamic> body = {
+      'content': content,
+    };
+
+    final response =
+        await http.post(url, headers: headers, body: jsonEncode(body));
+    final json = jsonDecode(utf8.decode(response.bodyBytes));
+
+    if (response.statusCode == 200) {
+      debugPrint("댓글 등록 성공! json: $json");
+      return true;
+    } else {
+      debugPrint('댓글 등록 실패 json $json');
+      return false;
+    }
+  }
 }

--- a/lib/data/remote/repository/comment_repository.dart
+++ b/lib/data/remote/repository/comment_repository.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:pocket_pose/config/api_url.dart';
+import 'package:pocket_pose/data/entity/response/comment_list_response.dart';
+import 'package:pocket_pose/domain/entity/comment_data.dart';
+
+const _storage = FlutterSecureStorage();
+const _accessTokenKey = 'kakaoAccessToken';
+const _refreshTokenKey = 'kakaoRefreshToken';
+
+class CommentRepository {
+  Future<CommentListResponse> getComments(String videoId) async {
+    final url = Uri.parse('${AppUrl.commentUrl}/$videoId');
+
+    final headers = <String, String>{
+      'Content-Type': 'application/json;charset=UTF-8',
+    };
+
+    final response = await http.get(url, headers: headers);
+
+    if (response.statusCode == 200) {
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      debugPrint("댓글 목록 조회 성공! json: $json");
+
+      final List<dynamic> commentListJson = json['data']['commentList'];
+      final List<CommentData> commentList = commentListJson
+          .map((commentJson) => CommentData.fromJson(commentJson))
+          .toList();
+
+      return CommentListResponse(
+        commentList: commentList,
+      );
+    } else {
+      throw Exception('댓글 목록 조회 실패');
+    }
+  }
+}

--- a/lib/data/remote/repository/comment_repository.dart
+++ b/lib/data/remote/repository/comment_repository.dart
@@ -66,4 +66,28 @@ class CommentRepository {
       return false;
     }
   }
+
+  Future<bool> deleteComment(String commentId) async {
+    final url = Uri.parse('${AppUrl.commentUrl}/$commentId');
+
+    final accessToken = await _storage.read(key: _accessTokenKey);
+    final refreshToken = await _storage.read(key: _refreshTokenKey);
+
+    final headers = <String, String>{
+      'Content-Type': 'application/json;charset=UTF-8',
+      if (accessToken != null && refreshToken != null)
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+    };
+
+    final response = await http.delete(url, headers: headers);
+    final json = jsonDecode(utf8.decode(response.bodyBytes));
+
+    if (response.statusCode == 200) {
+      debugPrint("댓글 삭제 성공! json: $json");
+      return true;
+    } else {
+      debugPrint('댓글 삭제 실패 json $json');
+      return false;
+    }
+  }
 }

--- a/lib/data/remote/repository/home_repository.dart
+++ b/lib/data/remote/repository/home_repository.dart
@@ -1,15 +1,23 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/request/home_videos_request.dart';
 import 'package:pocket_pose/data/entity/response/home_videos_response.dart';
 import 'package:pocket_pose/domain/entity/video_data.dart';
 
+const _storage = FlutterSecureStorage();
+const _accessTokenKey = 'kakaoAccessToken';
+const _refreshTokenKey = 'kakaoRefreshToken';
+
 class HomeRepository {
   Future<HomeVideosResponse> getVideos(
       HomeVideosRequest homeVideosRequest) async {
+    final accessToken = await _storage.read(key: _accessTokenKey);
+    final refreshToken = await _storage.read(key: _refreshTokenKey);
+
     final url = Uri.parse(AppUrl.homeVideosUrl).replace(queryParameters: {
       'page': homeVideosRequest.page.toString(),
       'size': homeVideosRequest.size.toString(),
@@ -17,6 +25,8 @@ class HomeRepository {
 
     final headers = {
       'Content-Type': 'application/json;charset=UTF-8',
+      if (accessToken != null && refreshToken != null)
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
     };
 
     final response = await http.get(url, headers: headers);

--- a/lib/data/remote/repository/kakao_login_repository.dart
+++ b/lib/data/remote/repository/kakao_login_repository.dart
@@ -36,7 +36,7 @@ class KaKaoLoginRepository {
       debugPrint("json: $json");
 
       final user = UserData(
-        uuid: json['data']['uuid'],
+        userId: json['data']['userId'],
         nickname: json['data']['nickname'],
         email: json['data']['email'],
         profileImg: json['data']['profileImg'],

--- a/lib/data/remote/repository/like_repository.dart
+++ b/lib/data/remote/repository/like_repository.dart
@@ -44,9 +44,6 @@ class LikeRepository {
     final accessToken = await _storage.read(key: _accessTokenKey);
     final refreshToken = await _storage.read(key: _refreshTokenKey);
 
-    // debugPrint('좋아요 엑세스토큰 $accessToken');
-    // debugPrint('좋아요 리프레시토큰 $refreshToken');
-
     final headers = <String, String>{
       'Content-Type': 'application/json;charset=UTF-8',
       if (accessToken != null && refreshToken != null)

--- a/lib/data/remote/repository/like_repository.dart
+++ b/lib/data/remote/repository/like_repository.dart
@@ -17,9 +17,6 @@ class LikeRepository {
     final accessToken = await _storage.read(key: _accessTokenKey);
     final refreshToken = await _storage.read(key: _refreshTokenKey);
 
-    // debugPrint('좋아요 엑세스토큰 $accessToken');
-    // debugPrint('좋아요 리프레시토큰 $refreshToken');
-
     final headers = <String, String>{
       'Content-Type': 'application/json;charset=UTF-8',
       if (accessToken != null && refreshToken != null)

--- a/lib/domain/entity/comment_data.dart
+++ b/lib/domain/entity/comment_data.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/domain/entity/user_data.dart';
+
+part 'comment_data.g.dart';
+
+@JsonSerializable()
+class CommentData {
+  final String uuid;
+  final String content;
+  final UserData user;
+  final DateTime createdAt;
+
+  const CommentData({
+    required this.uuid,
+    required this.content,
+    required this.user,
+    required this.createdAt,
+  });
+
+  factory CommentData.fromJson(Map<String, dynamic> json) =>
+      _$CommentDataFromJson(json);
+  Map<String, dynamic> toJson() => _$CommentDataToJson(this);
+}

--- a/lib/domain/entity/comment_data.g.dart
+++ b/lib/domain/entity/comment_data.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'comment_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CommentData _$CommentDataFromJson(Map<String, dynamic> json) => CommentData(
+      uuid: json['uuid'] as String,
+      content: json['content'] as String,
+      user: UserData.fromJson(json['user'] as Map<String, dynamic>),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+
+Map<String, dynamic> _$CommentDataToJson(CommentData instance) =>
+    <String, dynamic>{
+      'uuid': instance.uuid,
+      'content': instance.content,
+      'user': instance.user,
+      'createdAt': instance.createdAt.toIso8601String(),
+    };

--- a/lib/domain/entity/user_data.dart
+++ b/lib/domain/entity/user_data.dart
@@ -4,13 +4,13 @@ part 'user_data.g.dart';
 
 @JsonSerializable()
 class UserData {
-  final String uuid;
+  final String userId;
   final String nickname;
   final String? profileImg;
   final String? email;
 
   const UserData({
-    required this.uuid,
+    required this.userId,
     required this.nickname,
     required this.profileImg,
     required this.email,

--- a/lib/domain/entity/user_data.g.dart
+++ b/lib/domain/entity/user_data.g.dart
@@ -9,13 +9,13 @@ part of 'user_data.dart';
 UserData _$UserDataFromJson(Map<String, dynamic> json) => UserData(
       uuid: json['uuid'] as String,
       nickname: json['nickname'] as String,
-      profileImg: json['profileImg'] as String? ?? '',
-      email: json['email'] as String? ?? '',
+      profileImg: json['profileImg'] as String?,
+      email: json['email'] as String?,
     );
 
 Map<String, dynamic> _$UserDataToJson(UserData instance) => <String, dynamic>{
       'uuid': instance.uuid,
       'nickname': instance.nickname,
-      'profileImg': instance.profileImg ?? '',
-      'email': instance.email ?? '',
+      'profileImg': instance.profileImg,
+      'email': instance.email,
     };

--- a/lib/domain/entity/user_data.g.dart
+++ b/lib/domain/entity/user_data.g.dart
@@ -7,14 +7,14 @@ part of 'user_data.dart';
 // **************************************************************************
 
 UserData _$UserDataFromJson(Map<String, dynamic> json) => UserData(
-      uuid: json['uuid'] as String,
+      userId: json['userId'] as String,
       nickname: json['nickname'] as String,
       profileImg: json['profileImg'] as String?,
       email: json['email'] as String?,
     );
 
 Map<String, dynamic> _$UserDataToJson(UserData instance) => <String, dynamic>{
-      'uuid': instance.uuid,
+      'userId': instance.userId,
       'nickname': instance.nickname,
       'profileImg': instance.profileImg,
       'email': instance.email,

--- a/lib/domain/entity/video_data.dart
+++ b/lib/domain/entity/video_data.dart
@@ -14,7 +14,7 @@ class VideoData {
   late int commentCount;
   final int length;
   final DateTime createdAt;
-  final bool liked;
+  late bool liked;
 
   VideoData({
     required this.uuid,

--- a/lib/domain/entity/video_data.dart
+++ b/lib/domain/entity/video_data.dart
@@ -10,13 +10,13 @@ class VideoData {
   final String tag;
   final UserData user;
   final String videoUrl;
-  final int likeCount;
-  final int commentCount;
+  late int likeCount;
+  late int commentCount;
   final int length;
   final DateTime createdAt;
   final bool liked;
 
-  const VideoData({
+  VideoData({
     required this.uuid,
     required this.title,
     required this.tag,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,8 @@ Future<void> main() async {
 
 class MyApp extends StatelessWidget {
   final bool showOnBoarding;
+  static final GlobalKey<NavigatorState> navigatorKey =
+      GlobalKey<NavigatorState>();
 
   const MyApp({super.key, required this.showOnBoarding});
 
@@ -49,6 +51,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(fontFamily: 'GmarketSans'),
       themeMode: ThemeMode.system,
       home: showOnBoarding ? const OnBoardingScreen() : const MainScreen(),
+      navigatorKey: navigatorKey,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:pocket_pose/data/local/provider/local_pref_provider.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
+import 'package:pocket_pose/data/remote/provider/comment_provider.dart';
 
 import 'package:pocket_pose/data/remote/provider/home_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
@@ -31,6 +32,7 @@ Future<void> main() async {
     ChangeNotifierProvider(create: (_) => KaKaoLoginProvider()),
     ChangeNotifierProvider(create: (_) => HomeProvider()),
     ChangeNotifierProvider(create: (_) => LikeProvider()),
+    ChangeNotifierProvider(create: (_) => CommentProvider()),
     ChangeNotifierProvider(create: (_) => StageProviderImpl()),
   ], child: MyApp(showOnBoarding: showOnBoarding)));
 }

--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
+import 'package:pocket_pose/domain/entity/user_data.dart';
 import 'package:pocket_pose/ui/video_viewer/screen/video_someone_screen.dart';
 import 'package:pocket_pose/ui/screen/profile/profile_edit_screen.dart';
 import 'package:pocket_pose/ui/video_viewer/screen/video_my_screen.dart';
@@ -21,6 +22,7 @@ class ProfileScreen extends StatefulWidget {
 class _ProfileScreenState extends State<ProfileScreen>
     with SingleTickerProviderStateMixin {
   late KaKaoLoginProvider _loginProvider;
+  late UserData _user;
 
   final List<String> _videoImagePath1 = [
     "profile_video_0",
@@ -67,6 +69,18 @@ class _ProfileScreenState extends State<ProfileScreen>
     _tabController = TabController(length: 2, vsync: this);
   }
 
+  Future<bool> _initUser() async {
+    if (await _loginProvider.checkAccessToken()) {
+      UserData user = await _loginProvider.getUser();
+      setState(() {
+        _user = user;
+      });
+
+      return true;
+    }
+    return false;
+  }
+
   @override
   void dispose() {
     _tabController.dispose();
@@ -79,7 +93,7 @@ class _ProfileScreenState extends State<ProfileScreen>
     _loginProvider = Provider.of<KaKaoLoginProvider>(context, listen: true);
 
     return FutureBuilder<bool>(
-      future: _loginProvider.checkAccessToken(),
+      future: _initUser(),
       builder: (context, snapshot) {
         if (snapshot.data == true) {
           return Scaffold(
@@ -123,7 +137,9 @@ class _ProfileScreenState extends State<ProfileScreen>
                           )
                         ],
                       ),
-                      ProfileUserInfoWidget(index: 0), //사용자 index
+                      ProfileUserInfoWidget(
+                        user: _user,
+                      ),
                     ],
                   ),
                 ),

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -99,6 +99,7 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
                     },
                     onConfirm: () {
                       _loginProvider.signOut();
+                      _videoProvider.resetVideoPlayer();
                     },
                   );
                 })

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
-import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/profile/custom_simple_dialog.dart';
 import 'package:provider/provider.dart';
 
@@ -100,16 +98,7 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
                       Navigator.pop(context);
                     },
                     onConfirm: () {
-                      Fluttertoast.showToast(
-                        msg: '성공적으로 로그아웃 되었습니다.',
-                      );
                       _loginProvider.signOut();
-                      Navigator.pushAndRemoveUntil(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const MainScreen()),
-                        (route) => false,
-                      );
                     },
                   );
                 })

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -99,7 +99,6 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
                     },
                     onConfirm: () {
                       _loginProvider.signOut();
-                      _videoProvider.resetVideoPlayer();
                     },
                   );
                 })

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/profile/custom_simple_dialog.dart';
@@ -16,7 +17,7 @@ class ProfileSettingScreen extends StatefulWidget {
 
 class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
   late KaKaoLoginProvider _loginProvider;
-
+  late VideoPlayProvider _videoProvider;
   @override
   void initState() {
     super.initState();
@@ -25,6 +26,7 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
   @override
   Widget build(BuildContext context) {
     _loginProvider = Provider.of<KaKaoLoginProvider>(context);
+    _videoProvider = Provider.of<VideoPlayProvider>(context);
 
     return Scaffold(
       appBar: AppBar(
@@ -102,6 +104,7 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
                         msg: '성공적으로 로그아웃 되었습니다.',
                       );
                       _loginProvider.signOut();
+                      _videoProvider.resetVideo();
                       Navigator.pushAndRemoveUntil(
                         context,
                         MaterialPageRoute(

--- a/lib/ui/video_viewer/screen/video_someone_screen.dart
+++ b/lib/ui/video_viewer/screen/video_someone_screen.dart
@@ -4,7 +4,7 @@ import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
 import 'package:pocket_pose/ui/video_viewer/video_view.dart';
-import 'package:pocket_pose/ui/video_viewer/widget/chat_button_widget.dart';
+import 'package:pocket_pose/ui/video_viewer/widget/comment_button_widget.dart';
 import 'package:provider/provider.dart';
 
 // ignore: must_be_immutable
@@ -37,6 +37,7 @@ class _VideoSomeoneScreenState extends State<VideoSomeoneScreen> {
   @override
   Widget build(BuildContext context) {
     UserData user = _videoPlayProvider.videoList[widget.index].user;
+    final video = _videoPlayProvider.videoList[widget.index];
 
     return Scaffold(
         appBar: AppBar(
@@ -78,8 +79,9 @@ class _VideoSomeoneScreenState extends State<VideoSomeoneScreen> {
                         )),
               const Padding(padding: EdgeInsets.only(left: 18)),
               Expanded(
-                child: ChatButtonWidget(
-                  index: widget.index,
+                child: CommentButtonWidget(
+                  videoId: video.uuid,
+                  commentCount: video.commentCount,
                   childWidget: Container(
                     height: 36,
                     decoration: BoxDecoration(

--- a/lib/ui/video_viewer/screen/video_someone_screen.dart
+++ b/lib/ui/video_viewer/screen/video_someone_screen.dart
@@ -80,6 +80,10 @@ class _VideoSomeoneScreenState extends State<VideoSomeoneScreen> {
               const Padding(padding: EdgeInsets.only(left: 18)),
               Expanded(
                 child: CommentButtonWidget(
+                  index: widget.index,
+                  onRefresh: () {
+                    setState(() {});
+                  },
                   videoId: video.uuid,
                   commentCount: video.commentCount,
                   childWidget: Container(

--- a/lib/ui/video_viewer/video_right_frame.dart
+++ b/lib/ui/video_viewer/video_right_frame.dart
@@ -34,6 +34,10 @@ class _VideoRightFrameState extends State<VideoRightFrame> {
             LikeButtonWidget(index: widget.index),
             const Padding(padding: EdgeInsets.only(bottom: 14)),
             CommentButtonWidget(
+              index: widget.index,
+              onRefresh: () {
+                setState(() {});
+              },
               videoId: video.uuid,
               commentCount: video.commentCount,
               childWidget: Column(

--- a/lib/ui/video_viewer/video_right_frame.dart
+++ b/lib/ui/video_viewer/video_right_frame.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
-import 'package:pocket_pose/ui/video_viewer/widget/chat_button_widget.dart';
+import 'package:pocket_pose/ui/video_viewer/widget/comment_button_widget.dart';
 import 'package:pocket_pose/ui/video_viewer/widget/like_button_widget.dart';
 import 'package:pocket_pose/ui/video_viewer/widget/share_button_widget.dart';
 import 'package:provider/provider.dart';
@@ -21,6 +21,7 @@ class _VideoRightFrameState extends State<VideoRightFrame> {
   @override
   Widget build(BuildContext context) {
     _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+    final video = _videoPlayProvider.videoList[widget.index];
 
     return Positioned(
       right: 12,
@@ -32,8 +33,9 @@ class _VideoRightFrameState extends State<VideoRightFrame> {
           children: <Widget>[
             LikeButtonWidget(index: widget.index),
             const Padding(padding: EdgeInsets.only(bottom: 14)),
-            ChatButtonWidget(
-              index: widget.index,
+            CommentButtonWidget(
+              videoId: video.uuid,
+              commentCount: video.commentCount,
               childWidget: Column(
                 children: <Widget>[
                   SvgPicture.asset(
@@ -41,7 +43,7 @@ class _VideoRightFrameState extends State<VideoRightFrame> {
                   ),
                   const Padding(padding: EdgeInsets.only(bottom: 2)),
                   Text(
-                    '${_videoPlayProvider.videoList[widget.index].commentCount}',
+                    '${video.commentCount}',
                     style: const TextStyle(color: Colors.white, fontSize: 12),
                   ),
                 ],

--- a/lib/ui/video_viewer/video_user_info_frame.dart
+++ b/lib/ui/video_viewer/video_user_info_frame.dart
@@ -37,7 +37,8 @@ class VideoUserInfoFrame extends StatelessWidget {
                     ClipRRect(
                         borderRadius: BorderRadius.circular(50),
                         child: Image.network(
-                          user.profileImg!,
+                          user.profileImg ??
+                              'assets/images/charactor_popo_default.png',
                           loadingBuilder: (context, child, loadingProgress) {
                             if (loadingProgress == null) return child;
                             return Center(

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -46,7 +46,7 @@ class _VideoViewState extends State<VideoView>
 
       homeProvider
           .getVideos(HomeVideosRequest(
-              page: _videoPlayProvider.currentPage,
+              page: _videoPlayProvider.currentPage++,
               size: _videoPlayProvider.PAGESIZE))
           .then((value) {
         final response = homeProvider.response;
@@ -59,7 +59,6 @@ class _VideoViewState extends State<VideoView>
             }
 
             if (response.videoList.isNotEmpty) {
-              _videoPlayProvider.currentPage++;
               _videoPlayProvider.addVideos(response.videoList);
             }
           });

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -126,29 +126,36 @@ class _VideoViewState extends State<VideoView>
             allowImplicitScrolling: true,
             itemCount: 200,
             itemBuilder: (context, index) {
-              if (index < _videoPlayProvider.videoList.length) {
-                // 현재 비디오 인덱스 안에 있는 경우
-                return FutureBuilder(
-                  future: _videoPlayProvider
-                      .videoPlayerFutures[_videoPlayProvider.currentIndex],
-                  builder: (context, snapshot) {
-                    if (snapshot.connectionState == ConnectionState.done ||
-                        (snapshot.connectionState == ConnectionState.waiting &&
-                            _videoPlayProvider.loading)) {
-                      // 비디오가 준비된 경우
-                      _videoPlayProvider.loading = true;
-                      return buildVideoPlayer(index); // 비디오 플레이어 생성
-                    } else {
-                      return const MusicSpinner(); // 비디오 로딩 중
-                    }
-                  },
-                );
-              } else {
+              if (_videoPlayProvider.videoList.isEmpty) {
+                _loadMoreVideos();
                 _videoPlayProvider.loading = false;
-                if (_videoPlayProvider.currentIndex <= 0) {
-                  return const MusicSpinner(); // 비디오 로딩 중
+                return const MusicSpinner(); // 비디오 로딩 중
+              } else {
+                if (index < _videoPlayProvider.videoList.length) {
+                  // 현재 비디오 인덱스 안에 있는 경우
+                  return FutureBuilder(
+                    future: _videoPlayProvider
+                        .videoPlayerFutures[_videoPlayProvider.currentIndex],
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.done ||
+                          (snapshot.connectionState ==
+                                  ConnectionState.waiting &&
+                              _videoPlayProvider.loading)) {
+                        // 비디오가 준비된 경우
+                        _videoPlayProvider.loading = true;
+                        return buildVideoPlayer(index); // 비디오 플레이어 생성
+                      } else {
+                        return const MusicSpinner(); // 비디오 로딩 중
+                      }
+                    },
+                  );
                 } else {
-                  return Container(color: Colors.black);
+                  _videoPlayProvider.loading = false;
+                  if (_videoPlayProvider.currentIndex <= 0) {
+                    return const MusicSpinner(); // 비디오 로딩 중
+                  } else {
+                    return Container(color: Colors.black);
+                  }
                 }
               }
             },

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/comment_provider.dart';
@@ -251,11 +252,35 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                               padding:
                                                   const EdgeInsets.fromLTRB(
                                                       0, 4, 18, 12),
-                                              child: Text(
-                                                '삭제',
-                                                style: TextStyle(
-                                                    fontSize: 10,
-                                                    color: AppColor.grayColor2),
+                                              child: GestureDetector(
+                                                onTap: () {
+                                                  _commentProvider
+                                                      .deleteComment(
+                                                          _commentList?[index]
+                                                                  .uuid ??
+                                                              '')
+                                                      .then((value) {
+                                                    _loadCommentList(
+                                                        bottomState);
+                                                    Fluttertoast.showToast(
+                                                        msg: '댓글이 삭제되었습니다.');
+                                                    bottomState(() {
+                                                      setState(() {
+                                                        _videoPlayProvider
+                                                            .videoList[
+                                                                widget.index]
+                                                            .commentCount--;
+                                                      });
+                                                    });
+                                                  });
+                                                },
+                                                child: Text(
+                                                  '삭제',
+                                                  style: TextStyle(
+                                                      fontSize: 10,
+                                                      color:
+                                                          AppColor.grayColor2),
+                                                ),
                                               ),
                                             ),
                                           ],

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -4,6 +4,7 @@ import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/comment_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/entity/comment_data.dart';
+import 'package:pocket_pose/domain/entity/user_data.dart';
 import 'package:provider/provider.dart';
 
 // ignore: must_be_immutable
@@ -36,6 +37,7 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
   late final VideoPlayProvider _videoPlayProvider =
       Provider.of<VideoPlayProvider>(context, listen: false);
   bool _isInit = false;
+  late UserData user;
 
   String _profileImg = 'assets/images/charactor_popo_default.png';
   String _hintText = '따듯한 말 한마디 남겨 주세요 💛';
@@ -71,7 +73,7 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
 
   void _initUser(StateSetter bottomState) async {
     if (await _loginProvider.checkAccessToken()) {
-      final user = await _loginProvider.getUser();
+      user = await _loginProvider.getUser();
       bottomState(() {
         setState(() {
           _profileImg =
@@ -152,85 +154,109 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                       itemCount: _commentList?.length,
                                       itemBuilder: (context, index) {
                                         return Row(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.spaceBetween,
                                           crossAxisAlignment:
                                               CrossAxisAlignment.start,
                                           children: [
-                                            const Padding(
-                                                padding:
-                                                    EdgeInsets.only(left: 18)),
-                                            ClipRRect(
-                                                borderRadius:
-                                                    BorderRadius.circular(50),
-                                                child: Image.network(
-                                                  _commentList?[index]
-                                                          .user
-                                                          .profileImg ??
-                                                      'assets/images/charactor_popo_default.png',
-                                                  loadingBuilder: (context,
-                                                      child, loadingProgress) {
-                                                    if (loadingProgress ==
-                                                        null) {
-                                                      return child;
-                                                    }
-                                                    return Center(
-                                                      child:
-                                                          CircularProgressIndicator(
-                                                        color: AppColor
-                                                            .purpleColor,
+                                            Padding(
+                                              padding:
+                                                  const EdgeInsets.fromLTRB(
+                                                      18, 4, 0, 12),
+                                              child: Row(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.start,
+                                                children: [
+                                                  ClipRRect(
+                                                      borderRadius:
+                                                          BorderRadius.circular(
+                                                              50),
+                                                      child: Image.network(
+                                                        _commentList?[index]
+                                                                .user
+                                                                .profileImg ??
+                                                            'assets/images/charactor_popo_default.png',
+                                                        loadingBuilder: (context,
+                                                            child,
+                                                            loadingProgress) {
+                                                          if (loadingProgress ==
+                                                              null) {
+                                                            return child;
+                                                          }
+                                                          return Center(
+                                                            child:
+                                                                CircularProgressIndicator(
+                                                              color: AppColor
+                                                                  .purpleColor,
+                                                            ),
+                                                          );
+                                                        },
+                                                        errorBuilder: (context,
+                                                                error,
+                                                                stackTrace) =>
+                                                            Image.asset(
+                                                          'assets/images/charactor_popo_default.png',
+                                                          fit: BoxFit.cover,
+                                                          width: 35,
+                                                          height: 35,
+                                                        ),
+                                                        fit: BoxFit.cover,
+                                                        width: 35,
+                                                        height: 35,
+                                                      )),
+                                                  const Padding(
+                                                      padding: EdgeInsets.only(
+                                                          left: 8)),
+                                                  Column(
+                                                    crossAxisAlignment:
+                                                        CrossAxisAlignment
+                                                            .start,
+                                                    children: [
+                                                      Text(
+                                                        _commentList?[index]
+                                                                .user
+                                                                .nickname ??
+                                                            '',
+                                                        style: const TextStyle(
+                                                            fontSize: 12),
                                                       ),
-                                                    );
-                                                  },
-                                                  errorBuilder: (context, error,
-                                                          stackTrace) =>
-                                                      Image.asset(
-                                                    'assets/images/charactor_popo_default.png',
-                                                    fit: BoxFit.cover,
-                                                    width: 35,
-                                                    height: 35,
+                                                      const Padding(
+                                                          padding:
+                                                              EdgeInsets.only(
+                                                                  bottom: 8)),
+                                                      Text(
+                                                        _commentList?[index]
+                                                                .content ??
+                                                            '',
+                                                        style: const TextStyle(
+                                                            fontSize: 14),
+                                                      ),
+                                                      const Padding(
+                                                          padding:
+                                                              EdgeInsets.only(
+                                                                  bottom: 4)),
+                                                      Text(
+                                                        '${_commentList?[index].createdAt.year}-${_commentList?[index].createdAt.month}-${_commentList?[index].createdAt.day} ${_commentList?[index].createdAt.hour}:${_commentList?[index].createdAt.minute}',
+                                                        style: TextStyle(
+                                                            fontSize: 10,
+                                                            color: AppColor
+                                                                .grayColor2),
+                                                      ),
+                                                    ],
                                                   ),
-                                                  fit: BoxFit.cover,
-                                                  width: 35,
-                                                  height: 35,
-                                                )),
-                                            const Padding(
-                                                padding:
-                                                    EdgeInsets.only(left: 8)),
-                                            Column(
-                                              crossAxisAlignment:
-                                                  CrossAxisAlignment.start,
-                                              children: [
-                                                Text(
-                                                  _commentList?[index]
-                                                          .user
-                                                          .nickname ??
-                                                      '',
-                                                  style: const TextStyle(
-                                                      fontSize: 12),
-                                                ),
-                                                const Padding(
-                                                    padding: EdgeInsets.only(
-                                                        bottom: 8)),
-                                                Text(
-                                                  _commentList?[index]
-                                                          .content ??
-                                                      '',
-                                                  style: const TextStyle(
-                                                      fontSize: 14),
-                                                ),
-                                                const Padding(
-                                                    padding: EdgeInsets.only(
-                                                        bottom: 4)),
-                                                Text(
-                                                  '${_commentList?[index].createdAt.year}-${_commentList?[index].createdAt.month}-${_commentList?[index].createdAt.day} ${_commentList?[index].createdAt.hour}:${_commentList?[index].createdAt.minute}',
-                                                  style: TextStyle(
-                                                      fontSize: 10,
-                                                      color:
-                                                          AppColor.grayColor2),
-                                                ),
-                                                const Padding(
-                                                    padding: EdgeInsets.only(
-                                                        bottom: 20)),
-                                              ],
+                                                ],
+                                              ),
+                                            ),
+                                            Padding(
+                                              padding:
+                                                  const EdgeInsets.fromLTRB(
+                                                      0, 4, 18, 12),
+                                              child: Text(
+                                                '삭제',
+                                                style: TextStyle(
+                                                    fontSize: 10,
+                                                    color: AppColor.grayColor2),
+                                              ),
                                             ),
                                           ],
                                         );

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -71,11 +71,12 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
 
   void _initUser(StateSetter bottomState) async {
     if (await _loginProvider.checkAccessToken()) {
+      final user = await _loginProvider.getUser();
       bottomState(() {
         setState(() {
           _profileImg =
-              _profileImg ?? 'assets/images/charactor_popo_default.png';
-          _hintText = '{user.nickname}(으)로 댓글 달기...';
+              user.profileImg ?? 'assets/images/charactor_popo_default.png';
+          _hintText = '${user.nickname}(으)로 댓글 달기...';
         });
       });
     }

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -117,7 +117,19 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-        onTap: () => {
+        onTap: () async => {
+              if (_isInit)
+                {
+                  if (await _loginProvider.checkAccessToken())
+                    {
+                      user = await _loginProvider.getUser(),
+                      setState(() {
+                        _profileImg = user.profileImg ??
+                            'assets/images/charactor_popo_default.png';
+                        _hintText = '${user.nickname}(으)로 댓글 달기...';
+                      }),
+                    }
+                },
               showModalBottomSheet(
                 context: context,
                 shape: const RoundedRectangleBorder(

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -39,7 +39,7 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
       Provider.of<VideoPlayProvider>(context, listen: false);
   bool _isInit = false;
   late UserData user;
-
+  bool _isNotEmptyComment = false;
   String _profileImg = 'assets/images/charactor_popo_default.png';
   String _hintText = '따듯한 말 한마디 남겨 주세요 💛';
 
@@ -59,13 +59,17 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
       _commentProvider.getComments(widget.videoId).then((value) {
         final newCommentList = _commentProvider.response?.commentList;
 
-        if (newCommentList != null && newCommentList.isNotEmpty) {
-          bottomState(() {
-            setState(() {
-              _commentList = newCommentList.reversed.toList();
-            });
+        bottomState(() {
+          setState(() {
+            _commentList = newCommentList?.reversed.toList();
+
+            // commentCount api 완성되면 삭제
+            _isNotEmptyComment =
+                _commentList != null || _commentList!.isNotEmpty;
+            // commentCount api 완성되면 주석 해제
+            // _isNotEmptyComment =_videoPlayProvider.videoList[widget.index].commentCount > 0;
           });
-        }
+        });
       });
     } catch (e) {
       debugPrint('댓글 목록 조회 api 호출 실패');
@@ -95,6 +99,11 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
 
       setState(() {
         _commentList = newCommentList?.reversed.toList();
+
+        // commentCount api 완성되면 삭제
+        _isNotEmptyComment = _commentList != null || _commentList!.isNotEmpty;
+        // commentCount api 완성되면 주석 해제
+        // _isNotEmptyComment =_videoPlayProvider.videoList[widget.index].commentCount > 0;
       });
     });
   }
@@ -147,147 +156,140 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                           ),
                           resizeToAvoidBottomInset: true,
                           body: Padding(
-                              padding: const EdgeInsets.only(bottom: 95),
-                              child: _commentList != null ||
-                                      _commentList!.isEmpty
-                                  ? ListView.builder(
-                                      controller: _scrollController,
-                                      itemCount: _commentList?.length,
-                                      itemBuilder: (context, index) {
-                                        return Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.spaceBetween,
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.start,
-                                          children: [
-                                            Padding(
-                                              padding:
-                                                  const EdgeInsets.fromLTRB(
-                                                      18, 4, 0, 12),
-                                              child: Row(
+                            padding: const EdgeInsets.only(bottom: 95),
+                            child: Visibility(
+                                visible: _isNotEmptyComment,
+                                replacement:
+                                    const Center(child: Text('등록된 댓글이 없습니다.')),
+                                child: ListView.builder(
+                                  controller: _scrollController,
+                                  itemCount: _commentList?.length,
+                                  itemBuilder: (context, index) {
+                                    return Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.spaceBetween,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Padding(
+                                          padding: const EdgeInsets.fromLTRB(
+                                              18, 4, 0, 12),
+                                          child: Row(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            children: [
+                                              ClipRRect(
+                                                  borderRadius:
+                                                      BorderRadius.circular(50),
+                                                  child: Image.network(
+                                                    _commentList?[index]
+                                                            .user
+                                                            .profileImg ??
+                                                        'assets/images/charactor_popo_default.png',
+                                                    loadingBuilder: (context,
+                                                        child,
+                                                        loadingProgress) {
+                                                      if (loadingProgress ==
+                                                          null) {
+                                                        return child;
+                                                      }
+                                                      return Center(
+                                                        child:
+                                                            CircularProgressIndicator(
+                                                          color: AppColor
+                                                              .purpleColor,
+                                                        ),
+                                                      );
+                                                    },
+                                                    errorBuilder: (context,
+                                                            error,
+                                                            stackTrace) =>
+                                                        Image.asset(
+                                                      'assets/images/charactor_popo_default.png',
+                                                      fit: BoxFit.cover,
+                                                      width: 35,
+                                                      height: 35,
+                                                    ),
+                                                    fit: BoxFit.cover,
+                                                    width: 35,
+                                                    height: 35,
+                                                  )),
+                                              const Padding(
+                                                  padding:
+                                                      EdgeInsets.only(left: 8)),
+                                              Column(
                                                 crossAxisAlignment:
                                                     CrossAxisAlignment.start,
                                                 children: [
-                                                  ClipRRect(
-                                                      borderRadius:
-                                                          BorderRadius.circular(
-                                                              50),
-                                                      child: Image.network(
-                                                        _commentList?[index]
-                                                                .user
-                                                                .profileImg ??
-                                                            'assets/images/charactor_popo_default.png',
-                                                        loadingBuilder: (context,
-                                                            child,
-                                                            loadingProgress) {
-                                                          if (loadingProgress ==
-                                                              null) {
-                                                            return child;
-                                                          }
-                                                          return Center(
-                                                            child:
-                                                                CircularProgressIndicator(
-                                                              color: AppColor
-                                                                  .purpleColor,
-                                                            ),
-                                                          );
-                                                        },
-                                                        errorBuilder: (context,
-                                                                error,
-                                                                stackTrace) =>
-                                                            Image.asset(
-                                                          'assets/images/charactor_popo_default.png',
-                                                          fit: BoxFit.cover,
-                                                          width: 35,
-                                                          height: 35,
-                                                        ),
-                                                        fit: BoxFit.cover,
-                                                        width: 35,
-                                                        height: 35,
-                                                      )),
+                                                  Text(
+                                                    _commentList?[index]
+                                                            .user
+                                                            .nickname ??
+                                                        '',
+                                                    style: const TextStyle(
+                                                        fontSize: 12),
+                                                  ),
                                                   const Padding(
                                                       padding: EdgeInsets.only(
-                                                          left: 8)),
-                                                  Column(
-                                                    crossAxisAlignment:
-                                                        CrossAxisAlignment
-                                                            .start,
-                                                    children: [
-                                                      Text(
-                                                        _commentList?[index]
-                                                                .user
-                                                                .nickname ??
-                                                            '',
-                                                        style: const TextStyle(
-                                                            fontSize: 12),
-                                                      ),
-                                                      const Padding(
-                                                          padding:
-                                                              EdgeInsets.only(
-                                                                  bottom: 8)),
-                                                      Text(
-                                                        _commentList?[index]
-                                                                .content ??
-                                                            '',
-                                                        style: const TextStyle(
-                                                            fontSize: 14),
-                                                      ),
-                                                      const Padding(
-                                                          padding:
-                                                              EdgeInsets.only(
-                                                                  bottom: 4)),
-                                                      Text(
-                                                        '${_commentList?[index].createdAt.year}-${_commentList?[index].createdAt.month}-${_commentList?[index].createdAt.day} ${_commentList?[index].createdAt.hour}:${_commentList?[index].createdAt.minute}',
-                                                        style: TextStyle(
-                                                            fontSize: 10,
-                                                            color: AppColor
-                                                                .grayColor2),
-                                                      ),
-                                                    ],
+                                                          bottom: 8)),
+                                                  Text(
+                                                    _commentList?[index]
+                                                            .content ??
+                                                        '',
+                                                    style: const TextStyle(
+                                                        fontSize: 14),
+                                                  ),
+                                                  const Padding(
+                                                      padding: EdgeInsets.only(
+                                                          bottom: 4)),
+                                                  Text(
+                                                    '${_commentList?[index].createdAt.year}-${_commentList?[index].createdAt.month}-${_commentList?[index].createdAt.day} ${_commentList?[index].createdAt.hour}:${_commentList?[index].createdAt.minute}',
+                                                    style: TextStyle(
+                                                        fontSize: 10,
+                                                        color: AppColor
+                                                            .grayColor2),
                                                   ),
                                                 ],
                                               ),
-                                            ),
-                                            Padding(
-                                              padding:
-                                                  const EdgeInsets.fromLTRB(
-                                                      0, 4, 18, 12),
-                                              child: GestureDetector(
-                                                onTap: () {
-                                                  _commentProvider
-                                                      .deleteComment(
-                                                          _commentList?[index]
-                                                                  .uuid ??
-                                                              '')
-                                                      .then((value) {
-                                                    _loadCommentList(
-                                                        bottomState);
-                                                    Fluttertoast.showToast(
-                                                        msg: '댓글이 삭제되었습니다.');
-                                                    bottomState(() {
-                                                      setState(() {
-                                                        _videoPlayProvider
-                                                            .videoList[
-                                                                widget.index]
-                                                            .commentCount--;
-                                                      });
-                                                    });
+                                            ],
+                                          ),
+                                        ),
+                                        Padding(
+                                          padding: const EdgeInsets.fromLTRB(
+                                              0, 4, 18, 12),
+                                          child: GestureDetector(
+                                            onTap: () {
+                                              _commentProvider
+                                                  .deleteComment(
+                                                      _commentList?[index]
+                                                              .uuid ??
+                                                          '')
+                                                  .then((value) {
+                                                _loadCommentList(bottomState);
+                                                Fluttertoast.showToast(
+                                                    msg: '댓글이 삭제되었습니다.');
+                                                bottomState(() {
+                                                  setState(() {
+                                                    _videoPlayProvider
+                                                        .videoList[widget.index]
+                                                        .commentCount--;
                                                   });
-                                                },
-                                                child: Text(
-                                                  '삭제',
-                                                  style: TextStyle(
-                                                      fontSize: 10,
-                                                      color:
-                                                          AppColor.grayColor2),
-                                                ),
-                                              ),
+                                                });
+                                              });
+                                            },
+                                            child: Text(
+                                              '삭제',
+                                              style: TextStyle(
+                                                  fontSize: 10,
+                                                  color: AppColor.grayColor2),
                                             ),
-                                          ],
-                                        );
-                                      },
-                                    )
-                                  : const Center(child: Text('등록된 댓글이 없습니다.'))),
+                                          ),
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                )),
+                          ),
                           bottomSheet: SizedBox(
                             height: 95,
                             child: Column(

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -125,83 +125,98 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                           ),
                           resizeToAvoidBottomInset: true,
                           body: Padding(
-                            padding: const EdgeInsets.only(bottom: 95),
-                            child: ListView.builder(
-                              controller: _scrollController,
-                              itemCount: _commentList?.length,
-                              itemBuilder: (context, index) {
-                                return Row(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    const Padding(
-                                        padding: EdgeInsets.only(left: 18)),
-                                    ClipRRect(
-                                        borderRadius: BorderRadius.circular(50),
-                                        child: Image.network(
-                                          _commentList?[index]
-                                                  .user
-                                                  .profileImg ??
-                                              'assets/images/charactor_popo_default.png',
-                                          loadingBuilder: (context, child,
-                                              loadingProgress) {
-                                            if (loadingProgress == null) {
-                                              return child;
-                                            }
-                                            return Center(
-                                              child: CircularProgressIndicator(
-                                                color: AppColor.purpleColor,
-                                              ),
-                                            );
-                                          },
-                                          errorBuilder:
-                                              (context, error, stackTrace) =>
-                                                  Image.asset(
-                                            'assets/images/charactor_popo_default.png',
-                                            fit: BoxFit.cover,
-                                            width: 35,
-                                            height: 35,
-                                          ),
-                                          fit: BoxFit.cover,
-                                          width: 35,
-                                          height: 35,
-                                        )),
-                                    const Padding(
-                                        padding: EdgeInsets.only(left: 8)),
-                                    Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          _commentList?[index].user.nickname ??
-                                              '',
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                        const Padding(
-                                            padding:
-                                                EdgeInsets.only(bottom: 8)),
-                                        Text(
-                                          _commentList?[index].content ?? '',
-                                          style: const TextStyle(fontSize: 14),
-                                        ),
-                                        const Padding(
-                                            padding:
-                                                EdgeInsets.only(bottom: 4)),
-                                        Text(
-                                          '${_commentList?[index].createdAt.year}-${_commentList?[index].createdAt.month}-${_commentList?[index].createdAt.day} ${_commentList?[index].createdAt.hour}:${_commentList?[index].createdAt.minute}',
-                                          style: TextStyle(
-                                              fontSize: 10,
-                                              color: AppColor.grayColor2),
-                                        ),
-                                        const Padding(
-                                            padding:
-                                                EdgeInsets.only(bottom: 20)),
-                                      ],
-                                    ),
-                                  ],
-                                );
-                              },
-                            ),
-                          ),
+                              padding: const EdgeInsets.only(bottom: 95),
+                              child: _commentList != null
+                                  ? ListView.builder(
+                                      controller: _scrollController,
+                                      itemCount: _commentList?.length,
+                                      itemBuilder: (context, index) {
+                                        return Row(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            const Padding(
+                                                padding:
+                                                    EdgeInsets.only(left: 18)),
+                                            ClipRRect(
+                                                borderRadius:
+                                                    BorderRadius.circular(50),
+                                                child: Image.network(
+                                                  _commentList?[index]
+                                                          .user
+                                                          .profileImg ??
+                                                      'assets/images/charactor_popo_default.png',
+                                                  loadingBuilder: (context,
+                                                      child, loadingProgress) {
+                                                    if (loadingProgress ==
+                                                        null) {
+                                                      return child;
+                                                    }
+                                                    return Center(
+                                                      child:
+                                                          CircularProgressIndicator(
+                                                        color: AppColor
+                                                            .purpleColor,
+                                                      ),
+                                                    );
+                                                  },
+                                                  errorBuilder: (context, error,
+                                                          stackTrace) =>
+                                                      Image.asset(
+                                                    'assets/images/charactor_popo_default.png',
+                                                    fit: BoxFit.cover,
+                                                    width: 35,
+                                                    height: 35,
+                                                  ),
+                                                  fit: BoxFit.cover,
+                                                  width: 35,
+                                                  height: 35,
+                                                )),
+                                            const Padding(
+                                                padding:
+                                                    EdgeInsets.only(left: 8)),
+                                            Column(
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.start,
+                                              children: [
+                                                Text(
+                                                  _commentList?[index]
+                                                          .user
+                                                          .nickname ??
+                                                      '',
+                                                  style: const TextStyle(
+                                                      fontSize: 12),
+                                                ),
+                                                const Padding(
+                                                    padding: EdgeInsets.only(
+                                                        bottom: 8)),
+                                                Text(
+                                                  _commentList?[index]
+                                                          .content ??
+                                                      '',
+                                                  style: const TextStyle(
+                                                      fontSize: 14),
+                                                ),
+                                                const Padding(
+                                                    padding: EdgeInsets.only(
+                                                        bottom: 4)),
+                                                Text(
+                                                  '${_commentList?[index].createdAt.year}-${_commentList?[index].createdAt.month}-${_commentList?[index].createdAt.day} ${_commentList?[index].createdAt.hour}:${_commentList?[index].createdAt.minute}',
+                                                  style: TextStyle(
+                                                      fontSize: 10,
+                                                      color:
+                                                          AppColor.grayColor2),
+                                                ),
+                                                const Padding(
+                                                    padding: EdgeInsets.only(
+                                                        bottom: 20)),
+                                              ],
+                                            ),
+                                          ],
+                                        );
+                                      },
+                                    )
+                                  : const Center(child: Text('등록된 댓글이 없습니다.'))),
                           bottomSheet: SizedBox(
                             height: 95,
                             child: Column(

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -93,9 +93,8 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
     } finally {}
   }
 
-  void initUser() async {
+  void _initUser() async {
     if (await _loginProvider.checkAccessToken()) {
-      // 로그인
       _profileImg = _profileImg ?? 'assets/images/charactor_popo_default.png';
       _hintText = '{user.nickname}(으)로 댓글 달기...';
     }
@@ -115,11 +114,10 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
 
   @override
   Widget build(BuildContext context) {
-    initUser();
-
     _commentProvider = Provider.of<CommentProvider>(context, listen: false);
     return InkWell(
         onTap: () => {
+              _initUser(),
               _loadCommentList(),
               showModalBottomSheet(
                 context: context,
@@ -327,65 +325,61 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                                     border: InputBorder.none,
                                                   ),
                                                   onTap: () async {
-                                                    bottomState(() {
-                                                      setState(() async {
-                                                        if (await _loginProvider
-                                                                .checkAccessToken() ==
-                                                            false) {
-                                                          FocusScope.of(context)
-                                                              .unfocus();
-                                                          Navigator.pop(
-                                                              context);
-                                                          _loginProvider
-                                                              .showLoginBottomSheet();
-                                                        }
-                                                      });
-                                                    });
+                                                    if (await _loginProvider
+                                                            .checkAccessToken() ==
+                                                        false) {
+                                                      FocusScope.of(context)
+                                                          .unfocus();
+                                                      Navigator.pop(context);
+                                                      _loginProvider
+                                                          .showLoginBottomSheet();
+                                                    }
                                                   },
                                                   onChanged: (text) {
                                                     bottomState(() {
                                                       setState(() {});
                                                     });
                                                   },
+                                                  onEditingComplete: () {
+                                                    if (_textController
+                                                        .text.isNotEmpty) {
+                                                      // 댓글 등록 api 호출
+                                                      _commentProvider
+                                                          .postComment(
+                                                              widget.videoId,
+                                                              _textController
+                                                                  .text)
+                                                          .then((value) {
+                                                        // 댓글 목록 새로고침
+                                                        _loadCommentList();
+                                                        _textController.clear();
+                                                        FocusScope.of(context)
+                                                            .unfocus();
+                                                      });
+                                                    }
+                                                  },
                                                 ),
                                               ),
                                               TextButton(
-                                                onPressed: () async {
-                                                  setState(() async {
-                                                    if (await _loginProvider
-                                                            .checkAccessToken() ==
-                                                        false) {
-                                                      Navigator.pop(context);
-                                                      _loginProvider
-                                                          .showLoginBottomSheet();
-                                                    } else {
-                                                      _textController
-                                                              .text.isNotEmpty
-                                                          ? () {
-                                                              // 댓글 작성
-                                                              _commentProvider
-                                                                  .postComment(
-                                                                      widget
-                                                                          .videoId,
-                                                                      _textController
-                                                                          .text)
-                                                                  .then(
-                                                                (value) {
-                                                                  // 댓글 목록 새로고침
-                                                                  _loadCommentList();
-                                                                  // 댓글 입력창 초기화
-                                                                  _textController
-                                                                      .clear();
-                                                                  FocusScope.of(
-                                                                          context)
-                                                                      .unfocus();
-                                                                },
-                                                              );
-                                                            }
-                                                          : null;
-                                                    }
-                                                  });
-                                                },
+                                                onPressed: _textController
+                                                        .text.isNotEmpty
+                                                    ? () {
+                                                        // 댓글 등록 api 호출
+                                                        _commentProvider
+                                                            .postComment(
+                                                                widget.videoId,
+                                                                _textController
+                                                                    .text)
+                                                            .then((value) {
+                                                          // 댓글 목록 새로고침
+                                                          _loadCommentList();
+                                                          _textController
+                                                              .clear();
+                                                          FocusScope.of(context)
+                                                              .unfocus();
+                                                        });
+                                                      }
+                                                    : null,
                                                 child: Text(
                                                   '게시',
                                                   style: TextStyle(

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -73,15 +73,14 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
 
   List<Widget> textWidgets = [];
 
-  late String _profileImg;
-  late String _hintText;
+  String _profileImg = 'assets/images/charactor_popo_default.png';
+  String _hintText = '따듯한 말 한마디 남겨 주세요 💛';
+  late CommentProvider _commentProvider;
 
   Future<void> _loadCommentList() async {
     try {
-      final commentProvider =
-          Provider.of<CommentProvider>(context, listen: false);
-      commentProvider.getComments(widget.videoId).then((value) {
-        final comments = commentProvider.response?.commentList;
+      _commentProvider.getComments(widget.videoId).then((value) {
+        final comments = _commentProvider.response?.commentList;
 
         if (comments != null && comments.isNotEmpty) {
           setState(() {
@@ -99,10 +98,6 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
       // 로그인
       _profileImg = _profileImg ?? 'assets/images/charactor_popo_default.png';
       _hintText = '{user.nickname}(으)로 댓글 달기...';
-    } else {
-      // 비로그인
-      _profileImg = 'assets/images/charactor_popo_default.png';
-      _hintText = '따듯한 말 한마디 남겨 주세요 💛';
     }
   }
 
@@ -110,7 +105,6 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
   void initState() {
     super.initState();
     _loginProvider = Provider.of<KaKaoLoginProvider>(context, listen: false);
-    initUser();
   }
 
   @override
@@ -121,6 +115,9 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
 
   @override
   Widget build(BuildContext context) {
+    initUser();
+
+    _commentProvider = Provider.of<CommentProvider>(context, listen: false);
     return InkWell(
         onTap: () => {
               _loadCommentList(),
@@ -271,7 +268,8 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                           borderRadius:
                                               BorderRadius.circular(50),
                                           child: Image.network(
-                                            _profileImg,
+                                            _profileImg ??
+                                                'assets/images/charactor_popo_default.png',
                                             loadingBuilder: (context, child,
                                                 loadingProgress) {
                                               if (loadingProgress == null) {
@@ -364,11 +362,25 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                                       _textController
                                                               .text.isNotEmpty
                                                           ? () {
-                                                              _textController
-                                                                  .clear();
-                                                              FocusScope.of(
-                                                                      context)
-                                                                  .unfocus();
+                                                              // 댓글 작성
+                                                              _commentProvider
+                                                                  .postComment(
+                                                                      widget
+                                                                          .videoId,
+                                                                      _textController
+                                                                          .text)
+                                                                  .then(
+                                                                (value) {
+                                                                  // 댓글 목록 새로고침
+                                                                  _loadCommentList();
+                                                                  // 댓글 입력창 초기화
+                                                                  _textController
+                                                                      .clear();
+                                                                  FocusScope.of(
+                                                                          context)
+                                                                      .unfocus();
+                                                                },
+                                                              );
                                                             }
                                                           : null;
                                                     }

--- a/lib/ui/video_viewer/widget/like_button_widget.dart
+++ b/lib/ui/video_viewer/widget/like_button_widget.dart
@@ -54,7 +54,8 @@ class _LikeButtonWidgetState extends State<LikeButtonWidget> {
             return !isLiked;
           } else {
             loginProvider.showLoginBottomSheet();
-            return likeProvider.isPostSuccess ?? false;
+
+            return isLiked;
           }
         },
         likeBuilder: (isLiked) {

--- a/lib/ui/video_viewer/widget/like_button_widget.dart
+++ b/lib/ui/video_viewer/widget/like_button_widget.dart
@@ -43,10 +43,13 @@ class _LikeButtonWidgetState extends State<LikeButtonWidget> {
         },
         onTap: (isLiked) async {
           if (await loginProvider.checkAccessToken()) {
+            video.liked = !isLiked;
             if (!isLiked) {
               likeProvider.postLike(video.uuid);
+              video.likeCount++;
             } else {
               likeProvider.deleteLike(video.uuid);
+              video.likeCount--;
             }
             return !isLiked;
           } else {

--- a/lib/ui/widget/not_login_widget.dart
+++ b/lib/ui/widget/not_login_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
+import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:provider/provider.dart';
 
 class NotLoginWidget extends StatefulWidget {
@@ -39,6 +40,10 @@ class _NotLoginWidgetState extends State<NotLoginWidget> {
               ),
               onPressed: () {
                 _loginProvider.signIn();
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (context) => const MainScreen()),
+                );
               },
               child: const Text(
                 "로그인",

--- a/lib/ui/widget/not_login_widget.dart
+++ b/lib/ui/widget/not_login_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
-import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:provider/provider.dart';
 
 class NotLoginWidget extends StatefulWidget {
@@ -40,10 +39,6 @@ class _NotLoginWidgetState extends State<NotLoginWidget> {
               ),
               onPressed: () {
                 _loginProvider.signIn();
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(builder: (context) => const MainScreen()),
-                );
               },
               child: const Text(
                 "로그인",

--- a/lib/ui/widget/profile/profile_user_info_widget.dart
+++ b/lib/ui/widget/profile/profile_user_info_widget.dart
@@ -1,21 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
-import 'package:pocket_pose/data/local/provider/video_play_provider.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
 import 'package:pocket_pose/ui/screen/profile/profile_follow_screen.dart';
-import 'package:provider/provider.dart';
 
 // ignore: must_be_immutable
 class ProfileUserInfoWidget extends StatelessWidget {
   ProfileUserInfoWidget({
     super.key,
-    required this.index,
+    required this.user,
   });
 
-  int index;
-
-  late VideoPlayProvider _videoPlayProvider;
+  final UserData user;
 
   List<String> videoLinks = [
     'https://popo2023.s3.ap-northeast-2.amazonaws.com/video/test/V2-2.mp4',
@@ -35,9 +31,6 @@ class ProfileUserInfoWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _videoPlayProvider = Provider.of<VideoPlayProvider>(context);
-    UserData user = _videoPlayProvider.videoList[index].user;
-
     return SizedBox(
       //color: Colors.yellow,
       height: 300,


### PR DESCRIPTION
## 📱 작업 사진 

### 로그인 전
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/8ea6eb66-1fe9-4481-8d82-bc919ea7d37e

### 로그인 후
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/e05032ea-e2b1-463b-9cde-ea8b201eb3e0

## 💬 작업 설명
댓글 관련 api를 연결했습니다.

## ✅ 한 일
1. 댓글 목록 조회 api 연결
2. 댓글 등록 api 연결
3. 댓글 삭제 api 연결
4. 로그인 하지 않은 경우 댓글 창에 들어올 수 있지만 textfield 왼쪽의 사용자 이미지는 포포 기본 이미지로 나오고, textfield의 문구는 기본 문구이며, textfield 클릭시 로그인 바텀 시트 등장
5. 로그인 한 경우 textfield 왼쪽엔 사용자 프로필 이미지, textfield 문구는 사용자 닉네임을 포함한 문구이며, textfield 클릭시 댓글 등록 가능
6. 본인이 올린 댓글의 왼쪽 상단에 '삭제' text 버튼이 생기고, 누르면 댓글 삭제 가능
7. 기타 오류 해결

## ☝️ 참고 하세요~
1. 서버 작업 전으로 영상의 댓글 수가 항상 0으로 나옵니다. 댓글 등록, 삭제시 값이 증가, 감소하는데 서버 작업 전으로 값이 생각과 다를 수 있습니다.
2. 서버 측 필드명 변경으로 인해 uuid를 userId로 변경했습니다.
3. **로그인 후 사용자 정보 유지** 기능 추가 했습니다.

> 로그인 프로바이더, 유저 데이터 생성 후
> `KaKaoLoginProvider _loginProvider;`
> `UserData _user;`
> 
> onTap과 같은 함수에 다음과 같이 적용해 사용하면 됩니다.
> `onTap: () async {`
> `    if (await loginProvider.checkAccessToken()) {  // 로그인 한 상태인지 확인`
> `         _user = await _loginProvider.getUser(); // 사용자 정보 받아오기`
> `    }`


4. **로그인 바텀시트**가 열리는 함수를 추가했습니다.
로그인 후 main 화면으로 돌아가 홈 영상을 다시 로딩합니다.

> 로그인 프로바이더 생성 후
> `KaKaoLoginProvider _loginProvider;`
> 
> onTap과 같은 함수에 다음과 같이 적용해 사용하면 됩니다.
> `onTap: () async {`
> `    if (await loginProvider.checkAccessToken()) {  // 로그인 한 상태인지 확인`
> `        // 로그인 한 경우의 동작`
> `    }`
> `   else {`
> `        loginProvider.showLoginBottomSheet();     // 로그인 바텀 시트 생성`
> `}`

## 💃 부탁 드립니다~
1. pull 하고 로그아웃, 로그인 다시 하고 테스트 해주셔야 합니다~

## 🤓 다음에 할 일
1. api 호출 후 새로 받아온 토큰으로 업데이트
2. 영상 삭제 api 연결