### PR TITLE
[bug][ui] 댓글창 overflow 해결, 이모티콘바 ui 변경 (HH-274)

### DIFF
--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -345,12 +345,23 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                 )),
                           ),
                           bottomSheet: SizedBox(
-                            height: 95,
+                            height: 100,
                             child: Column(
                               children: [
                                 Container(
-                                  height: 30,
-                                  color: Colors.white,
+                                  height: 35,
+                                  decoration: BoxDecoration(
+                                    color: Colors.white,
+                                    borderRadius: BorderRadius.circular(30),
+                                    boxShadow: [
+                                      BoxShadow(
+                                        color: Colors.grey.withOpacity(0.3),
+                                        spreadRadius: 0,
+                                        blurRadius: 10,
+                                        offset: const Offset(0, 5),
+                                      ),
+                                    ],
+                                  ),
                                   child: Row(
                                     mainAxisAlignment:
                                         MainAxisAlignment.spaceEvenly,

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -272,12 +272,18 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                                   const Padding(
                                                       padding: EdgeInsets.only(
                                                           bottom: 8)),
-                                                  Text(
-                                                    _commentList?[index]
-                                                            .content ??
-                                                        '',
-                                                    style: const TextStyle(
-                                                        fontSize: 14),
+                                                  SizedBox(
+                                                    width: 300,
+                                                    child: Text(
+                                                      _commentList?[index]
+                                                              .content ??
+                                                          '',
+                                                      style: const TextStyle(
+                                                          fontSize: 14),
+                                                      maxLines: 10,
+                                                      overflow:
+                                                          TextOverflow.ellipsis,
+                                                    ),
                                                   ),
                                                   const Padding(
                                                       padding: EdgeInsets.only(

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -149,7 +149,7 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                     }
 
                     return SizedBox(
-                      height: 500,
+                      height: 600,
                       child: ClipRRect(
                         borderRadius: const BorderRadius.only(
                           topLeft: Radius.circular(16.0),


### PR DESCRIPTION
## 📱 작업 사진 
> ### 수정 전
> <img width="283" alt="수정전" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/d839400f-e3e5-4b87-8246-cda287ba5e7a">
> 
> ### 수정 후
> <img width="281" alt="수정후" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/e0780c9a-fb5f-4224-8cb3-8c13d3ff72fa">

## 💬 작업 설명
댓글창의 ui를 수정했습니다.

## ✅ 한 일
1. 댓글 길게 썼을 때 생기는 overflow 해결
2. 댓글창 키보드로 인한 overflow 해결
    -> 이제 일본어든 이모티콘이든 어떤 키보드를 열어도 overflow 안 생길겁니다.

3. 댓글창 이모티콘 바 상단에 그림자 추가, 테두리 둥글게 수정
    -> 이모티콘바와 댓글 경계가 잘 구분되지 않아 추가했습니다.

## 🤓 다음에 할 일
1. 비디오 플레이 로직 변경
2. 검색 랜덤 영상 목록 api 연결