### PR TITLE
[feat] 스테이지 MVP 스켈레톤 소켓에 전송/응답 처리 (HH-325)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -36,5 +36,6 @@ class AppUrl {
   static const socketSubscribeStageUrl = "/topic/stage";
   static const socketTalkUrl = "/app/talks/messages";
   static const socketReactionUrl = "/app/talks/reactions";
-  static const socketSkeletonUrl = "/app/stage/play/skeleton";
+  static const socketPlaySkeletonUrl = "/app/stage/play/skeleton";
+  static const socketMVPSkeletonUrl = "/app/stage/mvp/skeleton";
 }

--- a/lib/data/entity/socket_request/send_skeleton_request.dart
+++ b/lib/data/entity/socket_request/send_skeleton_request.dart
@@ -7,12 +7,12 @@ import 'package:pocket_pose/domain/entity/stage_skeleton_pose_landmark.dart';
 
 @JsonSerializable()
 class SendSkeletonRequest {
-  final int playerNum;
+  final int? playerNum;
   final int frameNum;
   final Map<String, StageSkeletonPoseLandmark> skeleton;
 
   SendSkeletonRequest({
-    required this.playerNum,
+    this.playerNum,
     required this.frameNum,
     required this.skeleton,
   });

--- a/lib/data/entity/socket_response/send_skeleton_response.dart
+++ b/lib/data/entity/socket_response/send_skeleton_response.dart
@@ -7,13 +7,13 @@ import 'package:pocket_pose/domain/entity/stage_skeleton_pose_landmark.dart';
 @JsonSerializable()
 class SendSkeletonResponse extends BaseObject {
   String userId;
-  int playerNum;
+  int? playerNum;
   int frameNum;
   Map<String, StageSkeletonPoseLandmark> skeleton;
 
   SendSkeletonResponse({
     required this.userId,
-    required this.playerNum,
+    this.playerNum,
     required this.frameNum,
     required this.skeleton,
   });

--- a/lib/data/entity/socket_response/stage_mvp_response.dart
+++ b/lib/data/entity/socket_response/stage_mvp_response.dart
@@ -1,0 +1,24 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
+
+part 'stage_mvp_response.g.dart';
+
+@JsonSerializable()
+class StageMVPResponse extends BaseObject<StageMVPResponse> {
+  StageUserListItem? mvpUser;
+
+  StageMVPResponse(
+    this.mvpUser,
+  );
+
+  factory StageMVPResponse.fromJson(Map<String, dynamic> json) =>
+      _$StageMVPResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageMVPResponseToJson(this);
+
+  @override
+  fromJson(json) {
+    return StageMVPResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/socket_response/stage_mvp_response.g.dart
+++ b/lib/data/entity/socket_response/stage_mvp_response.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_mvp_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageMVPResponse _$StageMVPResponseFromJson(Map<String, dynamic> json) =>
+    StageMVPResponse(
+      json['mvpUser'] == null
+          ? null
+          : StageUserListItem.fromJson(json['mvpUser'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$StageMVPResponseToJson(StageMVPResponse instance) =>
+    <String, dynamic>{
+      'mvpUser': instance.mvpUser,
+    };

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -13,7 +13,6 @@ import 'package:pocket_pose/data/entity/socket_response/talk_message_response.da
 import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
 import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
-import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
 import 'package:pocket_pose/domain/provider/socket_stage_provider.dart';
 import 'package:pocket_pose/ui/view/popo_catch_view.dart';
 import 'package:pocket_pose/ui/view/popo_play_view.dart';
@@ -47,7 +46,7 @@ class SocketStageProviderImpl extends ChangeNotifier
 
   int _userCount = 0;
   final List<StagePlayerListItem> _players = [];
-  StageUserListItem? _mvp;
+  StagePlayerListItem? _mvp;
   StageTalkListItem? _talk;
   Map<PoseLandmarkType, PoseLandmark>? player0;
   Map<PoseLandmarkType, PoseLandmark>? player1;
@@ -291,7 +290,8 @@ class SocketStageProviderImpl extends ChangeNotifier
             jsonDecode(frame.body.toString()),
             StageMVPResponse.fromJson(
                 jsonDecode(frame.body.toString())['data']));
-        _mvp = socketResponse.data?.mvpUser;
+        _mvp = _players.firstWhere((element) =>
+            element.userId == socketResponse.data?.mvpUser?.userId);
         _stageType = response.type;
         break;
       case StageType.MVP_SKELETON:

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -24,14 +24,18 @@ import 'package:stomp_dart_client/stomp_frame.dart';
 enum StageType {
   WAIT, // only front
   CATCH_START,
+  CATCH_END_RESTART,
   CATCH_END,
   PLAY_START,
+  PLAY_SKELETON,
+  PLAY_END,
   MVP_START,
+  MVP_SKELETON,
+  MVP_END,
   USER_COUNT,
   STAGE_ROUTINE_STOP,
   TALK_MESSAGE,
   TALK_REACTION,
-  PLAY_SKELETON
 }
 
 class SocketStageProviderImpl extends ChangeNotifier
@@ -268,9 +272,9 @@ class SocketStageProviderImpl extends ChangeNotifier
       case StageType.WAIT:
         return const PoPoWaitView();
       case StageType.CATCH_START:
-        return const PoPoCatchView();
+      case StageType.CATCH_END_RESTART:
+        return PoPoCatchView(type: type);
       case StageType.PLAY_START:
-        // UserData _user =
         return PoPoPlayView(
           isResultState: _stageType == StageType.MVP_START,
           players: _players,

--- a/lib/domain/provider/socket_stage_provider.dart
+++ b/lib/domain/provider/socket_stage_provider.dart
@@ -6,5 +6,6 @@ abstract class SocketStageProvider {
   void onSubscribe();
   void sendMessage(String message);
   void sendReaction();
-  void sendSkeleton(SendSkeletonRequest request);
+  void sendPlaySkeleton(SendSkeletonRequest request);
+  void sendMVPSkeleton(SendSkeletonRequest request);
 }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -29,6 +29,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   late StageProviderImpl _stageProvider;
   late SocketStageProviderImpl _socketStageProvider;
   late KaKaoLoginProvider _loginProvider;
+  UserData? _userData;
 
   @override
   Widget build(BuildContext context) {
@@ -66,11 +67,12 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                     right: 0,
                     child: StageLiveTalkListWidget(),
                   ),
-                  const Positioned(
+                  Positioned(
                     bottom: 0,
                     left: 0,
                     right: 0,
-                    child: StageLiveChatBarWidget(),
+                    child: StageLiveChatBarWidget(
+                        nickName: _userData?.nickname ?? ""),
                   ),
                 ],
               ),
@@ -83,7 +85,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   void initState() {
     super.initState();
     _loginProvider = Provider.of<KaKaoLoginProvider>(context, listen: false);
-    _setUserId();
+    _initUser();
   }
 
   @override
@@ -277,8 +279,17 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     );
   }
 
-  _setUserId() async {
-    UserData user = await _loginProvider.getUser();
-    _socketStageProvider.setUserId(user.userId);
+  _initUser() async {
+    UserData userData = await _loginProvider.getUser();
+    _socketStageProvider.setUserId(userData.userId);
+
+    setState(() {
+      _userData = userData;
+    });
+  }
+
+  Future<String> _getUserNickname() async {
+    UserData userData = await _loginProvider.getUser();
+    return userData.nickname;
   }
 }

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -4,13 +4,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:provider/provider.dart';
 import 'package:semicircle_indicator/semicircle_indicator.dart';
 import 'dart:math' as math;
 
 class PoPoCatchView extends StatefulWidget {
-  const PoPoCatchView({Key? key}) : super(key: key);
+  final StageType type;
+  const PoPoCatchView({Key? key, required this.type}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _PoPoCatchViewState();
@@ -23,12 +25,26 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   late Timer _timer;
   late AnimationController _animationController;
   late Animation<double> _opacityAnimation;
-
   late StageProviderImpl _stageProvider;
+  StageType _prevStageType = StageType.CATCH_START;
 
   @override
   Widget build(BuildContext context) {
     _stageProvider = Provider.of<StageProviderImpl>(context, listen: true);
+    if (_prevStageType != widget.type) {
+      _prevStageType = widget.type;
+      _milliseconds = 0;
+      _catchCountDown = 0.0;
+      _startTimer();
+      Fluttertoast.showToast(
+        msg: "캐치를 아무도 안 했어요...😢",
+        toastLength: Toast.LENGTH_SHORT,
+        timeInSecForIosWeb: 1,
+        backgroundColor: Colors.black,
+        textColor: Colors.white,
+        fontSize: 16.0,
+      );
+    }
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
@@ -123,7 +139,6 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
     _timer = Timer.periodic(const Duration(milliseconds: 10), (timer) {
       if (_milliseconds >= 3000) {
         _stopTimer();
-        Fluttertoast.showToast(msg: '캐치 성공!');
       } else {
         if (mounted) {
           setState(() {
@@ -136,12 +151,15 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   }
 
   void _stopTimer() {
-    _timer.cancel();
+    if (_timer.isActive) {
+      _timer.cancel();
+    }
   }
 
   @override
   void dispose() {
     _animationController.dispose();
+    _stopTimer();
     super.dispose();
   }
 

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -256,7 +256,7 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
 
       var resuest = SendSkeletonRequest(
           playerNum: _playerNum, frameNum: _frameNum, skeleton: resultMap);
-      _socketStageProvider.sendSkeleton(resuest);
+      _socketStageProvider.sendPlaySkeleton(resuest);
     }
     _frameNum++;
 

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -6,8 +6,8 @@ import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/custom_pose_painter.dart';
 import 'package:pocket_pose/data/entity/socket_request/send_skeleton_request.dart';
 import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
+import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_skeleton_pose_landmark.dart';
-import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
 import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
 import 'package:provider/provider.dart';
 
@@ -17,7 +17,7 @@ class PoPoResultView extends StatefulWidget {
       {Key? key, required this.isResultState, this.mvp, required this.userId})
       : super(key: key);
   final bool isResultState;
-  final StageUserListItem? mvp;
+  final StagePlayerListItem? mvp;
   final String userId;
 
   @override
@@ -36,6 +36,11 @@ class _PoPoResultViewState extends State<PoPoResultView> {
   // 스켈레톤 전송
   int _frameNum = 0;
   late SocketStageProviderImpl _socketStageProvider;
+  final skeletonColorList = [
+    AppColor.mintNeonColor,
+    AppColor.yellowNeonColor,
+    AppColor.greenNeonColor
+  ];
 
   @override
   void initState() {
@@ -110,11 +115,11 @@ class _PoPoResultViewState extends State<PoPoResultView> {
         [Pose(landmarks: _socketStageProvider.mvpSkeleton ?? {})],
         const Size(1280.0, 720.0),
         InputImageRotation.rotation270deg,
-        AppColor.mintNeonColor);
+        skeletonColorList[widget.mvp!.playerNum!]);
     _customPaintMid = CustomPaint(painter: painterMid);
   }
 
-  Container buildMVPWidget(StageUserListItem user) {
+  Container buildMVPWidget(StagePlayerListItem user) {
     return Container(
       decoration: BoxDecoration(
           border: Border.all(

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -1,15 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/ml_kit/custom_pose_painter.dart';
+import 'package:pocket_pose/data/entity/socket_request/send_skeleton_request.dart';
+import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
+import 'package:pocket_pose/domain/entity/stage_skeleton_pose_landmark.dart';
+import 'package:pocket_pose/domain/entity/stage_user_list_item.dart';
 import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
+import 'package:provider/provider.dart';
 
 // ml_kit_skeleton_custom_view
 class PoPoResultView extends StatefulWidget {
-  const PoPoResultView({Key? key, required this.isResultState})
+  const PoPoResultView(
+      {Key? key, required this.isResultState, this.mvp, required this.userId})
       : super(key: key);
   final bool isResultState;
+  final StageUserListItem? mvp;
+  final String userId;
 
   @override
   State<StatefulWidget> createState() => _PoPoResultViewState();
@@ -24,13 +33,42 @@ class _PoPoResultViewState extends State<PoPoResultView> {
   // 스켈레톤 모양을 그려주는 변수
   CustomPaint? _customPaintMid;
   // 스켈레톤 추출할지 안할지, 추출한다면 배열에 저장할지 할지 관리하는 변수
-  SkeletonDetectMode _skeletonDetectMode = SkeletonDetectMode.userMode;
-  final bool _isPlayer = true;
-  // input Lists
-  final List<List<double>> _inputLists = [];
+  final SkeletonDetectMode _skeletonDetectMode = SkeletonDetectMode.userMode;
+  bool _isPlayer = true;
+  // 스켈레톤 전송
+  int _frameNum = 0;
+  late SocketStageProviderImpl _socketStageProvider;
+
+  @override
+  void initState() {
+    if (widget.userId == widget.mvp?.userId) {
+      _isPlayer = true;
+    }
+
+    if (_isPlayer) {
+      Fluttertoast.showToast(
+        msg: "춤 짱은 바로 나!!",
+        toastLength: Toast.LENGTH_SHORT,
+        timeInSecForIosWeb: 1,
+        backgroundColor: Colors.black,
+        textColor: Colors.white,
+        fontSize: 16.0,
+      );
+    }
+
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
+    _socketStageProvider =
+        Provider.of<SocketStageProviderImpl>(context, listen: true);
+
+    if (_socketStageProvider.isMVPSkeletonChange) {
+      _socketStageProvider.setIsMVPSkeletonChange(false);
+      _paintSkeleton();
+    }
+
     // 카메라뷰 보이기
     return Stack(
       children: [
@@ -41,7 +79,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              buildMVPWidget('assets/images/home_profile_1.jpg', 'okoi2202'),
+              (widget.mvp != null) ? buildMVPWidget(widget.mvp!) : Container()
             ],
           ),
         ),
@@ -70,7 +108,16 @@ class _PoPoResultViewState extends State<PoPoResultView> {
     super.dispose();
   }
 
-  Container buildMVPWidget(String profileImg, String nickName) {
+  void _paintSkeleton() {
+    CustomPosePainter painterMid = CustomPosePainter(
+        [Pose(landmarks: _socketStageProvider.mvpSkeleton ?? {})],
+        const Size(1280.0, 720.0),
+        InputImageRotation.rotation270deg,
+        AppColor.mintNeonColor);
+    _customPaintMid = CustomPaint(painter: painterMid);
+  }
+
+  Container buildMVPWidget(StageUserListItem user) {
     return Container(
       decoration: BoxDecoration(
           border: Border.all(
@@ -115,11 +162,18 @@ class _PoPoResultViewState extends State<PoPoResultView> {
                   padding: const EdgeInsets.fromLTRB(2, 0, 0, 12),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(50),
-                    child: Image.asset(
-                      profileImg,
-                      width: 62,
-                      height: 62,
-                    ),
+                    child: (user.profileImg == null)
+                        ? Image.asset(
+                            'assets/images/charactor_popo_default.png',
+                            width: 62,
+                            height: 62,
+                          )
+                        : Image.network(
+                            user.profileImg!,
+                            fit: BoxFit.cover,
+                            width: 62,
+                            height: 62,
+                          ),
                   ),
                 ),
               ],
@@ -128,7 +182,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
               height: 2,
             ),
             Text(
-              nickName,
+              user.nickname,
               style: const TextStyle(color: Colors.white, fontSize: 12),
             ),
           ],
@@ -145,23 +199,26 @@ class _PoPoResultViewState extends State<PoPoResultView> {
     // poseDetector에서 추출된 포즈 가져오기
     List<Pose> poses = await _poseDetector.processImage(inputImage);
 
-    // var test = StageSkeletonTest.fromJson(poses);
-    // print("mmm result test : $test");
-
+    // 소켓에 스켈레톤 전송
     for (final pose in poses) {
-      _inputLists.add(_poseMapToInputList(pose.landmarks));
-    }
+      Map<String, StageSkeletonPoseLandmark> resultMap = {};
 
-    // 이미지가 정상적이면 포즈에 스켈레톤 그려주기
-    if (inputImage.inputImageData?.size != null &&
-        inputImage.inputImageData?.imageRotation != null) {
-      final painter = CustomPosePainter(poses, inputImage.inputImageData!.size,
-          inputImage.inputImageData!.imageRotation, AppColor.mintNeonColor);
-      _customPaintMid = CustomPaint(painter: painter);
-    } else {
-      // 추출된 포즈 없음
-      _customPaintMid = null;
+      pose.landmarks.forEach((key, value) {
+        var poseLandmark = StageSkeletonPoseLandmark(
+            type: value.type.index,
+            x: value.x,
+            y: value.y,
+            z: value.z,
+            likelihood: value.likelihood);
+
+        resultMap[key.index.toString()] = poseLandmark;
+      });
+
+      var resuest =
+          SendSkeletonRequest(frameNum: _frameNum, skeleton: resultMap);
+      _socketStageProvider.sendMVPSkeleton(resuest);
     }
+    _frameNum++;
     _isBusy = false;
     if (mounted) {
       setState(() {});
@@ -170,45 +227,14 @@ class _PoPoResultViewState extends State<PoPoResultView> {
 
   void setIsSkeletonDetectMode(SkeletonDetectMode mode) async {
     if (_isPlayer && mounted) {
-      setState(() {
-        _skeletonDetectMode = mode;
+      // setState(() {
+      //   _skeletonDetectMode = mode;
 
-        // 노래 끝나면 대기 화면으로 이동
-        if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
-          _inputLists.clear();
-        }
-      });
+      //   // 노래 끝나면 대기 화면으로 이동
+      //   if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
+      //     _inputLists.clear();
+      //   }
+      // });
     }
-  }
-
-  List<double> _poseMapToInputList(Map<PoseLandmarkType, PoseLandmark> entry) {
-    return [
-      entry[PoseLandmarkType.nose]!.x,
-      entry[PoseLandmarkType.nose]!.y,
-      entry[PoseLandmarkType.rightShoulder]!.x,
-      entry[PoseLandmarkType.rightShoulder]!.y,
-      entry[PoseLandmarkType.rightElbow]!.x,
-      entry[PoseLandmarkType.rightElbow]!.y,
-      entry[PoseLandmarkType.rightWrist]!.x,
-      entry[PoseLandmarkType.rightWrist]!.y,
-      entry[PoseLandmarkType.leftShoulder]!.x,
-      entry[PoseLandmarkType.leftShoulder]!.y,
-      entry[PoseLandmarkType.leftElbow]!.x,
-      entry[PoseLandmarkType.leftElbow]!.y,
-      entry[PoseLandmarkType.leftWrist]!.x,
-      entry[PoseLandmarkType.leftWrist]!.y,
-      entry[PoseLandmarkType.rightHip]!.x,
-      entry[PoseLandmarkType.rightHip]!.y,
-      entry[PoseLandmarkType.rightKnee]!.x,
-      entry[PoseLandmarkType.rightKnee]!.y,
-      entry[PoseLandmarkType.rightAnkle]!.x,
-      entry[PoseLandmarkType.rightAnkle]!.y,
-      entry[PoseLandmarkType.leftHip]!.x,
-      entry[PoseLandmarkType.leftHip]!.y,
-      entry[PoseLandmarkType.leftKnee]!.x,
-      entry[PoseLandmarkType.leftKnee]!.y,
-      entry[PoseLandmarkType.leftAnkle]!.x,
-      entry[PoseLandmarkType.leftAnkle]!.y
-    ];
   }
 }

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -32,9 +32,7 @@ class _PoPoResultViewState extends State<PoPoResultView> {
   bool _isBusy = false;
   // 스켈레톤 모양을 그려주는 변수
   CustomPaint? _customPaintMid;
-  // 스켈레톤 추출할지 안할지, 추출한다면 배열에 저장할지 할지 관리하는 변수
-  final SkeletonDetectMode _skeletonDetectMode = SkeletonDetectMode.userMode;
-  bool _isPlayer = true;
+  bool _isPlayer = false;
   // 스켈레톤 전송
   int _frameNum = 0;
   late SocketStageProviderImpl _socketStageProvider;
@@ -90,9 +88,8 @@ class _PoPoResultViewState extends State<PoPoResultView> {
           customPaintMid: _customPaintMid,
           // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
           onImage: (inputImage) {
-            // player는 항상 스켈레톤 추출
-            if (_skeletonDetectMode != SkeletonDetectMode.userMode ||
-                _skeletonDetectMode != SkeletonDetectMode.musicEndMode) {
+            // 플레이어만 스켈레톤 추출
+            if (_isPlayer) {
               processImage(inputImage);
             }
           },

--- a/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
+++ b/lib/ui/widget/stage/stage_live_chat_bar_widget.dart
@@ -5,7 +5,8 @@ import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:provider/provider.dart';
 
 class StageLiveChatBarWidget extends StatefulWidget {
-  const StageLiveChatBarWidget({super.key});
+  const StageLiveChatBarWidget({super.key, required this.nickName});
+  final String nickName;
 
   @override
   State<StageLiveChatBarWidget> createState() => _StageLiveChatBarWidgetState();
@@ -96,10 +97,11 @@ class _StageLiveChatBarWidgetState extends State<StageLiveChatBarWidget>
                     controller: _textController,
                     cursorColor: Colors.white,
                     focusNode: _inputFieldFocusNode,
-                    decoration: const InputDecoration(
-                      hintText: 'nickname(으)로 댓글 달기...',
-                      hintStyle: TextStyle(color: Colors.white70, fontSize: 14),
-                      labelStyle: TextStyle(color: Colors.white),
+                    decoration: InputDecoration(
+                      hintText: '${widget.nickName}(으)로 댓글 달기...',
+                      hintStyle:
+                          const TextStyle(color: Colors.white70, fontSize: 14),
+                      labelStyle: const TextStyle(color: Colors.white),
                       border: InputBorder.none,
                     ),
                     textInputAction: TextInputAction.next,


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/7acb1261-7bc8-4f9b-8ccd-2b3eaaf60ed2

## 💬 작업 설명
- 스테이지 mvp화면도 (플레이 화면과 동일하게) mvp의 스켈레톤을 실시간으로 소켓에 전송하고, 응답받아 출력하도록 했습니다~
- 캐치를 아무도 안 했을 때 _"캐치를 아무도 안 했어요...😢"_라는 토스트가 뜨고, 캐치를 다시 하는 로직을 추가했습니다.
- 스테이지 채팅 textField에 사용자의 nickname이 들어가도록 수정했습니다.

## ✅ 한 일
1. 스테이지 mvp 스켈레톤 전송 소켓 연결
2. 캐치 재시작 로직 추가
3. 스테이지 채팅 textField에 사용자 nickname 추가

## 🤓 다음에 할 일
1. 스테이지 실시간 채팅 페이지네이션
2. 스테이지 플레이어 인원별 ui 다르게
3. 캐치 버튼 뾱뾱 소리
4. 캐치 3, 2, 1 틱틱소리
