### PR TITLE
[bug][feat] 홈, 프로필 UI 수정(HH-218)

### DIFF
--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -104,40 +104,43 @@ class _ProfileScreenState extends State<ProfileScreen>
                 SliverToBoxAdapter(
                   child: Column(
                     children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          InkWell(
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        const ProfileEditScreen()),
-                              );
-                            },
-                            child: Container(
-                              margin: const EdgeInsets.fromLTRB(0, 36, 14, 0),
-                              child: SvgPicture.asset(
-                                  'assets/icons/ic_profile_edit.svg'),
+                      Container(
+                        color: Colors.white,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            InkWell(
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) =>
+                                          const ProfileEditScreen()),
+                                );
+                              },
+                              child: Container(
+                                margin: const EdgeInsets.fromLTRB(0, 36, 14, 0),
+                                child: SvgPicture.asset(
+                                    'assets/icons/ic_profile_edit.svg'),
+                              ),
                             ),
-                          ),
-                          InkWell(
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        const ProfileSettingScreen()),
-                              );
-                            },
-                            child: Container(
-                              margin: const EdgeInsets.fromLTRB(0, 36, 14, 0),
-                              child: SvgPicture.asset(
-                                  'assets/icons/ic_profile_setting.svg'),
-                            ),
-                          )
-                        ],
+                            InkWell(
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) =>
+                                          const ProfileSettingScreen()),
+                                );
+                              },
+                              child: Container(
+                                margin: const EdgeInsets.fromLTRB(0, 36, 14, 0),
+                                child: SvgPicture.asset(
+                                    'assets/icons/ic_profile_setting.svg'),
+                              ),
+                            )
+                          ],
+                        ),
                       ),
                       ProfileUserInfoWidget(
                         user: _user,
@@ -148,7 +151,7 @@ class _ProfileScreenState extends State<ProfileScreen>
                 SliverAppBar(
                   pinned: true,
                   backgroundColor: Colors.white,
-                  toolbarHeight: 0,
+                  toolbarHeight: 0.0,
                   bottom: TabBar(
                     controller: _tabController,
                     tabs: [

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -116,6 +116,7 @@ class _VideoViewState extends State<VideoView>
         });
       },
       color: AppColor.purpleColor,
+      backgroundColor: const Color.fromARGB(60, 234, 234, 234),
       child: Stack(
         children: <Widget>[
           PageView.builder(

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -143,7 +143,7 @@ class _VideoViewState extends State<VideoView>
                               _videoPlayProvider.loading)) {
                         // 비디오가 준비된 경우
                         _videoPlayProvider.loading = true;
-                        return buildVideoPlayer(index); // 비디오 플레이어 생성
+                        return VideoPlayerWidget(index: index); // 비디오 플레이어 생성
                       } else {
                         return const MusicSpinner(); // 비디오 로딩 중
                       }
@@ -165,23 +165,104 @@ class _VideoViewState extends State<VideoView>
       ),
     );
   }
+}
 
-  Widget buildVideoPlayer(int index) {
+class VideoPlayerWidget extends StatefulWidget {
+  const VideoPlayerWidget({super.key, required int index}) : index = index;
+
+  final int index;
+
+  @override
+  _VideoPlayerWidgetState createState() => _VideoPlayerWidgetState();
+}
+
+class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
+    with SingleTickerProviderStateMixin {
+  bool isPlaying = false;
+  bool isIconVisible = false;
+  late VideoPlayProvider _videoPlayProvider;
+  late AnimationController _animationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _videoPlayProvider = Provider.of<VideoPlayProvider>(context, listen: false);
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 0), // 아이콘이 나타날 때의 애니메이션 속도
+      reverseDuration:
+          const Duration(milliseconds: 800), // 아이콘이 사라질 때의 애니메이션 속도
+      value: 0.0, // 시작 값 설정
+    );
+  }
+
+  void _toggleIconVisibility(bool newValue) {
+    setState(() {
+      isIconVisible = newValue;
+      if (isIconVisible) {
+        _animationController.forward();
+      } else {
+        _animationController.reverse().then((_) {
+          setState(() {
+            isIconVisible = false;
+          });
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
         GestureDetector(
           onTap: () {
-            // 비디오 클릭 시 영상 정지/재생
-            if (_videoPlayProvider.controllers[index].value.isPlaying) {
+            final controller = _videoPlayProvider.controllers[widget.index];
+            if (controller.value.isPlaying) {
               _videoPlayProvider.pauseVideo();
+              isPlaying = false;
+              _toggleIconVisibility(true);
+              Future.delayed(const Duration(milliseconds: 800), () {
+                _toggleIconVisibility(false);
+              });
             } else {
               _videoPlayProvider.playVideo();
+              isPlaying = true;
+              _toggleIconVisibility(true);
+              Future.delayed(const Duration(milliseconds: 800), () {
+                _toggleIconVisibility(false);
+              });
             }
           },
-          child: VideoPlayer(_videoPlayProvider.controllers[index]),
+          child: VideoPlayer(_videoPlayProvider.controllers[widget.index]),
         ),
-        VideoRightFrame(index: index),
-        VideoUserInfoFrame(index: index),
+        Positioned.fill(
+          child: AnimatedBuilder(
+            animation: _animationController,
+            builder: (context, child) {
+              return Opacity(
+                opacity: _animationController.value,
+                child: Center(
+                  child: Icon(
+                    isPlaying
+                        ? Icons.play_circle_filled_rounded
+                        : Icons.pause_circle_filled_rounded,
+                    size: 60,
+                    color: const Color.fromARGB(60, 234, 234, 234),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        VideoRightFrame(index: widget.index),
+        VideoUserInfoFrame(index: widget.index),
       ],
     );
   }

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -396,49 +396,56 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                       ),
                                     ],
                                   ),
-                                  child: Row(
-                                    mainAxisAlignment:
-                                        MainAxisAlignment.spaceEvenly,
-                                    crossAxisAlignment: CrossAxisAlignment.end,
-                                    children: [
-                                      for (int i = 0; i < emojiList.length; i++)
-                                        InkWell(
-                                          onTap: () async {
-                                            if (await _loginProvider
-                                                    .checkAccessToken() ==
-                                                false) {
-                                              Navigator.pop(context);
-                                              _loginProvider
-                                                  .showLoginBottomSheet();
-                                            } else {
-                                              int cursorPosition =
-                                                  _textController.text.length;
-                                              String text =
-                                                  _textController.text;
-                                              String newText =
-                                                  text + emojiList[i];
-                                              _textController.value =
-                                                  TextEditingValue(
-                                                text: newText,
-                                                selection:
-                                                    TextSelection.collapsed(
-                                                        offset: cursorPosition +
-                                                            emojiList[i]
-                                                                .length),
-                                              );
+                                  child: Container(
+                                    color: Colors.white,
+                                    child: Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.spaceEvenly,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.end,
+                                      children: [
+                                        for (int i = 0;
+                                            i < emojiList.length;
+                                            i++)
+                                          InkWell(
+                                            onTap: () async {
+                                              if (await _loginProvider
+                                                      .checkAccessToken() ==
+                                                  false) {
+                                                Navigator.pop(context);
+                                                _loginProvider
+                                                    .showLoginBottomSheet();
+                                              } else {
+                                                int cursorPosition =
+                                                    _textController.text.length;
+                                                String text =
+                                                    _textController.text;
+                                                String newText =
+                                                    text + emojiList[i];
+                                                _textController.value =
+                                                    TextEditingValue(
+                                                  text: newText,
+                                                  selection:
+                                                      TextSelection.collapsed(
+                                                          offset:
+                                                              cursorPosition +
+                                                                  emojiList[i]
+                                                                      .length),
+                                                );
 
-                                              bottomState(() {
-                                                setState(() {});
-                                              });
-                                            }
-                                          },
-                                          child: Text(
-                                            emojiList[i],
-                                            style:
-                                                const TextStyle(fontSize: 20),
+                                                bottomState(() {
+                                                  setState(() {});
+                                                });
+                                              }
+                                            },
+                                            child: Text(
+                                              emojiList[i],
+                                              style:
+                                                  const TextStyle(fontSize: 20),
+                                            ),
                                           ),
-                                        ),
-                                    ],
+                                      ],
+                                    ),
                                   ),
                                 ),
                                 Container(

--- a/lib/ui/widget/login_modal_content_widget.dart
+++ b/lib/ui/widget/login_modal_content_widget.dart
@@ -17,60 +17,63 @@ class _LoginModalContentState extends State<LoginModalContent> {
   Widget build(BuildContext context) {
     _loginProvider = Provider.of<KaKaoLoginProvider>(context);
 
-    return Column(
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            InkWell(
-              onTap: () {
-                //bottom sheet 없애기
-                Navigator.pop(context);
-              },
-              child: Container(
-                margin: const EdgeInsets.fromLTRB(18, 18, 0, 0),
-                child: SvgPicture.asset(
-                  'assets/icons/ic_exit.svg',
-                  width: 14,
+    return SizedBox(
+      height: 400,
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              InkWell(
+                onTap: () {
+                  //bottom sheet 없애기
+                  Navigator.pop(context);
+                },
+                child: Container(
+                  margin: const EdgeInsets.fromLTRB(18, 18, 0, 0),
+                  child: SvgPicture.asset(
+                    'assets/icons/ic_exit.svg',
+                    width: 14,
+                  ),
                 ),
               ),
-            ),
-          ],
-        ),
-        Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Container(
-              margin: const EdgeInsets.fromLTRB(0, 14, 0, 14),
-              child: const Text(
-                "Pocket Pose 가입하기",
-                style: TextStyle(fontSize: 26, fontWeight: FontWeight.bold),
+            ],
+          ),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                margin: const EdgeInsets.fromLTRB(0, 14, 0, 14),
+                child: const Text(
+                  "Pocket Pose 가입하기",
+                  style: TextStyle(fontSize: 26, fontWeight: FontWeight.bold),
+                ),
               ),
-            ),
-            Container(
-              margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
-              child: const Text(
-                "간편하게 로그인하고 다양한 서비스를 이용해보세요.",
-                style: TextStyle(color: Colors.black87),
+              Container(
+                margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
+                child: const Text(
+                  "간편하게 로그인하고 다양한 서비스를 이용해보세요.",
+                  style: TextStyle(color: Colors.black87),
+                ),
               ),
-            ),
-            Container(
-              margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
-              child: SvgPicture.asset(
-                'assets/images/kakao_login_popo.svg',
-                width: 150,
+              Container(
+                margin: const EdgeInsets.fromLTRB(0, 0, 0, 14),
+                child: SvgPicture.asset(
+                  'assets/images/kakao_login_popo.svg',
+                  width: 150,
+                ),
               ),
-            ),
-            _loginButton(
-              'kakao_login',
-              () {
-                _loginProvider.signIn();
-                Navigator.pop(context);
-              },
-            ),
-          ],
-        ),
-      ],
+              _loginButton(
+                'kakao_login',
+                () {
+                  _loginProvider.signIn();
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/ui/widget/profile/profile_user_info_widget.dart
+++ b/lib/ui/widget/profile/profile_user_info_widget.dart
@@ -31,8 +31,8 @@ class ProfileUserInfoWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      //color: Colors.yellow,
+    return Container(
+      color: Colors.white,
       height: 300,
       child: Center(
           child: Column(


### PR DESCRIPTION
## 💬 작업 설명
8/9(수) 학교에서 회의 후 발견한 홈과 프로필의 ui 상 오류를 해결하였고,
홈 영상의 재생과 정지를 알아볼 수 있는 아이콘을 추가하였습니다. 

## ✅ 한 일
1. 로그인 바텀시트의 height 고정
<img width="293" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/4aa07411-6c06-479d-99b0-c467e3c44151">

2. 프로필 페이지의 appbar와 tab 상단의 색이 다른 오류 해결
<img width="273" alt="수정후" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/1d222bf6-b3fa-459b-b32b-905bfc1b2680">

3. 댓글 화면의 이모티콘바 배경색이 다른 오류 해결
<img width="273" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/787b042c-dc2e-4385-a14f-4df2426279cf">

4. 홈에서 당겨서 새로고침 시 등장하는 새로고침 아이콘 배경을 투명하게 변경
<img width="276" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/db6e5b06-5e0c-48e7-aa10-845208570783">

5. 영상 재생과 정지를 나타내는 아이콘 등장 기능 개발
[untitled.webm](https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/ca766a41-f147-4cb0-b58f-46ab7f694e62)

## 🤓 다음에 할 일
1. 비디오 플레이어 오류 해결
2. 검색 api 연결
