### PR TITLE
[feat] 스테이지 플레이 화면 중간 입장 (HH-337)

### DIFF
--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -25,7 +25,6 @@ class AppUrl {
   static const stageAccuracyUrl = "$_stageUrl/similarity";
   static const stageUserListUrl = "$_stageUrl/users";
   static const stageEnterUrl = "$_stageUrl/enter";
-  static const stageExitUrl = "$_stageUrl/exit"; // 임시 url
   static const stageCatchUrl = "$_stageUrl/catch";
   static const stageTalkUrl = "$_talkUrl/messages";
 
@@ -38,4 +37,5 @@ class AppUrl {
   static const socketReactionUrl = "/app/talks/reactions";
   static const socketPlaySkeletonUrl = "/app/stage/play/skeleton";
   static const socketMVPSkeletonUrl = "/app/stage/mvp/skeleton";
+  static const socketExitUrl = "/app/stage/exit";
 }

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,10 +1,9 @@
-import 'package:audio_session/audio_session.dart';
 import 'package:camera/camera.dart';
 import 'package:just_audio/just_audio.dart';
 
 class AudioPlayerUtil {
   CameraController? _controller;
-  late AudioSession audioSession;
+  // late AudioSession? audioSession;
   AudioPlayer player = AudioPlayer();
 
   static final AudioPlayerUtil _instance = AudioPlayerUtil._internal();
@@ -12,7 +11,7 @@ class AudioPlayerUtil {
   factory AudioPlayerUtil() => _instance;
 
   AudioPlayerUtil._internal() {
-    _audioSessionConfigure();
+    // _audioSessionConfigure();
   }
 
   setCameraController(CameraController? cameraController) {
@@ -27,7 +26,7 @@ class AudioPlayerUtil {
     // 내부 음악 실행
     await player.play();
     // 외부 음악 종료
-    // await audioSession.setActive(false);
+    // await audioSession?.setActive(false);
   }
 
   playSeek(int sec) async {
@@ -35,7 +34,7 @@ class AudioPlayerUtil {
     await player.seek(Duration(seconds: sec));
     await player.play();
     // 외부 음악 종료
-    // await audioSession.setActive(false);
+    // await audioSession?.setActive(false);
   }
 
   stop() async {
@@ -49,27 +48,27 @@ class AudioPlayerUtil {
     // 내부 음악 종료
     await player.stop();
     // 외부 음악 실행
-    // await audioSession.setActive(true);
+    // await audioSession?.setActive(true);
   }
 
   // 외부 음악 들릴 때 반응 설정
-  _audioSessionConfigure() =>
-      AudioSession.instance.then((audioSession) async => await audioSession
-          .configure(const AudioSessionConfiguration(
-              avAudioSessionCategory: AVAudioSessionCategory.playback,
-              avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
-              avAudioSessionMode: AVAudioSessionMode.defaultMode,
-              avAudioSessionRouteSharingPolicy:
-                  AVAudioSessionRouteSharingPolicy.defaultPolicy,
-              avAudioSessionSetActiveOptions:
-                  AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
-              androidAudioAttributes: AndroidAudioAttributes(
-                contentType: AndroidAudioContentType.music,
-                flags: AndroidAudioFlags.none,
-                usage: AndroidAudioUsage.media,
-              ),
-              androidAudioFocusGainType:
-                  AndroidAudioFocusGainType.gainTransient,
-              androidWillPauseWhenDucked: true))
-          .then((_) => audioSession = audioSession));
+  // _audioSessionConfigure() =>
+  //     AudioSession.instance.then((audioSession) async => await audioSession
+  //         .configure(const AudioSessionConfiguration(
+  //             avAudioSessionCategory: AVAudioSessionCategory.playback,
+  //             avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
+  //             avAudioSessionMode: AVAudioSessionMode.defaultMode,
+  //             avAudioSessionRouteSharingPolicy:
+  //                 AVAudioSessionRouteSharingPolicy.defaultPolicy,
+  //             avAudioSessionSetActiveOptions:
+  //                 AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
+  //             androidAudioAttributes: AndroidAudioAttributes(
+  //               contentType: AndroidAudioContentType.music,
+  //               flags: AndroidAudioFlags.none,
+  //               usage: AndroidAudioUsage.media,
+  //             ),
+  //             androidAudioFocusGainType:
+  //                 AndroidAudioFocusGainType.gainTransient,
+  //             androidWillPauseWhenDucked: true))
+  //         .then((_) => audioSession = audioSession));
 }

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,6 +1,5 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:camera/camera.dart';
-import 'package:pocket_pose/ui/view/ml_kit_camera_view.dart';
 
 class AudioPlayerUtil {
   CameraController? _controller;
@@ -21,17 +20,12 @@ class AudioPlayerUtil {
 
   // 노래 종료 후 실행할 함수 설정
   setPlayerCompletion(Function setIsSkeletonDetectStart) {
-    player.onPlayerCompletion.listen((event) {
-      // 노래 종료
-      setIsSkeletonDetectStart(SkeletonDetectMode.musicEndMode);
-    });
+    player.onPlayerCompletion.listen((event) {});
   }
 
   play(String musicUrl, Function setIsSkeletonDetectStart) async {
     // 내부 음악 실행
     await player.play(musicUrl);
-    // 노래 시작, 스켈레톤 추출 시작
-    setIsSkeletonDetectStart(SkeletonDetectMode.musicStartMode);
     // 외부 음악 종료
     // await audioSession.setActive(false);
   }

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,9 +1,10 @@
-import 'package:audioplayers/audioplayers.dart';
+import 'package:audio_session/audio_session.dart';
 import 'package:camera/camera.dart';
+import 'package:just_audio/just_audio.dart';
 
 class AudioPlayerUtil {
   CameraController? _controller;
-  // late AudioSession audioSession;
+  late AudioSession audioSession;
   AudioPlayer player = AudioPlayer();
 
   static final AudioPlayerUtil _instance = AudioPlayerUtil._internal();
@@ -11,21 +12,28 @@ class AudioPlayerUtil {
   factory AudioPlayerUtil() => _instance;
 
   AudioPlayerUtil._internal() {
-    // _audioSessionConfigure();
+    _audioSessionConfigure();
   }
 
   setCameraController(CameraController? cameraController) {
     _controller = cameraController;
   }
 
-  // 노래 종료 후 실행할 함수 설정
-  setPlayerCompletion() {
-    player.onPlayerCompletion.listen((event) {});
+  setMusicUrl(String musicUrl) async {
+    await player.setUrl(musicUrl);
   }
 
-  play(String musicUrl) async {
+  play() async {
     // 내부 음악 실행
-    await player.play(musicUrl);
+    await player.play();
+    // 외부 음악 종료
+    // await audioSession.setActive(false);
+  }
+
+  playSeek(int sec) async {
+    // 내부 음악 실행
+    await player.seek(Duration(seconds: sec));
+    await player.play();
     // 외부 음악 종료
     // await audioSession.setActive(false);
   }
@@ -45,23 +53,23 @@ class AudioPlayerUtil {
   }
 
   // 외부 음악 들릴 때 반응 설정
-  // _audioSessionConfigure() =>
-  //     AudioSession.instance.then((audioSession) async => await audioSession
-  //         .configure(const AudioSessionConfiguration(
-  //             avAudioSessionCategory: AVAudioSessionCategory.playback,
-  //             avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
-  //             avAudioSessionMode: AVAudioSessionMode.defaultMode,
-  //             avAudioSessionRouteSharingPolicy:
-  //                 AVAudioSessionRouteSharingPolicy.defaultPolicy,
-  //             avAudioSessionSetActiveOptions:
-  //                 AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
-  //             androidAudioAttributes: AndroidAudioAttributes(
-  //               contentType: AndroidAudioContentType.music,
-  //               flags: AndroidAudioFlags.none,
-  //               usage: AndroidAudioUsage.media,
-  //             ),
-  //             androidAudioFocusGainType:
-  //                 AndroidAudioFocusGainType.gainTransient,
-  //             androidWillPauseWhenDucked: true))
-  //         .then((_) => audioSession = audioSession));
+  _audioSessionConfigure() =>
+      AudioSession.instance.then((audioSession) async => await audioSession
+          .configure(const AudioSessionConfiguration(
+              avAudioSessionCategory: AVAudioSessionCategory.playback,
+              avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.none,
+              avAudioSessionMode: AVAudioSessionMode.defaultMode,
+              avAudioSessionRouteSharingPolicy:
+                  AVAudioSessionRouteSharingPolicy.defaultPolicy,
+              avAudioSessionSetActiveOptions:
+                  AVAudioSessionSetActiveOptions.notifyOthersOnDeactivation,
+              androidAudioAttributes: AndroidAudioAttributes(
+                contentType: AndroidAudioContentType.music,
+                flags: AndroidAudioFlags.none,
+                usage: AndroidAudioUsage.media,
+              ),
+              androidAudioFocusGainType:
+                  AndroidAudioFocusGainType.gainTransient,
+              androidWillPauseWhenDucked: true))
+          .then((_) => audioSession = audioSession));
 }

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -19,11 +19,11 @@ class AudioPlayerUtil {
   }
 
   // 노래 종료 후 실행할 함수 설정
-  setPlayerCompletion(Function setIsSkeletonDetectStart) {
+  setPlayerCompletion() {
     player.onPlayerCompletion.listen((event) {});
   }
 
-  play(String musicUrl, Function setIsSkeletonDetectStart) async {
+  play(String musicUrl) async {
     // 내부 음악 실행
     await player.play(musicUrl);
     // 외부 음악 종료

--- a/lib/data/entity/response/stage_enter_response.dart
+++ b/lib/data/entity/response/stage_enter_response.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:pocket_pose/data/entity/base_object.dart';
 import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+import 'package:pocket_pose/domain/entity/stage_music_data.dart';
 
 part 'stage_enter_response.g.dart';
 
@@ -8,11 +9,15 @@ part 'stage_enter_response.g.dart';
 class StageEnterResponse extends BaseObject<StageEnterResponse> {
   String stageStatus;
   int userCount;
+  double? statusElapsedTime;
+  StageMusicData? currentMusic;
   StageTalkMessageResponse talkMessageData;
 
   StageEnterResponse({
     required this.stageStatus,
     required this.userCount,
+    this.statusElapsedTime,
+    this.currentMusic,
     required this.talkMessageData,
   });
 

--- a/lib/data/entity/response/stage_enter_response.g.dart
+++ b/lib/data/entity/response/stage_enter_response.g.dart
@@ -10,6 +10,11 @@ StageEnterResponse _$StageEnterResponseFromJson(Map<String, dynamic> json) =>
     StageEnterResponse(
       stageStatus: json['stageStatus'] as String,
       userCount: json['userCount'] as int,
+      statusElapsedTime: (json['statusElapsedTime'] as num?)?.toDouble(),
+      currentMusic: json['currentMusic'] == null
+          ? null
+          : StageMusicData.fromJson(
+              json['currentMusic'] as Map<String, dynamic>),
       talkMessageData: StageTalkMessageResponse.fromJson(
           json['talkMessageData'] as Map<String, dynamic>),
     );
@@ -18,5 +23,7 @@ Map<String, dynamic> _$StageEnterResponseToJson(StageEnterResponse instance) =>
     <String, dynamic>{
       'stageStatus': instance.stageStatus,
       'userCount': instance.userCount,
+      'statusElapsedTime': instance.statusElapsedTime,
+      'currentMusic': instance.currentMusic,
       'talkMessageData': instance.talkMessageData,
     };

--- a/lib/data/entity/socket_response/catch_start_response.dart
+++ b/lib/data/entity/socket_response/catch_start_response.dart
@@ -1,0 +1,24 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+import 'package:pocket_pose/domain/entity/stage_music_data.dart';
+
+part 'catch_start_response.g.dart';
+
+@JsonSerializable()
+class CatchStartResponse extends BaseObject {
+  StageMusicData music;
+
+  CatchStartResponse({
+    required this.music,
+  });
+
+  factory CatchStartResponse.fromJson(Map<String, dynamic> json) =>
+      _$CatchStartResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CatchStartResponseToJson(this);
+
+  @override
+  fromJson(json) {
+    return CatchStartResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/socket_response/catch_start_response.g.dart
+++ b/lib/data/entity/socket_response/catch_start_response.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'catch_start_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+CatchStartResponse _$CatchStartResponseFromJson(Map<String, dynamic> json) =>
+    CatchStartResponse(
+      music: StageMusicData.fromJson(json['music'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$CatchStartResponseToJson(CatchStartResponse instance) =>
+    <String, dynamic>{
+      'music': instance.music,
+    };

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -25,7 +25,10 @@ import 'package:stomp_dart_client/stomp_config.dart';
 import 'package:stomp_dart_client/stomp_frame.dart';
 
 enum StageType {
-  WAIT, // only front
+  WAIT,
+  CATCH,
+  PLAY,
+  MVP,
   CATCH_START,
   CATCH_END_RESTART,
   CATCH_END,
@@ -62,6 +65,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool _isTalk = false;
   bool _isReaction = false;
   bool _isUserCountChange = false;
+  bool _isPlayEnter = false;
   bool _isPlaySkeletonChange = false;
   bool _isMVPSkeletonChange = false;
 
@@ -76,6 +80,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool get isTalk => _isTalk;
   bool get isReaction => _isReaction;
   bool get isUserCountChange => _isUserCountChange;
+  bool get isPlayEnter => _isPlayEnter;
   bool get isPlaySkeletonChange => _isPlaySkeletonChange;
   bool get isMVPSkeletonChange => _isMVPSkeletonChange;
 
@@ -127,6 +132,11 @@ class SocketStageProviderImpl extends ChangeNotifier
 
   setIsReaction(bool value) {
     _isReaction = value;
+    if (value) notifyListeners();
+  }
+
+  setIsPlayEnter(bool value) {
+    _isPlayEnter = value;
     if (value) notifyListeners();
   }
 
@@ -352,15 +362,18 @@ class SocketStageProviderImpl extends ChangeNotifier
       case StageType.STAGE_ROUTINE_STOP:
       case StageType.WAIT:
         return const PoPoWaitView();
+      case StageType.CATCH:
       case StageType.CATCH_START:
       case StageType.CATCH_END_RESTART:
         return PoPoCatchView(type: type);
+      case StageType.PLAY:
       case StageType.PLAY_START:
         return PoPoPlayView(
           isResultState: _stageType == StageType.MVP_START,
           players: _players,
           userId: _userId,
         );
+      case StageType.MVP:
       case StageType.MVP_START:
         return (_mvp != null)
             ? PoPoResultView(

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -87,7 +89,6 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool _isTalk = false;
   bool _isReaction = false;
   bool _isUserCountChange = false;
-  bool _isPlayEnter = false;
   bool _isPlaySkeletonChange = false;
   bool _isMVPSkeletonChange = false;
 
@@ -104,7 +105,6 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool get isTalk => _isTalk;
   bool get isReaction => _isReaction;
   bool get isUserCountChange => _isUserCountChange;
-  bool get isPlayEnter => _isPlayEnter;
   bool get isPlaySkeletonChange => _isPlaySkeletonChange;
   bool get isMVPSkeletonChange => _isMVPSkeletonChange;
 
@@ -159,11 +159,6 @@ class SocketStageProviderImpl extends ChangeNotifier
     if (value) notifyListeners();
   }
 
-  setIsPlayEnter(bool value) {
-    _isPlayEnter = value;
-    if (value) notifyListeners();
-  }
-
   @override
   void connectWebSocket() async {
     const storage = FlutterSecureStorage();
@@ -199,7 +194,6 @@ class SocketStageProviderImpl extends ChangeNotifier
             // stage 상태 변경
             var socketResponse = BaseSocketResponse.fromJson(
                 jsonDecode(frame.body.toString()), null);
-            print("mmmm 소켓 구독 후 응답받고 화면 변경: ${socketResponse.type}:");
             _setStageType(socketResponse, frame);
           }
         });

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -7,10 +7,12 @@ import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/base_socket_response.dart';
 import 'package:pocket_pose/data/entity/socket_request/send_skeleton_request.dart';
 import 'package:pocket_pose/data/entity/socket_response/catch_end_response.dart';
+import 'package:pocket_pose/data/entity/socket_response/catch_start_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/send_skeleton_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/stage_mvp_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/talk_message_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
+import 'package:pocket_pose/domain/entity/stage_music_data.dart';
 import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
 import 'package:pocket_pose/domain/provider/socket_stage_provider.dart';
@@ -43,6 +45,7 @@ class SocketStageProviderImpl extends ChangeNotifier
     implements SocketStageProvider {
   String? _userId;
   StompClient? _stompClient;
+  StageMusicData? _catchMusicData;
 
   int _userCount = 0;
   final List<StagePlayerListItem> _players = [];
@@ -63,6 +66,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool _isMVPSkeletonChange = false;
 
   String? get userId => _userId;
+  StageMusicData? get catchMusicData => _catchMusicData;
   int get userCount => _userCount;
   StageTalkListItem? get talk => _talk;
 
@@ -248,6 +252,14 @@ class SocketStageProviderImpl extends ChangeNotifier
         break;
       case StageType.TALK_REACTION:
         setIsReaction(true);
+        break;
+      case StageType.CATCH_START:
+        var socketResponse = BaseSocketResponse<CatchStartResponse>.fromJson(
+            jsonDecode(frame.body.toString()),
+            CatchStartResponse.fromJson(
+                jsonDecode(frame.body.toString())['data']));
+        _catchMusicData = socketResponse.data?.music;
+        _stageType = response.type;
         break;
       case StageType.CATCH_END:
         var socketResponse = BaseSocketResponse<CatchEndResponse>.fromJson(

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -226,6 +226,19 @@ class SocketStageProviderImpl extends ChangeNotifier
     }
   }
 
+  @override
+  void exitStage() async {
+    const storage = FlutterSecureStorage();
+    const storageKey = 'kakaoAccessToken';
+    String token = await storage.read(key: storageKey) ?? "";
+
+    if (_stompClient != null && (_stompClient?.isActive ?? false)) {
+      _stompClient?.send(
+          destination: AppUrl.socketExitUrl,
+          headers: {'x-access-token': token});
+    }
+  }
+
   void _setStageType(BaseSocketResponse response, StompFrame frame) {
     switch (response.type) {
       case StageType.USER_COUNT:

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -155,7 +155,7 @@ class SocketStageProviderImpl extends ChangeNotifier
       },
       stompConnectHeaders: {'x-access-token': token},
       webSocketConnectHeaders: {'x-access-token': token},
-      onDebugMessage: (p0) => print("mmm socket: $p0"),
+      onDebugMessage: (p0) => print("popo socket: $p0"),
     ));
     _stompClient!.activate();
   }
@@ -175,6 +175,7 @@ class SocketStageProviderImpl extends ChangeNotifier
             // stage 상태 변경
             var socketResponse = BaseSocketResponse.fromJson(
                 jsonDecode(frame.body.toString()), null);
+            print("mmmm 소켓 구독 후 응답받고 화면 변경: ${socketResponse.type}:");
             _setStageType(socketResponse, frame);
           }
         });
@@ -361,6 +362,7 @@ class SocketStageProviderImpl extends ChangeNotifier
     switch (type) {
       case StageType.STAGE_ROUTINE_STOP:
       case StageType.WAIT:
+        print("mmmm wait");
         return const PoPoWaitView();
       case StageType.CATCH:
       case StageType.CATCH_START:

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -15,13 +15,16 @@ import 'package:pocket_pose/domain/provider/stage_provider.dart';
 class StageProviderImpl extends ChangeNotifier implements StageProvider {
   final List<StageTalkListItem> _talkList = [];
   final List<StageUserListItem> _userList = [];
+  late double _stageElapsedTime;
   bool _isClicked = false;
 
   List<StageTalkListItem> get talkList => _talkList;
   List<StageUserListItem> get userList => _userList;
+  double get stageElapsedTime => _stageElapsedTime;
 
   bool get isClicked => _isClicked;
   setIsClicked(bool value) => _isClicked = value;
+  setStageElapsedTime() => _stageElapsedTime = 5;
 
   void toggleIsLeft() {
     if (isClicked) notifyListeners();
@@ -85,6 +88,7 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
 
       var responseJson = BaseResponse<StageEnterResponse>.fromJson(
           response.data, StageEnterResponse.fromJson(response.data['data']));
+      _stageElapsedTime = responseJson.data.statusElapsedTime ?? 5;
 
       addTalkList(responseJson.data.talkMessageData.messages ?? []);
 

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -15,16 +15,16 @@ import 'package:pocket_pose/domain/provider/stage_provider.dart';
 class StageProviderImpl extends ChangeNotifier implements StageProvider {
   final List<StageTalkListItem> _talkList = [];
   final List<StageUserListItem> _userList = [];
-  late double _stageCurSecond;
+  late double? _stageCurSecond;
   bool _isClicked = false;
 
   List<StageTalkListItem> get talkList => _talkList;
   List<StageUserListItem> get userList => _userList;
-  double get stageCurTime => _stageCurSecond;
+  double? get stageCurTime => _stageCurSecond;
 
   bool get isClicked => _isClicked;
   setIsClicked(bool value) => _isClicked = value;
-  setStageCurTime() => _stageCurSecond = 5;
+  setStageCurSecondNULL() => _stageCurSecond = null;
 
   void toggleIsLeft() {
     if (isClicked) notifyListeners();
@@ -88,8 +88,7 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
 
       var responseJson = BaseResponse<StageEnterResponse>.fromJson(
           response.data, StageEnterResponse.fromJson(response.data['data']));
-      print("mmmm enter 응답 sec: ${responseJson.data.statusElapsedTime}");
-      _stageCurSecond = responseJson.data.statusElapsedTime ?? 5;
+      _stageCurSecond = responseJson.data.statusElapsedTime;
 
       addTalkList(responseJson.data.talkMessageData.messages ?? []);
 

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -96,33 +96,6 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
   }
 
   @override
-  Future<BaseResponse> getStageExit() async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
-
-    var dio = Dio();
-    try {
-      dio.options.headers = {
-        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
-      };
-      dio.options.contentType = "application/json";
-      var response = await dio.get(AppUrl.stageExitUrl);
-      var responseJson = BaseResponse.fromJson(response.data, null);
-      return responseJson;
-    } catch (e) {
-      debugPrint("mmm StageProviderImpl catch: ${e.toString()}");
-      if (e.toString().contains("500")) {
-        return BaseResponse(
-            timeStamp: "", code: "500", message: "", data: null);
-      }
-    }
-    throw UnimplementedError();
-  }
-
-  @override
   Future<void> getStageCatch() async {
     const storage = FlutterSecureStorage();
     const storageKey = 'kakaoAccessToken';

--- a/lib/data/remote/provider/stage_provider_impl.dart
+++ b/lib/data/remote/provider/stage_provider_impl.dart
@@ -15,16 +15,16 @@ import 'package:pocket_pose/domain/provider/stage_provider.dart';
 class StageProviderImpl extends ChangeNotifier implements StageProvider {
   final List<StageTalkListItem> _talkList = [];
   final List<StageUserListItem> _userList = [];
-  late double _stageElapsedTime;
+  late double _stageCurSecond;
   bool _isClicked = false;
 
   List<StageTalkListItem> get talkList => _talkList;
   List<StageUserListItem> get userList => _userList;
-  double get stageElapsedTime => _stageElapsedTime;
+  double get stageCurTime => _stageCurSecond;
 
   bool get isClicked => _isClicked;
   setIsClicked(bool value) => _isClicked = value;
-  setStageElapsedTime() => _stageElapsedTime = 5;
+  setStageCurTime() => _stageCurSecond = 5;
 
   void toggleIsLeft() {
     if (isClicked) notifyListeners();
@@ -88,9 +88,12 @@ class StageProviderImpl extends ChangeNotifier implements StageProvider {
 
       var responseJson = BaseResponse<StageEnterResponse>.fromJson(
           response.data, StageEnterResponse.fromJson(response.data['data']));
-      _stageElapsedTime = responseJson.data.statusElapsedTime ?? 5;
+      print("mmmm enter 응답 sec: ${responseJson.data.statusElapsedTime}");
+      _stageCurSecond = responseJson.data.statusElapsedTime ?? 5;
 
       addTalkList(responseJson.data.talkMessageData.messages ?? []);
+
+      notifyListeners();
 
       return responseJson;
     } catch (e) {

--- a/lib/domain/entity/stage_music_data.dart
+++ b/lib/domain/entity/stage_music_data.dart
@@ -1,0 +1,26 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'stage_music_data.g.dart';
+
+@JsonSerializable()
+class StageMusicData {
+  String musicId;
+  String title;
+  String singer;
+  int length;
+  String musicUrl;
+  String concept;
+
+  StageMusicData(
+      {required this.musicId,
+      required this.title,
+      required this.singer,
+      required this.length,
+      required this.musicUrl,
+      required this.concept});
+
+  factory StageMusicData.fromJson(Map<String, dynamic> json) =>
+      _$StageMusicDataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageMusicDataToJson(this);
+}

--- a/lib/domain/entity/stage_music_data.g.dart
+++ b/lib/domain/entity/stage_music_data.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_music_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageMusicData _$StageMusicDataFromJson(Map<String, dynamic> json) =>
+    StageMusicData(
+      musicId: json['musicId'] as String,
+      title: json['title'] as String,
+      singer: json['singer'] as String,
+      length: json['length'] as int,
+      musicUrl: json['musicUrl'] as String,
+      concept: json['concept'] as String,
+    );
+
+Map<String, dynamic> _$StageMusicDataToJson(StageMusicData instance) =>
+    <String, dynamic>{
+      'musicId': instance.musicId,
+      'title': instance.title,
+      'singer': instance.singer,
+      'length': instance.length,
+      'musicUrl': instance.musicUrl,
+      'concept': instance.concept,
+    };

--- a/lib/domain/provider/socket_stage_provider.dart
+++ b/lib/domain/provider/socket_stage_provider.dart
@@ -8,4 +8,5 @@ abstract class SocketStageProvider {
   void sendReaction();
   void sendPlaySkeleton(SendSkeletonRequest request);
   void sendMVPSkeleton(SendSkeletonRequest request);
+  void exitStage();
 }

--- a/lib/domain/provider/stage_provider.dart
+++ b/lib/domain/provider/stage_provider.dart
@@ -7,6 +7,5 @@ abstract class StageProvider {
   Future<BaseResponse<StageUserListResponse>> getUserList();
   Future<BaseResponse<StageEnterResponse>> getStageEnter(
       StageEnterRequest request);
-  Future<BaseResponse> getStageExit();
   Future<void> getStageCatch();
 }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -96,8 +96,8 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     }
 
     if (_isEnter) {
+      _socketStageProvider.exitStage();
       _socketStageProvider.deactivateWebSocket();
-      _stageProvider.getStageExit();
       _isEnter = false;
     }
 

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -59,8 +59,14 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
               appBar: _buildAppBar(context),
               body: Stack(
                 children: [
-                  _socketStageProvider
-                      .buildStageView(_socketStageProvider.stageType),
+                  Expanded(
+                    flex: 1,
+                    child: Navigator(
+                      key: _socketStageProvider.navigatorKey,
+                      initialRoute: stageStageList[0],
+                      onGenerateRoute: _socketStageProvider.onGenerateRoute,
+                    ),
+                  ),
                   const Positioned(
                     bottom: 68,
                     left: 0,
@@ -128,7 +134,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
           _socketStageProvider.setUserCount(value.data.userCount);
         }).then((_) {
           print("mmmm 입장 후 화면 변경: $stageType:");
-          _socketStageProvider.buildStageView(stageType);
+          _socketStageProvider.setStageView(stageType);
         }).then((_) => _socketStageProvider.onSubscribe());
       });
     }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -98,6 +98,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     if (_isEnter) {
       _socketStageProvider.exitStage();
       _socketStageProvider.deactivateWebSocket();
+      print("mmmm 퇴장----------------------");
       _isEnter = false;
     }
 
@@ -114,16 +115,20 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   void _onSocketResponse() {
     if (_socketStageProvider.isConnect) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
+        StageType stageType = StageType.WAIT;
         _socketStageProvider.setIsConnect(false);
         _stageProvider
             .getStageEnter(StageEnterRequest(page: 0, size: 10))
             .then((value) {
-          print("mmm second screen1: ${value.data.statusElapsedTime}");
+          print("mmmm 입장----------------------");
+          print("mmmm 입장 후 바로 sec: ${value.data.statusElapsedTime}");
           print(
-              "mmm second screen2: ${((value.data.statusElapsedTime ?? 0) / (1000000 * 1000)).round()}");
+              "mmmm 입장 후 바로 sec: ${((value.data.statusElapsedTime ?? 0) / (1000000 * 1000)).round()}");
+          stageType = StageType.values.byName(value.data.stageStatus);
           _socketStageProvider.setUserCount(value.data.userCount);
-          _socketStageProvider
-              .buildStageView(StageType.values.byName(value.data.stageStatus));
+        }).then((_) {
+          print("mmmm 입장 후 화면 변경: $stageType:");
+          _socketStageProvider.buildStageView(stageType);
         }).then((_) => _socketStageProvider.onSubscribe());
       });
     }
@@ -291,10 +296,5 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     setState(() {
       _userData = userData;
     });
-  }
-
-  Future<String> _getUserNickname() async {
-    UserData userData = await _loginProvider.getUser();
-    return userData.nickname;
   }
 }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -59,13 +59,10 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
               appBar: _buildAppBar(context),
               body: Stack(
                 children: [
-                  Expanded(
-                    flex: 1,
-                    child: Navigator(
-                      key: _socketStageProvider.navigatorKey,
-                      initialRoute: stageStageList[0],
-                      onGenerateRoute: _socketStageProvider.onGenerateRoute,
-                    ),
+                  Navigator(
+                    key: _socketStageProvider.navigatorKey,
+                    initialRoute: stageStageList[0],
+                    onGenerateRoute: _socketStageProvider.onGenerateRoute,
                   ),
                   const Positioned(
                     bottom: 68,

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -117,9 +117,14 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         _socketStageProvider.setIsConnect(false);
         _stageProvider
             .getStageEnter(StageEnterRequest(page: 0, size: 10))
-            .then((value) =>
-                _socketStageProvider.setUserCount(value.data.userCount))
-            .then((_) => _socketStageProvider.onSubscribe());
+            .then((value) {
+          print("mmm second screen1: ${value.data.statusElapsedTime}");
+          print(
+              "mmm second screen2: ${((value.data.statusElapsedTime ?? 0) / (1000000 * 1000)).round()}");
+          _socketStageProvider.setUserCount(value.data.userCount);
+          _socketStageProvider
+              .buildStageView(StageType.values.byName(value.data.stageStatus));
+        }).then((_) => _socketStageProvider.onSubscribe());
       });
     }
 

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -104,7 +104,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     if (_isEnter) {
       _socketStageProvider.exitStage();
       _socketStageProvider.deactivateWebSocket();
-      print("mmmm 퇴장----------------------");
       _isEnter = false;
     }
 
@@ -126,16 +125,11 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         _stageProvider
             .getStageEnter(StageEnterRequest(page: 0, size: 10))
             .then((value) {
-          print("mmmm 입장----------------------");
-          print("mmmm 입장 후 바로 sec: ${value.data.statusElapsedTime}");
-          print(
-              "mmmm 입장 후 바로 sec: ${((value.data.statusElapsedTime ?? 0) / (1000000 * 1000)).round()}");
-          stageType = StageType.values.byName(value.data.stageStatus);
-          _socketStageProvider.setUserCount(value.data.userCount);
-        }).then((_) {
-          print("mmmm 입장 후 화면 변경: $stageType:");
-          _socketStageProvider.setStageView(stageType);
-        }).then((_) => _socketStageProvider.onSubscribe());
+              stageType = StageType.values.byName(value.data.stageStatus);
+              _socketStageProvider.setUserCount(value.data.userCount);
+            })
+            .then((_) => _socketStageProvider.setStageView(stageType))
+            .then((_) => _socketStageProvider.onSubscribe());
       });
     }
 

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -111,54 +111,32 @@ class _CameraViewState extends State<CameraView> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 플레이 상태인 경우
       if (!widget.isResultState) {
-        var curSecond =
-            (_stageProvider.stageCurTime / (1000000 * 1000)).round();
-        print("mmmm cameraview sec: ${_stageProvider.stageCurTime}");
-        print("mmmm cameraview sec2: $curSecond");
+        AudioPlayerUtil()
+            .setMusicUrl(_socketStageProvider.catchMusicData!.musicUrl);
+
+        if (_stageProvider.stageCurTime != null) {
+          _seconds = (_stageProvider.stageCurTime! / (1000000 * 1000)).round();
+          _stageProvider.setStageCurSecondNULL();
+        } else {
+          _seconds = 0;
+        }
         // 카운트다운
-        if (curSecond < 5) {
+        if (_seconds < 5) {
           // 카운트다운 시작 후 노래 재생
           setState(() {
-            _seconds = 5 - curSecond;
-            _stageProvider.setStageCurTime();
+            _seconds = 5 - _seconds;
             _countdownVisibility = true;
           });
           _startTimer();
         }
         // 노래 재생
         else {
-          AudioPlayerUtil().play(
-            _socketStageProvider.catchMusicData!.musicUrl,
-          );
+          AudioPlayerUtil().playSeek(_seconds - 5);
         }
       }
       // 결과 상태인 경우
       else {}
     });
-
-    // // 결과 상태인 경우
-    // if (widget.isResultState) {
-    //   // AudioPlayerUtil().play(
-    //   //     "https://popo2023.s3.ap-northeast-2.amazonaws.com/effect/Happyhappy.mp3",
-    //   //     widget.setIsSkeletonDetectMode);
-    // }
-    // // 플레이 상태인 경우
-    // else {
-    //   // 카운트다운
-    //   if (_stageProvider.stageElapsedTime < 5000000.0) {
-    //     // 카운트다운 시작 후 노래 재생
-    //     _startTimer();
-    //     setState(() {
-    //       print("mmm second: ${_stageProvider.stageElapsedTime}");
-    //       _seconds = (_stageProvider.stageElapsedTime).round();
-
-    //       _stageProvider.setStageElapsedTime();
-    //       _countdownVisibility = true;
-    //     });
-    //   }
-    //   // 노래 play
-    //   else {}
-    // }
   }
 
   void _startTimer() {
@@ -174,9 +152,7 @@ class _CameraViewState extends State<CameraView> {
           });
         }
         _seconds = 5;
-        AudioPlayerUtil().play(
-          _socketStageProvider.catchMusicData!.musicUrl,
-        );
+        AudioPlayerUtil().play();
       } else {
         if (mounted) {
           _assetsAudioPlayer.open(Audio("assets/audios/sound_play_wait.mp3"));

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_mlkit_commons/google_mlkit_commons.dart';
+import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
 import 'package:pocket_pose/main.dart';
+import 'package:provider/provider.dart';
 
 enum SkeletonDetectMode {
   playerWaitMode, // 플레이어가 춤 추기 전 준비하는 모드(스켈레톤 추출 O, 스켈레톤 배열에 저장 X)
@@ -57,9 +59,12 @@ class _CameraViewState extends State<CameraView> {
   int _seconds = 5;
   late Timer _timer;
   late AssetsAudioPlayer _assetsAudioPlayer;
+  late SocketStageProviderImpl _socketStageProvider;
 
   @override
   Widget build(BuildContext context) {
+    _socketStageProvider =
+        Provider.of<SocketStageProviderImpl>(context, listen: false);
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: Colors.transparent,
@@ -246,9 +251,9 @@ class _CameraViewState extends State<CameraView> {
             'assets/icons/ic_music_note_small.svg',
           ),
           const SizedBox(width: 8.0),
-          const Text(
-            "I AM-IVE",
-            style: TextStyle(fontSize: 10, color: Colors.white),
+          Text(
+            '${_socketStageProvider.catchMusicData?.singer} - ${_socketStageProvider.catchMusicData?.title}',
+            style: const TextStyle(fontSize: 10, color: Colors.white),
           ),
         ],
       ),

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -48,8 +48,8 @@ class _CameraViewState extends State<CameraView> {
   // 5초 카운트다운 텍스트
   bool _countdownVisibility = false;
   int _seconds = 5;
-  late Timer _timer;
-  late AssetsAudioPlayer _assetsAudioPlayer;
+  Timer? _timer;
+  AssetsAudioPlayer? _assetsAudioPlayer;
   late StageProviderImpl _stageProvider;
   late SocketStageProviderImpl _socketStageProvider;
 
@@ -140,7 +140,7 @@ class _CameraViewState extends State<CameraView> {
   }
 
   void _startTimer() {
-    _assetsAudioPlayer.open(Audio("assets/audios/sound_play_wait.mp3"));
+    _assetsAudioPlayer?.open(Audio("assets/audios/sound_play_wait.mp3"));
 
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (_seconds == 1) {
@@ -155,7 +155,7 @@ class _CameraViewState extends State<CameraView> {
         AudioPlayerUtil().play();
       } else {
         if (mounted) {
-          _assetsAudioPlayer.open(Audio("assets/audios/sound_play_wait.mp3"));
+          _assetsAudioPlayer?.open(Audio("assets/audios/sound_play_wait.mp3"));
           setState(() {
             _seconds--;
           });
@@ -165,13 +165,16 @@ class _CameraViewState extends State<CameraView> {
   }
 
   void _stopTimer() {
-    _timer.cancel();
+    _timer?.cancel();
+    _timer = null;
   }
 
   @override
   void dispose() {
     AudioPlayerUtil().stop();
-    _assetsAudioPlayer.dispose();
+    _assetsAudioPlayer = null;
+    _assetsAudioPlayer?.dispose();
+    _stopTimer();
 
     super.dispose();
   }

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -11,20 +11,11 @@ import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart
 import 'package:pocket_pose/main.dart';
 import 'package:provider/provider.dart';
 
-enum SkeletonDetectMode {
-  playerWaitMode, // 플레이어가 춤 추기 전 준비하는 모드(스켈레톤 추출 O, 스켈레톤 배열에 저장 X)
-  musicStartMode, // 노래 시작. 플레이어의 스켈레톤을 배열에 저장하는 모드 (스켈레톤 추출 O, 스켈레톤 배열에 저장 시작)
-  musicEndMode, // 노래 종료. 플레이어의 스켈레톤을 서버에 전달  (스켈레톤 추출 종료, 스켈레톤 배열에 저장 종료)
-  resultMode, // 결과 화면. 항상 스켈레톤 추출 (스켈레톤 추출 O, 스켈레톤 배열에 저장 X)
-  userMode // 유저 모드. 스켈레톤 추출 안 함 (스켈레톤 추출 X, 스켈레톤 배열에 저장 X)
-}
-
 // ignore: must_be_immutable
 class CameraView extends StatefulWidget {
   CameraView(
       {Key? key,
       required this.isResultState,
-      required this.setIsSkeletonDetectMode,
       this.customPaintLeft,
       required this.customPaintMid,
       this.customPaintRight,
@@ -32,8 +23,6 @@ class CameraView extends StatefulWidget {
       this.initialDirection = CameraLensDirection.back})
       : super(key: key);
   bool isResultState;
-  // skeleton 트리거
-  Function setIsSkeletonDetectMode;
   // 스켈레톤을 그려주는 객체
   final CustomPaint? customPaintLeft;
   final CustomPaint? customPaintMid;

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -194,10 +194,8 @@ class _CameraViewState extends State<CameraView> {
 
   @override
   void dispose() {
-    if (!widget.isResultState) {
-      AudioPlayerUtil().stop();
-      _assetsAudioPlayer.dispose();
-    }
+    AudioPlayerUtil().stop();
+    _assetsAudioPlayer.dispose();
 
     super.dispose();
   }

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -58,35 +58,12 @@ class _CameraViewState extends State<CameraView> {
     _socketStageProvider =
         Provider.of<SocketStageProviderImpl>(context, listen: true);
 
-    if (!_socketStageProvider.isPlayEnter) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _socketStageProvider.setIsPlayEnter(true);
+    // if (!_socketStageProvider.isPlayEnter) {
+    //   WidgetsBinding.instance.addPostFrameCallback((_) {
+    //     _socketStageProvider.setIsPlayEnter(true);
 
-        // 플레이 상태인 경우
-        if (!widget.isResultState) {
-          // 카운트다운
-          if (_stageProvider.stageElapsedTime < 1000000 * 1000 * 5) {
-            // 카운트다운 시작 후 노래 재생
-            _startTimer();
-            setState(() {
-              print(
-                  "mmm second: ${(_stageProvider.stageElapsedTime / 1000000 * 1000).round()}");
-              _seconds = (_stageProvider.stageElapsedTime).round();
-              _stageProvider.setStageElapsedTime();
-              _countdownVisibility = true;
-            });
-          }
-          // 노래 재생
-          else {
-            AudioPlayerUtil().play(
-              _socketStageProvider.catchMusicData!.musicUrl,
-            );
-          }
-        }
-        // 결과 상태인 경우
-        else {}
-      });
-    }
+    //   });
+    // }
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
@@ -131,6 +108,34 @@ class _CameraViewState extends State<CameraView> {
 
     _assetsAudioPlayer = AssetsAudioPlayer();
 
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // 플레이 상태인 경우
+      if (!widget.isResultState) {
+        var curSecond =
+            (_stageProvider.stageCurTime / (1000000 * 1000)).round();
+        print("mmmm cameraview sec: ${_stageProvider.stageCurTime}");
+        print("mmmm cameraview sec2: $curSecond");
+        // 카운트다운
+        if (curSecond < 5) {
+          // 카운트다운 시작 후 노래 재생
+          setState(() {
+            _seconds = 5 - curSecond;
+            _stageProvider.setStageCurTime();
+            _countdownVisibility = true;
+          });
+          _startTimer();
+        }
+        // 노래 재생
+        else {
+          AudioPlayerUtil().play(
+            _socketStageProvider.catchMusicData!.musicUrl,
+          );
+        }
+      }
+      // 결과 상태인 경우
+      else {}
+    });
+
     // // 결과 상태인 경우
     // if (widget.isResultState) {
     //   // AudioPlayerUtil().play(
@@ -168,6 +173,7 @@ class _CameraViewState extends State<CameraView> {
             _countdownVisibility = false;
           });
         }
+        _seconds = 5;
         AudioPlayerUtil().play(
           _socketStageProvider.catchMusicData!.musicUrl,
         );

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -27,11 +27,14 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   late AnimationController _animationController;
   late Animation<double> _opacityAnimation;
   late StageProviderImpl _stageProvider;
+  late SocketStageProviderImpl _socketStageProvider;
   StageType _prevStageType = StageType.CATCH_START;
 
   @override
   Widget build(BuildContext context) {
     _stageProvider = Provider.of<StageProviderImpl>(context, listen: true);
+    _socketStageProvider =
+        Provider.of<SocketStageProviderImpl>(context, listen: true);
     if (_prevStageType != widget.type) {
       _prevStageType = widget.type;
       _milliseconds = 0;
@@ -64,7 +67,8 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
                 style: TextStyle(fontSize: 18, color: Colors.white),
               ),
               const SizedBox(height: 10.0),
-              musicTitleContainer('I AM-IVE'),
+              musicTitleContainer(
+                  '${_socketStageProvider.catchMusicData?.singer} - ${_socketStageProvider.catchMusicData?.title}'),
               const SizedBox(height: 10.0),
               Flexible(
                 child: SvgPicture.asset(
@@ -194,7 +198,7 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
                 const SizedBox(width: 8.0),
                 Text(
                   title,
-                  style: const TextStyle(fontSize: 24, color: Colors.white),
+                  style: const TextStyle(fontSize: 12, color: Colors.white),
                 ),
               ],
             ),

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:external_path/external_path.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
@@ -293,52 +290,5 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     } else {
       _customPaintRight = null;
     }
-  }
-
-  // 파일화를 위한 배열 저장
-  List<double> _poseMapToInputList(Map<PoseLandmarkType, PoseLandmark> entry) {
-    return [
-      entry[PoseLandmarkType.nose]!.x,
-      entry[PoseLandmarkType.nose]!.y,
-      entry[PoseLandmarkType.rightShoulder]!.x,
-      entry[PoseLandmarkType.rightShoulder]!.y,
-      entry[PoseLandmarkType.rightElbow]!.x,
-      entry[PoseLandmarkType.rightElbow]!.y,
-      entry[PoseLandmarkType.rightWrist]!.x,
-      entry[PoseLandmarkType.rightWrist]!.y,
-      entry[PoseLandmarkType.leftShoulder]!.x,
-      entry[PoseLandmarkType.leftShoulder]!.y,
-      entry[PoseLandmarkType.leftElbow]!.x,
-      entry[PoseLandmarkType.leftElbow]!.y,
-      entry[PoseLandmarkType.leftWrist]!.x,
-      entry[PoseLandmarkType.leftWrist]!.y,
-      entry[PoseLandmarkType.rightHip]!.x,
-      entry[PoseLandmarkType.rightHip]!.y,
-      entry[PoseLandmarkType.rightKnee]!.x,
-      entry[PoseLandmarkType.rightKnee]!.y,
-      entry[PoseLandmarkType.rightAnkle]!.x,
-      entry[PoseLandmarkType.rightAnkle]!.y,
-      entry[PoseLandmarkType.leftHip]!.x,
-      entry[PoseLandmarkType.leftHip]!.y,
-      entry[PoseLandmarkType.leftKnee]!.x,
-      entry[PoseLandmarkType.leftKnee]!.y,
-      entry[PoseLandmarkType.leftAnkle]!.x,
-      entry[PoseLandmarkType.leftAnkle]!.y
-    ];
-  }
-
-  Future<void> skeletonToFile(List<List<double>> inputLists) async {
-    var today = DateTime.now().toString().substring(0, 9);
-    var now = DateTime.now();
-
-    final dir = await ExternalPath.getExternalStoragePublicDirectory(
-        ExternalPath.DIRECTORY_DOCUMENTS);
-    // 폴더 생성
-    String folderPath = '$dir/PoPo';
-    await Directory(folderPath).create(recursive: true);
-    // 파일 생성 및 저장
-    final path =
-        '$dir/PoPo/popo-skeleton-$today-${now.hour}-${now.minute}-${now.second}.txt';
-    File(path).writeAsString(inputLists.toString());
   }
 }

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -123,20 +123,18 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
             ],
           ),
         ),
-        CameraView(
-          isResultState: widget.isResultState,
-          // 스켈레톤 그려주는 객체 전달
-          customPaintLeft: _customPaintLeft,
-          customPaintMid: _customPaintMid,
-          customPaintRight: _customPaintRight,
-          // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
-          onImage: (inputImage) {
-            // 플레이어만 스켈레톤 추출
-            if (_isPlayer) {
+        if (_isPlayer)
+          CameraView(
+            isResultState: widget.isResultState,
+            // 스켈레톤 그려주는 객체 전달
+            customPaintLeft: _customPaintLeft,
+            customPaintMid: _customPaintMid,
+            customPaintRight: _customPaintRight,
+            // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
+            onImage: (inputImage) {
               processImage(inputImage);
-            }
-          },
-        ),
+            },
+          ),
       ],
     );
   }

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -41,13 +41,10 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
   CustomPaint? _customPaintLeft;
   CustomPaint? _customPaintMid;
   CustomPaint? _customPaintRight;
-  // 스켈레톤 추출할지 안할지, 추출한다면 배열에 저장할지 할지 관리하는 변수
-  final SkeletonDetectMode _skeletonDetectMode = SkeletonDetectMode.userMode;
   bool _isPlayer = false;
   int _playerNum = -1;
   int _frameNum = 0;
-  // input Lists
-  final List<List<double>> _inputLists = [];
+
   late SocketStageProviderImpl _socketStageProvider;
 
   @override
@@ -128,7 +125,6 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
         ),
         CameraView(
           isResultState: widget.isResultState,
-          setIsSkeletonDetectMode: setIsSkeletonDetectMode,
           // 스켈레톤 그려주는 객체 전달
           customPaintLeft: _customPaintLeft,
           customPaintMid: _customPaintMid,
@@ -260,13 +256,6 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     }
     _frameNum++;
 
-    // 사용자가 춤 추기 시작할 때 스켈레톤 배열에 저장
-    if (_skeletonDetectMode == SkeletonDetectMode.musicStartMode) {
-      for (final pose in poses) {
-        _inputLists.add(_poseMapToInputList(pose.landmarks));
-      }
-    }
-
     _isBusy = false;
     if (mounted) {
       setState(() {});
@@ -305,34 +294,6 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
       _customPaintRight = CustomPaint(painter: painterRignt);
     } else {
       _customPaintRight = null;
-    }
-  }
-
-  void setIsSkeletonDetectMode(SkeletonDetectMode mode) async {
-    if (_isPlayer && mounted) {
-      // setState(() {
-      //   _skeletonDetectMode = mode;
-
-      //   // 노래 끝나면 스켈레톤 서버에 보내기
-      //   if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
-      //     // 스켈레톤 파일로 저장: 실행 안 되도록 설정
-      //     if (1 > 2) {
-      //       skeletonToFile(_inputLists);
-      //     }
-
-      //     _provider
-      //         .postSkeletonList(_inputLists)
-      //         .then((value) => Fluttertoast.showToast(
-      //               msg: value.toString(),
-      //               toastLength: Toast.LENGTH_SHORT,
-      //               timeInSecForIosWeb: 1,
-      //               backgroundColor: Colors.black,
-      //               textColor: Colors.white,
-      //               fontSize: 16.0,
-      //             ))
-      //         .then((_) => _inputLists.clear());
-      //   }
-      // });
     }
   }
 

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -86,18 +86,19 @@ class _PoPoResultViewState extends State<PoPoResultView> {
             ],
           ),
         ),
-        CameraView(
-          isResultState: widget.isResultState,
-          // 스켈레톤 그려주는 객체 전달
-          customPaintMid: _customPaintMid,
-          // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
-          onImage: (inputImage) {
-            // 플레이어만 스켈레톤 추출
-            if (_isPlayer) {
-              processImage(inputImage);
-            }
-          },
-        ),
+        if (_isPlayer)
+          CameraView(
+            isResultState: widget.isResultState,
+            // 스켈레톤 그려주는 객체 전달
+            customPaintMid: _customPaintMid,
+            // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
+            onImage: (inputImage) {
+              // 플레이어만 스켈레톤 추출
+              if (_isPlayer) {
+                processImage(inputImage);
+              }
+            },
+          ),
       ],
     );
   }

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -88,7 +88,6 @@ class _PoPoResultViewState extends State<PoPoResultView> {
         ),
         CameraView(
           isResultState: widget.isResultState,
-          setIsSkeletonDetectMode: setIsSkeletonDetectMode,
           // 스켈레톤 그려주는 객체 전달
           customPaintMid: _customPaintMid,
           // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
@@ -224,19 +223,6 @@ class _PoPoResultViewState extends State<PoPoResultView> {
     _isBusy = false;
     if (mounted) {
       setState(() {});
-    }
-  }
-
-  void setIsSkeletonDetectMode(SkeletonDetectMode mode) async {
-    if (_isPlayer && mounted) {
-      // setState(() {
-      //   _skeletonDetectMode = mode;
-
-      //   // 노래 끝나면 대기 화면으로 이동
-      //   if (_skeletonDetectMode == SkeletonDetectMode.musicEndMode) {
-      //     _inputLists.clear();
-      //   }
-      // });
     }
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,9 @@ import Foundation
 import assets_audio_player
 import assets_audio_player_web
 import audio_session
-import audioplayers
 import file_selector_macos
 import flutter_secure_storage_macos
+import just_audio
 import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
@@ -19,9 +19,9 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AssetsAudioPlayerPlugin.register(with: registry.registrar(forPlugin: "AssetsAudioPlayerPlugin"))
   AssetsAudioPlayerWebPlugin.register(with: registry.registrar(forPlugin: "AssetsAudioPlayerWebPlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
-  AudioplayersPlugin.register(with: registry.registrar(forPlugin: "AudioplayersPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,14 +73,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.16"
-  audioplayers:
-    dependency: "direct main"
-    description:
-      name: audioplayers
-      sha256: a565e7e3e8a21a823b8cd7fed0bde1eb3796a96b373374be557adecfb511fa6b
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.20.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -720,6 +712,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.0"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: "890cd0fc41a1a4530c171e375a2a3fb6a09d84e9d508c5195f40bcff54330327"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.34"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: d8409da198bbc59426cd45d4c92fca522a2ec269b576ce29459d6d6fcaeb44df
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: ff62f733f437b25a0ff590f0e295fa5441dcb465f1edbdb33b3dea264705bc13
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.8"
   kakao_flutter_sdk_auth:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   http: ^0.13.5
   dio: ^5.0.3
   audio_session: ^0.1.15
-  audioplayers: ^0.20.0
+  just_audio: ^0.9.34
   video_player: ^2.6.1
   json_annotation: ^4.8.0
   change_app_package_name: ^1.1.0


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/2fc98e1a-e9e1-415d-9c30-a12895df4dbf

## 💬 작업 설명
- 스테이지 중간 입장 처리(5초 카운트다운 시 중간입장, 노래 재생 시 중간입장) 기능 추가하였습니다.
- 위 영상은 스테이지 입장 후 카운트다운 할 때 퇴장했다가 중간에 입장한 경우, 노래 재생 중 퇴장했다가 중간 입장한 경우를 담았습니다~~!
- 애뮬에서는 스켈레톤 추출을 안 해서 그런지 중간 퇴장하고 노래 재생하는 게 빠른데... 실기기에서는 스켈레톤을 추출해서 그런지 중간에 입장하고 노래 재생하는 데에 시간이 조금(1초) 걸립니다...

## ✅ 한 일
1. 퇴장요청 api 변경
2. 스테이지 중간 입장 처리(5초 카운트다운 시 중간입장, 노래 재생 시 중간입장)
3. 스테이지 음악 연결

## 😥 어려웠던점
1. 중간 입장 논리 로직 짜는 것이 어려웠습니다... 논리로직은 너무나 어려워

## 🤓 다음에 할 일
1. 스테이지 실시간 채팅 페이지네이션
2. 스테이지 플레이어 인원별 ui 다르게
3. 스테이지 동영상 녹화 후 업로드
4. 캐치, 카운트다운 사운드 변경
