### PR TITLE
[feat] 스테이지 캐치, 결과 화면 중간입장 처리(HH-339)

### DIFF
--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -1,8 +1,6 @@
-import 'package:camera/camera.dart';
 import 'package:just_audio/just_audio.dart';
 
 class AudioPlayerUtil {
-  CameraController? _controller;
   // late AudioSession? audioSession;
   AudioPlayer player = AudioPlayer();
 
@@ -12,10 +10,6 @@ class AudioPlayerUtil {
 
   AudioPlayerUtil._internal() {
     // _audioSessionConfigure();
-  }
-
-  setCameraController(CameraController? cameraController) {
-    _controller = cameraController;
   }
 
   setMusicUrl(String musicUrl) async {
@@ -38,13 +32,6 @@ class AudioPlayerUtil {
   }
 
   stop() async {
-    // 카메라 종료(포포 스테이지 종료)
-    if (_controller != null) {
-      _controller = null;
-      await _controller?.stopImageStream();
-      await _controller?.dispose();
-    }
-
     // 내부 음악 종료
     await player.stop();
     // 외부 음악 실행

--- a/lib/config/audio_player/audio_player_util.dart
+++ b/lib/config/audio_player/audio_player_util.dart
@@ -2,7 +2,7 @@ import 'package:just_audio/just_audio.dart';
 
 class AudioPlayerUtil {
   // late AudioSession? audioSession;
-  AudioPlayer player = AudioPlayer();
+  AudioPlayer? player = AudioPlayer();
 
   static final AudioPlayerUtil _instance = AudioPlayerUtil._internal();
 
@@ -13,27 +13,27 @@ class AudioPlayerUtil {
   }
 
   setMusicUrl(String musicUrl) async {
-    await player.setUrl(musicUrl);
+    await player?.setUrl(musicUrl);
   }
 
   play() async {
     // 내부 음악 실행
-    await player.play();
+    await player?.play();
     // 외부 음악 종료
     // await audioSession?.setActive(false);
   }
 
   playSeek(int sec) async {
     // 내부 음악 실행
-    await player.seek(Duration(seconds: sec));
-    await player.play();
+    await player?.seek(Duration(seconds: sec));
+    await player?.play();
     // 외부 음악 종료
     // await audioSession?.setActive(false);
   }
 
   stop() async {
     // 내부 음악 종료
-    await player.stop();
+    await player?.stop();
     // 외부 음악 실행
     // await audioSession?.setActive(true);
   }

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -89,6 +89,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool _isTalk = false;
   bool _isReaction = false;
   bool _isUserCountChange = false;
+  bool _isCatchMidEnter = false;
   bool _isPlaySkeletonChange = false;
   bool _isMVPSkeletonChange = false;
 
@@ -105,6 +106,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool get isTalk => _isTalk;
   bool get isReaction => _isReaction;
   bool get isUserCountChange => _isUserCountChange;
+  bool get isCatchMidEnter => _isCatchMidEnter;
   bool get isPlaySkeletonChange => _isPlaySkeletonChange;
   bool get isMVPSkeletonChange => _isMVPSkeletonChange;
 
@@ -136,6 +138,11 @@ class SocketStageProviderImpl extends ChangeNotifier
 
   setIsUserCountChange(bool value) {
     _isUserCountChange = value;
+    if (value) notifyListeners();
+  }
+
+  setIsCatchMidEnter(bool value) {
+    _isCatchMidEnter = value;
     if (value) notifyListeners();
   }
 

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -124,6 +124,9 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
             .then((value) {
               stageType = StageType.values.byName(value.data.stageStatus);
               _socketStageProvider.setUserCount(value.data.userCount);
+              if (stageType == StageType.CATCH) {
+                _socketStageProvider.setIsCatchMidEnter(true);
+              }
             })
             .then((_) => _socketStageProvider.setStageView(stageType))
             .then((_) => _socketStageProvider.onSubscribe());

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -96,11 +96,13 @@ class _CameraViewState extends State<CameraView> {
       _startLiveFeed();
     }
 
-    // AudioPlayer 초기화
-    AudioPlayerUtil().setCameraController(_controller);
-
     _assetsAudioPlayer = AssetsAudioPlayer();
 
+    // 중간입장 처리
+    _onMidEnter();
+  }
+
+  void _onMidEnter() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 플레이 상태인 경우
       if (!widget.isResultState) {
@@ -131,7 +133,21 @@ class _CameraViewState extends State<CameraView> {
         }
       }
       // 결과 상태인 경우
-      else {}
+      else {
+        AudioPlayerUtil().setMusicUrl(
+            "https://popo2023.s3.ap-northeast-2.amazonaws.com/effect/Happyhappy.mp3");
+        // 중간임장인 경우
+        if (_stageProvider.stageCurTime != null) {
+          // 중간 입장한 초부터 시작
+          _seconds = (_stageProvider.stageCurTime! / (1000000 * 1000)).round();
+          _stageProvider.setStageCurSecondNULL();
+          AudioPlayerUtil().playSeek(_seconds);
+        } else {
+          // 중간입장 아닐 시 0초부터 시작
+          _seconds = 0;
+          AudioPlayerUtil().play();
+        }
+      }
     });
   }
 
@@ -167,7 +183,7 @@ class _CameraViewState extends State<CameraView> {
 
   @override
   void dispose() {
-    AudioPlayerUtil().stop();
+    // AudioPlayerUtil().stop();
     _assetsAudioPlayer = null;
     _assetsAudioPlayer?.dispose();
     _stopTimer();

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -58,13 +58,6 @@ class _CameraViewState extends State<CameraView> {
     _socketStageProvider =
         Provider.of<SocketStageProviderImpl>(context, listen: true);
 
-    // if (!_socketStageProvider.isPlayEnter) {
-    //   WidgetsBinding.instance.addPostFrameCallback((_) {
-    //     _socketStageProvider.setIsPlayEnter(true);
-
-    //   });
-    // }
-
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: Colors.transparent,
@@ -114,10 +107,13 @@ class _CameraViewState extends State<CameraView> {
         AudioPlayerUtil()
             .setMusicUrl(_socketStageProvider.catchMusicData!.musicUrl);
 
+        // 중간임장인 경우
         if (_stageProvider.stageCurTime != null) {
+          // 중간 입장한 초부터 시작
           _seconds = (_stageProvider.stageCurTime! / (1000000 * 1000)).round();
           _stageProvider.setStageCurSecondNULL();
         } else {
+          // 중간입장 아닐 시 0초부터 시작
           _seconds = 0;
         }
         // 카운트다운

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
 import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:provider/provider.dart';
@@ -152,6 +153,7 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   void initState() {
     super.initState();
 
+    AudioPlayerUtil().stop();
     _startTimer();
 
     _animationController = AnimationController(

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -23,7 +23,7 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
     with SingleTickerProviderStateMixin {
   int _milliseconds = 0;
   double _catchCountDown = 0.0;
-  late Timer _timer;
+  Timer? _timer;
   late AnimationController _animationController;
   late Animation<double> _opacityAnimation;
   late StageProviderImpl _stageProvider;
@@ -35,19 +35,12 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
     _stageProvider = Provider.of<StageProviderImpl>(context, listen: true);
     _socketStageProvider =
         Provider.of<SocketStageProviderImpl>(context, listen: true);
+
+    _onMidEnter();
+
+    // 캐치 재진행인 경우 토스트 띄우고 카운트다운 재시작
     if (_prevStageType != widget.type) {
-      _prevStageType = widget.type;
-      _milliseconds = 0;
-      _catchCountDown = 0.0;
-      _startTimer();
-      Fluttertoast.showToast(
-        msg: "캐치를 아무도 안 했어요...😢",
-        toastLength: Toast.LENGTH_SHORT,
-        timeInSecForIosWeb: 1,
-        backgroundColor: Colors.black,
-        textColor: Colors.white,
-        fontSize: 16.0,
-      );
+      _reCountDown();
     }
 
     return Column(
@@ -90,12 +83,43 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
     );
   }
 
+  void _onMidEnter() {
+    if (_socketStageProvider.isCatchMidEnter) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _socketStageProvider.setIsCatchMidEnter(false);
+        // 중간임장인 경우
+        if (_stageProvider.stageCurTime != null) {
+          // 중간 입장한 초부터 시작
+          setState(() {
+            _milliseconds = (_stageProvider.stageCurTime! / 1000000).round();
+          });
+          _stageProvider.setStageCurSecondNULL();
+        }
+      });
+    }
+  }
+
+  void _reCountDown() {
+    _prevStageType = widget.type;
+    _milliseconds = 0;
+    _catchCountDown = 0.0;
+    _startTimer();
+    Fluttertoast.showToast(
+      msg: "캐치를 아무도 안 했어요...😢",
+      toastLength: Toast.LENGTH_SHORT,
+      timeInSecForIosWeb: 1,
+      backgroundColor: Colors.black,
+      textColor: Colors.white,
+      fontSize: 16.0,
+    );
+  }
+
   SizedBox _buildCatchButton() {
     return SizedBox(
       width: 100,
       height: 45,
       child: SemicircularIndicator(
-        progress: _catchCountDown,
+        progress: (_catchCountDown > 1) ? 1 : _catchCountDown,
         color: Colors.yellow,
         bottomPadding: 0,
         strokeWidth: 2,
@@ -157,9 +181,7 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   }
 
   void _stopTimer() {
-    if (_timer.isActive) {
-      _timer.cancel();
-    }
+    _timer?.cancel();
   }
 
   @override


### PR DESCRIPTION
## 📱 작업 사진 
- 스테이지 캐치 화면 중간입장 처리: 프로그레스 바 중간부터 시작
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/dd41dfef-be60-4cb6-973f-e0cd4d84d825
- 스테이지 결과 화면 중간입장 처리: 노래 중간부터 재생
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/b8b2402c-25f1-4ebc-b98b-2956be8a2171

## 💬 작업 설명
- 스테이지 캐치, 결과 화면의 중간 입장 시 중간부터 자연스럽게 진행될 수 있도록 수정하였습니다.
- 이로써 캐치, 플레이, 결과 화면 모두 중간 입장 로직 처리가 완료되었습니다!

## ✅ 한 일
1. 스테이지 캐치 화면 중간 입장 처리
2. 스테이지 결과 화면 중간 입장 처리

## 😥 어려웠던점
1. 논리 로직은 정말 헷갈려🥲

## ☝️ 참고 하세요~
1. 스테이지 캐치 중간입장 확인하는 게 좀 어려울 수 있습니다... 캐치 시간이 3초이다보니 프로그래스바가 중간까지 차있는 경우를 보려면 1~2초 정도에 입장해야하는데 그게 어려워요...ㅎㅎ

## 🤓 다음에 할 일
1. 스테이지 실시간 채팅 페이지네이션
2. 스테이지 플레이어 인원별 ui 다르게
3. 스테이지 동영상 녹화 후 업로드
4. 캐치, 카운트다운 사운드 변경
