### PR TITLE
[bug] #76 홈, 프로필 UI 오류 해결 (HH-274)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -6,6 +6,7 @@ class AppColor {
   static Color purpleColor = const Color(0xFFB259F8);
   static Color purpleColor2 = const Color(0xFFBD00FF);
   static Color purpleColor3 = const Color(0xFFBFC1F4);
+  static Color whiteColor = const Color.fromARGB(255, 252, 253, 255);
   static Color blackColor = const Color(0xFF414B5A);
   static Color grayColor = const Color(0xFF3F3F3F);
   static Color grayColor1 = const Color(0xFFE7EBF0);

--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -105,7 +105,7 @@ class _ProfileScreenState extends State<ProfileScreen>
                   child: Column(
                     children: [
                       Container(
-                        color: Colors.white,
+                        color: AppColor.whiteColor,
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
@@ -150,7 +150,7 @@ class _ProfileScreenState extends State<ProfileScreen>
                 ),
                 SliverAppBar(
                   pinned: true,
-                  backgroundColor: Colors.white,
+                  backgroundColor: AppColor.whiteColor,
                   toolbarHeight: 0.0,
                   bottom: TabBar(
                     controller: _tabController,

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -288,10 +288,10 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
                 child: Center(
                   child: Icon(
                     isPlaying
-                        ? Icons.play_circle_filled_rounded
-                        : Icons.pause_circle_filled_rounded,
+                        ? Icons.play_circle_filled_sharp
+                        : Icons.pause_circle_filled_sharp,
                     size: 60,
-                    color: const Color.fromARGB(60, 234, 234, 234),
+                    color: const Color.fromARGB(127, 147, 147, 147),
                   ),
                 ),
               );

--- a/lib/ui/video_viewer/video_view.dart
+++ b/lib/ui/video_viewer/video_view.dart
@@ -51,16 +51,18 @@ class _VideoViewState extends State<VideoView>
           .then((value) {
         final response = videoProvider.response;
 
-        if (response != null) {
-          setState(() {
-            if (response.videoList.isNotEmpty) {
-              _multiVideoPlayProvider.addVideos(response.videoList);
-            }
-            if (response.isLast) {
-              _multiVideoPlayProvider.isLast = true;
-              return;
-            }
-          });
+        if (mounted) {
+          if (response != null) {
+            setState(() {
+              if (response.videoList.isNotEmpty) {
+                _multiVideoPlayProvider.addVideos(response.videoList);
+              }
+              if (response.isLast) {
+                _multiVideoPlayProvider.isLast = true;
+                return;
+              }
+            });
+          }
         }
       });
 
@@ -74,31 +76,33 @@ class _VideoViewState extends State<VideoView>
   }
 
   void onPageChanged(int index) {
-    setState(() {
-      _multiVideoPlayProvider.pauseVideo();
+    if (mounted) {
+      setState(() {
+        _multiVideoPlayProvider.pauseVideo();
 
-      if (!_multiVideoPlayProvider.isLast) {
-        _multiVideoPlayProvider.currentIndex = index;
-
-        if (_multiVideoPlayProvider.videoList.length -
-                _multiVideoPlayProvider.currentIndex <=
-            _multiVideoPlayProvider.PAGESIZE - 1) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            _loadMoreVideos();
-          });
-        }
-      } else {
-        if (_multiVideoPlayProvider.videoList.length == index) {
-          // 마지막 페이지에 도달했을 때 페이지를 0으로 바로 이동
-          _multiVideoPlayProvider.pageController.jumpToPage(0);
-          _multiVideoPlayProvider.currentIndex = 0;
-        } else {
+        if (!_multiVideoPlayProvider.isLast) {
           _multiVideoPlayProvider.currentIndex = index;
-        }
-      }
 
-      _multiVideoPlayProvider.playVideo();
-    });
+          if (_multiVideoPlayProvider.videoList.length -
+                  _multiVideoPlayProvider.currentIndex <=
+              _multiVideoPlayProvider.PAGESIZE - 1) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _loadMoreVideos();
+            });
+          }
+        } else {
+          if (_multiVideoPlayProvider.videoList.length == index) {
+            // 마지막 페이지에 도달했을 때 페이지를 0으로 바로 이동
+            _multiVideoPlayProvider.pageController.jumpToPage(0);
+            _multiVideoPlayProvider.currentIndex = 0;
+          } else {
+            _multiVideoPlayProvider.currentIndex = index;
+          }
+        }
+
+        _multiVideoPlayProvider.playVideo();
+      });
+    }
   }
 
   @override
@@ -113,9 +117,11 @@ class _VideoViewState extends State<VideoView>
 
     return RefreshIndicator(
       onRefresh: () async {
-        setState(() {
-          _multiVideoPlayProvider.resetVideoPlayer();
-        });
+        if (mounted) {
+          setState(() {
+            _multiVideoPlayProvider.resetVideoPlayer();
+          });
+        }
       },
       color: AppColor.purpleColor,
       child: Stack(
@@ -225,18 +231,20 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
   }
 
   void _toggleIconVisibility(bool newValue) {
-    setState(() {
-      isIconVisible = newValue;
-      if (isIconVisible) {
-        _animationController.forward();
-      } else {
-        _animationController.reverse().then((_) {
-          setState(() {
-            isIconVisible = false;
+    if (mounted) {
+      setState(() {
+        isIconVisible = newValue;
+        if (isIconVisible) {
+          _animationController.forward();
+        } else {
+          _animationController.reverse().then((_) {
+            setState(() {
+              isIconVisible = false;
+            });
           });
-        });
-      }
-    });
+        }
+      });
+    }
   }
 
   @override

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -33,7 +33,7 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
   late KaKaoLoginProvider _loginProvider;
   late final CommentProvider _commentProvider =
       Provider.of<CommentProvider>(context, listen: false);
-  late List<CommentData>? _commentList;
+  List<CommentData>? _commentList = [];
   final ScrollController _scrollController = ScrollController();
   late final MultiVideoPlayProvider _multiVideoPlayProvider =
       Provider.of<MultiVideoPlayProvider>(context, listen: false);

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -426,7 +426,7 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                       mainAxisAlignment:
                                           MainAxisAlignment.spaceEvenly,
                                       crossAxisAlignment:
-                                          CrossAxisAlignment.end,
+                                          CrossAxisAlignment.center,
                                       children: [
                                         for (int i = 0;
                                             i < emojiList.length;
@@ -466,8 +466,9 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                                             },
                                             child: Text(
                                               emojiList[i],
-                                              style:
-                                                  const TextStyle(fontSize: 20),
+                                              style: const TextStyle(
+                                                fontSize: 20,
+                                              ),
                                             ),
                                           ),
                                       ],

--- a/lib/ui/video_viewer/widget/comment_button_widget.dart
+++ b/lib/ui/video_viewer/widget/comment_button_widget.dart
@@ -66,10 +66,12 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
               _commentList = newCommentList?.reversed.toList();
 
               // commentCount api 완성되면 삭제
-              _isNotEmptyComment =
-                  _commentList != null || _commentList!.isNotEmpty;
+              // _isNotEmptyComment =
+              //     _commentList != null || _commentList!.isNotEmpty;
               // commentCount api 완성되면 주석 해제
-              // _isNotEmptyComment =_videoPlayProvider.videoList[widget.index].commentCount > 0;
+              _isNotEmptyComment =
+                  _multiVideoPlayProvider.videoList[widget.index].commentCount >
+                      0;
             });
           });
         }
@@ -107,9 +109,10 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
           _commentList = newCommentList?.reversed.toList();
 
           // commentCount api 완성되면 삭제
-          _isNotEmptyComment = _commentList != null || _commentList!.isNotEmpty;
+          //_isNotEmptyComment = _commentList != null || _commentList!.isNotEmpty;
           // commentCount api 완성되면 주석 해제
-          // _isNotEmptyComment =_videoPlayProvider.videoList[widget.index].commentCount > 0;
+          _isNotEmptyComment =
+              _multiVideoPlayProvider.videoList[widget.index].commentCount > 0;
         });
       }
     });
@@ -198,196 +201,207 @@ class _CommentButtonWidgetState extends State<CommentButtonWidget> {
                             ),
                           ),
                           resizeToAvoidBottomInset: true,
-                          body: Padding(
-                            padding: const EdgeInsets.only(bottom: 95),
-                            child: Visibility(
-                                visible: _isNotEmptyComment,
-                                replacement:
-                                    const Center(child: Text('등록된 댓글이 없습니다.')),
-                                child: ListView.builder(
-                                  controller: _scrollController,
-                                  itemCount: _commentList?.length,
-                                  itemBuilder: (context, index) {
-                                    final year =
-                                        _commentList?[index].createdAt.year;
-                                    final month = _commentList?[index]
-                                        .createdAt
-                                        .month
-                                        .toString()
-                                        .padLeft(2, '0');
+                          body: SingleChildScrollView(
+                            controller: _scrollController,
+                            child: Padding(
+                              padding: const EdgeInsets.only(bottom: 95),
+                              child: Visibility(
+                                  visible: _isNotEmptyComment,
+                                  replacement: const Padding(
+                                    padding: EdgeInsets.fromLTRB(0, 50, 0, 0),
+                                    child:
+                                        Center(child: Text('등록된 댓글이 없습니다. 🥲')),
+                                  ),
+                                  child: ListView.builder(
+                                    shrinkWrap: true,
+                                    controller: _scrollController,
+                                    itemCount: _commentList?.length,
+                                    itemBuilder: (context, index) {
+                                      final year =
+                                          _commentList?[index].createdAt.year;
+                                      final month = _commentList?[index]
+                                          .createdAt
+                                          .month
+                                          .toString()
+                                          .padLeft(2, '0');
 
-                                    final day = _commentList?[index]
-                                        .createdAt
-                                        .day
-                                        .toString()
-                                        .padLeft(2, '0');
+                                      final day = _commentList?[index]
+                                          .createdAt
+                                          .day
+                                          .toString()
+                                          .padLeft(2, '0');
 
-                                    final hour = _commentList?[index]
-                                        .createdAt
-                                        .hour
-                                        .toString()
-                                        .padLeft(2, '0');
-                                    final minute = _commentList?[index]
-                                        .createdAt
-                                        .minute
-                                        .toString()
-                                        .padLeft(2, '0');
-                                    final createdAt =
-                                        '$year-$month-$day $hour:$minute';
+                                      final hour = _commentList?[index]
+                                          .createdAt
+                                          .hour
+                                          .toString()
+                                          .padLeft(2, '0');
+                                      final minute = _commentList?[index]
+                                          .createdAt
+                                          .minute
+                                          .toString()
+                                          .padLeft(2, '0');
+                                      final createdAt =
+                                          '$year-$month-$day $hour:$minute';
 
-                                    return Padding(
-                                      padding: const EdgeInsets.only(top: 8),
-                                      child: Row(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.spaceBetween,
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Padding(
-                                            padding: const EdgeInsets.fromLTRB(
-                                                18, 4, 0, 12),
-                                            child: Row(
-                                              crossAxisAlignment:
-                                                  CrossAxisAlignment.start,
-                                              children: [
-                                                ClipRRect(
-                                                    borderRadius:
-                                                        BorderRadius.circular(
-                                                            50),
-                                                    child: Image.network(
-                                                      _commentList?[index]
-                                                              .user
-                                                              .profileImg ??
+                                      return Padding(
+                                        padding: const EdgeInsets.only(top: 8),
+                                        child: Row(
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.spaceBetween,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: [
+                                            Padding(
+                                              padding:
+                                                  const EdgeInsets.fromLTRB(
+                                                      18, 4, 0, 12),
+                                              child: Row(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.start,
+                                                children: [
+                                                  ClipRRect(
+                                                      borderRadius:
+                                                          BorderRadius.circular(
+                                                              50),
+                                                      child: Image.network(
+                                                        _commentList?[index]
+                                                                .user
+                                                                .profileImg ??
+                                                            'assets/images/charactor_popo_default.png',
+                                                        loadingBuilder: (context,
+                                                            child,
+                                                            loadingProgress) {
+                                                          if (loadingProgress ==
+                                                              null) {
+                                                            return child;
+                                                          }
+                                                          return Center(
+                                                            child:
+                                                                CircularProgressIndicator(
+                                                              color: AppColor
+                                                                  .purpleColor,
+                                                            ),
+                                                          );
+                                                        },
+                                                        errorBuilder: (context,
+                                                                error,
+                                                                stackTrace) =>
+                                                            Image.asset(
                                                           'assets/images/charactor_popo_default.png',
-                                                      loadingBuilder: (context,
-                                                          child,
-                                                          loadingProgress) {
-                                                        if (loadingProgress ==
-                                                            null) {
-                                                          return child;
-                                                        }
-                                                        return Center(
-                                                          child:
-                                                              CircularProgressIndicator(
-                                                            color: AppColor
-                                                                .purpleColor,
-                                                          ),
-                                                        );
-                                                      },
-                                                      errorBuilder: (context,
-                                                              error,
-                                                              stackTrace) =>
-                                                          Image.asset(
-                                                        'assets/images/charactor_popo_default.png',
+                                                          fit: BoxFit.cover,
+                                                          width: 35,
+                                                          height: 35,
+                                                        ),
                                                         fit: BoxFit.cover,
                                                         width: 35,
                                                         height: 35,
-                                                      ),
-                                                      fit: BoxFit.cover,
-                                                      width: 35,
-                                                      height: 35,
-                                                    )),
-                                                const Padding(
-                                                    padding: EdgeInsets.only(
-                                                        left: 8)),
-                                                Column(
-                                                  crossAxisAlignment:
-                                                      CrossAxisAlignment.start,
-                                                  children: [
-                                                    Text(
-                                                      _commentList?[index]
-                                                              .user
-                                                              .nickname ??
-                                                          '',
-                                                      style: const TextStyle(
-                                                          fontSize: 12),
-                                                    ),
-                                                    const Padding(
-                                                        padding:
-                                                            EdgeInsets.only(
-                                                                bottom: 8)),
-                                                    SizedBox(
-                                                      width:
-                                                          MediaQuery.of(context)
-                                                                  .size
-                                                                  .width -
-                                                              120,
-                                                      child: Text(
+                                                      )),
+                                                  const Padding(
+                                                      padding: EdgeInsets.only(
+                                                          left: 8)),
+                                                  Column(
+                                                    crossAxisAlignment:
+                                                        CrossAxisAlignment
+                                                            .start,
+                                                    children: [
+                                                      Text(
                                                         _commentList?[index]
-                                                                .content ??
+                                                                .user
+                                                                .nickname ??
                                                             '',
                                                         style: const TextStyle(
-                                                            fontSize: 14),
-                                                        maxLines: 50,
-                                                        overflow: TextOverflow
-                                                            .ellipsis,
+                                                            fontSize: 12),
                                                       ),
-                                                    ),
-                                                    const Padding(
-                                                        padding:
-                                                            EdgeInsets.only(
-                                                                bottom: 4)),
-                                                    Text(
-                                                      createdAt,
-                                                      style: TextStyle(
-                                                          fontSize: 10,
-                                                          color: AppColor
-                                                              .grayColor2),
-                                                    ),
-                                                  ],
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                          Visibility(
-                                            visible: user != null &&
-                                                user!.userId ==
-                                                    _commentList?[index]
-                                                        .user
-                                                        .userId,
-                                            child: Padding(
-                                              padding:
-                                                  const EdgeInsets.fromLTRB(
-                                                      0, 4, 18, 12),
-                                              child: GestureDetector(
-                                                onTap: () {
-                                                  _commentProvider
-                                                      .deleteComment(
+                                                      const Padding(
+                                                          padding:
+                                                              EdgeInsets.only(
+                                                                  bottom: 8)),
+                                                      SizedBox(
+                                                        width: MediaQuery.of(
+                                                                    context)
+                                                                .size
+                                                                .width -
+                                                            120,
+                                                        child: Text(
                                                           _commentList?[index]
-                                                                  .uuid ??
-                                                              '')
-                                                      .then((value) {
-                                                    _loadCommentList(
-                                                        bottomState);
-                                                    Fluttertoast.showToast(
-                                                        msg: '댓글이 삭제되었습니다.');
-                                                    if (mounted) {
-                                                      bottomState(() {
-                                                        setState(() {
-                                                          _multiVideoPlayProvider
-                                                              .videoList[
-                                                                  widget.index]
-                                                              .commentCount--;
+                                                                  .content ??
+                                                              '',
+                                                          style:
+                                                              const TextStyle(
+                                                                  fontSize: 14),
+                                                          maxLines: 50,
+                                                          overflow: TextOverflow
+                                                              .ellipsis,
+                                                        ),
+                                                      ),
+                                                      const Padding(
+                                                          padding:
+                                                              EdgeInsets.only(
+                                                                  bottom: 4)),
+                                                      Text(
+                                                        createdAt,
+                                                        style: TextStyle(
+                                                            fontSize: 10,
+                                                            color: AppColor
+                                                                .grayColor2),
+                                                      ),
+                                                    ],
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                            Visibility(
+                                              visible: user != null &&
+                                                  user!.userId ==
+                                                      _commentList?[index]
+                                                          .user
+                                                          .userId,
+                                              child: Padding(
+                                                padding:
+                                                    const EdgeInsets.fromLTRB(
+                                                        0, 4, 18, 12),
+                                                child: GestureDetector(
+                                                  onTap: () {
+                                                    _commentProvider
+                                                        .deleteComment(
+                                                            _commentList?[index]
+                                                                    .uuid ??
+                                                                '')
+                                                        .then((value) {
+                                                      _loadCommentList(
+                                                          bottomState);
+                                                      Fluttertoast.showToast(
+                                                          msg: '댓글이 삭제되었습니다.');
+                                                      if (mounted) {
+                                                        bottomState(() {
+                                                          setState(() {
+                                                            _multiVideoPlayProvider
+                                                                .videoList[
+                                                                    widget
+                                                                        .index]
+                                                                .commentCount--;
+                                                          });
                                                         });
-                                                      });
-                                                    }
-                                                  });
-                                                },
-                                                child: Text(
-                                                  '삭제',
-                                                  style: TextStyle(
-                                                      fontSize: 10,
-                                                      color:
-                                                          AppColor.grayColor2),
+                                                      }
+                                                    });
+                                                  },
+                                                  child: Text(
+                                                    '삭제',
+                                                    style: TextStyle(
+                                                        fontSize: 10,
+                                                        color: AppColor
+                                                            .grayColor2),
+                                                  ),
                                                 ),
                                               ),
                                             ),
-                                          ),
-                                        ],
-                                      ),
-                                    );
-                                  },
-                                )),
+                                          ],
+                                        ),
+                                      );
+                                    },
+                                  )),
+                            ),
                           ),
                           bottomSheet: SizedBox(
                             height: 100,

--- a/lib/ui/widget/profile/profile_user_info_widget.dart
+++ b/lib/ui/widget/profile/profile_user_info_widget.dart
@@ -32,7 +32,7 @@ class ProfileUserInfoWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Colors.white,
+      color: AppColor.whiteColor,
       height: 300,
       child: Center(
           child: Column(


### PR DESCRIPTION
## 📱 작업 사진 

## 💬 작업 설명
#76 홈, 프로필의 UI 오류를 해결했습니다.

## ✅ 한 일
1. 홈에서 댓글 누를 때 _commentList가 init 되지 않았다는 오류 나오지 않게 처리
-> 민영님이 보셨다는데 저는 여러번 테스트 해봐도 이 오류가 보이지 않았습니다. 일단 오류나지 않게 처리는 해놨습니다.
2. 등록된 댓글이 없는 경우 ui 변경
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/82979f98-80f6-4c1a-9abf-0222ae854039

4. 영상 재생/정지 시 dispose 후 setState 된 오류 해결
5. 영상 재생/정지 아이콘 디자인 수정 (HH-274)
-> 이전의 색이 연해 잘 안보여서 진하게 수정했습니다.
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/00ce8f06-a03f-4e5b-b037-8fc266b359ed

6. 프로필 페이지의 앱바, 사용자 정보, 탭바의 색 모두 통일
7. 댓글의 이모티콘 바의 희미한 회색 선 안지워져서 자연스럽게 수정

## 💃 부탁 드립니다~
1. 6,7 부분 화면 캡쳐와 감상평(?) 부탁드립니다~

## 🤓 다음에 할 일
1. 조회수 등록 api 연결
2. 조회수 조회 api 연결
3. 사용자 프로필 정보 조회 api 연결
