### PR TITLE
[feat] 조회수 등록 api 연결 (HH-346)

### DIFF
--- a/lib/data/remote/provider/video_provider.dart
+++ b/lib/data/remote/provider/video_provider.dart
@@ -31,4 +31,14 @@ class VideoProvider extends ChangeNotifier {
       debugPrint('VideoRepository deleteVideo 에러: $e');
     }
   }
+
+  Future<void> getView(String videoId) async {
+    try {
+      await VideoRepository().getView(videoId);
+
+      notifyListeners();
+    } catch (e) {
+      debugPrint('VideoRepository getView 에러: $e');
+    }
+  }
 }

--- a/lib/data/remote/repository/video_repository.dart
+++ b/lib/data/remote/repository/video_repository.dart
@@ -70,4 +70,30 @@ class VideoRepository {
       return false;
     }
   }
+
+  Future<void> getView(String videoId) async {
+    final url = Uri.parse('${AppUrl.videoUrl}/$videoId/view');
+
+    await loginProvider.checkAccessToken();
+
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
+
+    final headers = {
+      'Content-Type': 'application/json;charset=UTF-8',
+      if (accessToken != null && refreshToken != null)
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+    };
+
+    final response = await http.get(url, headers: headers);
+    final json = jsonDecode(utf8.decode(response.bodyBytes));
+
+    loginProvider.updateToken(response.headers);
+
+    if (response.statusCode == 200) {
+      debugPrint("조회수 증가 성공! json: $json");
+    } else {
+      debugPrint('조회수 증가 실패 json $json');
+    }
+  }
 }

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -34,6 +34,7 @@ class _MainScreenState extends State<MainScreen> {
     _loginProvider = Provider.of<KaKaoLoginProvider>(context, listen: false);
     _multiVideoPlayProvider =
         Provider.of<MultiVideoPlayProvider>(context, listen: false);
+    _multiVideoPlayProvider.mainContext = context;
   }
 
   final List<Widget> _screens = <Widget>[


### PR DESCRIPTION
## 📱 작업 사진 
작업 설명을 읽고 영상을 보시는 걸 추천드립니다~
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/508ece09-310c-4e20-b5bc-6e2eebe6b2e1

## 💬 작업 설명
조회수 등록 api를 연결해 20% 이상 영상을 시청했을 때 조회수를 증가시키는 기능을 추가했습니다.


'조회수 조회' 기능은 '업로드한 영상 조회 api'에 함께 포함되어 있어 추후에 개발될 예정입니다. 따라서 이번에 '조회수 등록'이 잘 적용 됐는지 응답 json을 출력해 확인 했습니다.


영상의 20% 지점에 도달하면 해당 영상의 '조회수 등록 api'가 호출되어 조회수가 증가됩니다.

작업 사진에 첨부한 영상에서는 페이지를 이리저리 왔다갔다 하면서 해당 영상의 20% 지점에서 딱 한번 조회수가 증가되고 다시 영상이 시작되었을때도 20% 지점에 도달하면 조회수가 증가하는지 확인한 영상입니다.

> **1번 영상 - 최애의 아이 20% 지점:** 아또모 어쩌고쩌고~ 💥키💥미 시타~
> **2번 영상 - 꿈빛파티시엘 20% 지점:** 울고싶어질때도~ 💥미💥소 짓게 만드는 마법~
> **3번 영상 - 구찌 20% 지점:** 아쿳헤마 구찌 온~ 구찌 온~ 아쿳헷마 💥루💥이 비통~

## 😥 어려웠던점
1. 진짜 미쳣습니다~ 정처기 문제 중에 그 고난이도 문제 있죠???? 헷갈려서 에이포 하나 다 써야되는!! 그 급입니다 영상 종류별로 상태를 관리해야하고, 재생 중인 영상의 시간이 영상의 총 시간과 정확히 일치하지 않아 한 영상에서도 영상의 시작과 끝을 알아내기 어려워 계속 코드 범벅 쓰다가 끝내 정리되었습니다 ~~ 음하하 천잰가 (?) 암튼 기분 좋습니다~~~ 

하 이건 기록해놔야됩니다 .. 안 복잡해 보이나요? 그럴리가 없어요 이거 엄청납니다
코드로는 10줄정돈가..  if else 한가득 썼어요 하 뿌듯 가득 
<img width="200" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/bdbcf797-4aeb-4bb5-bd6b-c89d80f1f82b">

## ☝️ 참고 하세요~
1. 작업 영상 마지막쯤에 뜨는 'System~' 메시지 다이얼로그는 애뮬레이터에서 앱 실행중에 메모리 문제로 뜨는 다이얼로그입니다. 실기기에서 영상보다 더 난리치면서 테스트 해봤을 때 아무런 오류도 나지 않았으니 걱정 안하셔도 됩니다~

## 🤓 다음에 할 일
1. 프로필 api 연결