### PR TITLE
[feat] 채팅, 스테이지 페이지네이션 (HH-352)

### DIFF
--- a/assets/icons/ic_home_comment.svg
+++ b/assets/icons/ic_home_comment.svg
@@ -1,0 +1,23 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_di_508_943)">
+<path d="M13.5033 3C11.6903 2.99962 9.90814 3.44624 8.33019 4.29637C6.75225 5.14651 5.43231 6.3712 4.49886 7.85125C3.56541 9.3313 3.05023 11.0163 3.00349 12.7422C2.95675 14.4681 3.38002 16.1761 4.23212 17.7L3.0861 20.974C2.99117 21.2451 2.97739 21.536 3.04631 21.8141C3.11523 22.0922 3.26413 22.3466 3.4763 22.5486C3.68848 22.7507 3.95556 22.8924 4.2476 22.9581C4.53964 23.0237 4.8451 23.0106 5.12976 22.9202L8.56783 21.8288C9.97614 22.5422 11.5366 22.9406 13.1307 22.9938C14.7249 23.0471 16.3108 22.7538 17.7682 22.1363C19.2255 21.5187 20.516 20.5931 21.5416 19.4297C22.5672 18.2663 23.3011 16.8957 23.6874 15.4219C24.0737 13.9481 24.1024 12.4098 23.7712 10.9239C23.44 9.43795 22.7577 8.0434 21.7761 6.84607C20.7945 5.64875 19.5393 4.68012 18.1059 4.01371C16.6724 3.3473 15.0984 3.00062 13.5033 3ZM13.5033 21.4615C11.9413 21.4626 10.4066 21.0708 9.05451 20.326C8.95551 20.2713 8.84544 20.2373 8.7316 20.2262C8.61776 20.2151 8.50274 20.2271 8.39416 20.2615L4.61783 21.4615L5.87694 17.8654C5.91324 17.7621 5.92607 17.6526 5.91458 17.5441C5.90309 17.4357 5.86755 17.3309 5.8103 17.2365C4.83085 15.624 4.43761 13.7486 4.69157 11.9015C4.94553 10.0544 5.83251 8.33867 7.2149 7.02057C8.59729 5.70247 10.3978 4.85564 12.3372 4.61146C14.2765 4.36728 16.2463 4.7394 17.9409 5.67008C19.6355 6.60076 20.9603 8.03799 21.7096 9.7588C22.4589 11.4796 22.591 13.3878 22.0853 15.1874C21.5796 16.987 20.4644 18.5773 18.9127 19.7117C17.361 20.8462 15.4595 21.4612 13.5033 21.4615Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_di_508_943" x="0" y="0" width="25" height="24" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_508_943"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_508_943" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.875 0 0 0 0 0.875 0 0 0 0 0.875 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_508_943"/>
+</filter>
+</defs>
+</svg>

--- a/lib/data/remote/provider/chat_provider_impl.dart
+++ b/lib/data/remote/provider/chat_provider_impl.dart
@@ -81,7 +81,7 @@ class ChatProviderImpl extends ChangeNotifier implements ChatProvider {
 
   @override
   Future<BaseResponse<ChatDetailListResponse>> getChatDetailList(
-      String chatRoomId) async {
+      String chatRoomId, int page) async {
     const storage = FlutterSecureStorage();
     const storageKey = 'kakaoAccessToken';
     const refreshTokenKey = 'kakaoRefreshToken';
@@ -95,7 +95,7 @@ class ChatProviderImpl extends ChangeNotifier implements ChatProvider {
       };
       dio.options.contentType = "application/json";
       var response = await dio
-          .get('${AppUrl.chatRoomUrl}/$chatRoomId/messages?page=0&size=5');
+          .get('${AppUrl.chatRoomUrl}/$chatRoomId/messages?page=$page&size=15');
 
       var responseJson = BaseResponse<ChatDetailListResponse>.fromJson(
           response.data,

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -15,6 +15,7 @@ import 'package:pocket_pose/data/entity/socket_response/stage_mvp_response.dart'
 import 'package:pocket_pose/data/entity/socket_response/talk_message_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
 import 'package:pocket_pose/domain/entity/stage_music_data.dart';
+import 'package:pocket_pose/domain/entity/stage_player_info_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/domain/entity/stage_talk_list_item.dart';
 import 'package:pocket_pose/domain/provider/socket_stage_provider.dart';
@@ -79,6 +80,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   int _userCount = 0;
   final List<StagePlayerListItem> _players = [];
   StagePlayerListItem? _mvp;
+  List<StagePlayerInfoListItem> _playerInfos = [];
   StageTalkListItem? _talk;
   Map<PoseLandmarkType, PoseLandmark>? player0;
   Map<PoseLandmarkType, PoseLandmark>? player1;
@@ -100,6 +102,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   String? get userId => _userId;
   StageMusicData? get catchMusicData => _catchMusicData;
   int get userCount => _userCount;
+  List<StagePlayerInfoListItem> get playerInfos => _playerInfos;
   StageTalkListItem? get talk => _talk;
 
   SocketType get stageType => _stageType;
@@ -360,6 +363,7 @@ class SocketStageProviderImpl extends ChangeNotifier
                 jsonDecode(frame.body.toString())['data']));
         _mvp = _players.firstWhere((element) =>
             element.playerNum == socketResponse.data?.mvpPlayerNum);
+        _playerInfos = socketResponse.data?.playerInfos ?? [];
         _stageType = response.type;
         setStageView(_stageType);
         break;

--- a/lib/data/remote/provider/stage_talk_provider_impl.dart
+++ b/lib/data/remote/provider/stage_talk_provider_impl.dart
@@ -9,7 +9,8 @@ import 'package:pocket_pose/data/entity/request/stage_talk_message_request.dart'
 import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
 import 'package:pocket_pose/domain/provider/stage_talk_provider.dart';
 
-class StageTalkProviderImpl implements StageTalkProvider {
+class StageTalkProviderImpl extends ChangeNotifier
+    implements StageTalkProvider {
   @override
   Future<BaseResponse<StageTalkMessageResponse>> getTalkMessages(
       StageTalkMessageRequest request) async {

--- a/lib/domain/provider/chat_provider.dart
+++ b/lib/domain/provider/chat_provider.dart
@@ -8,5 +8,5 @@ abstract class ChatProvider {
   Future<BaseResponse<ChatRoomResponse>> putChatRoom(ChatRoomRequest request);
   Future<BaseResponse<ChatRoomListResponse>> getChatRoomList();
   Future<BaseResponse<ChatDetailListResponse>> getChatDetailList(
-      String chatRoomId);
+      String chatRoomId, int page);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:pocket_pose/data/remote/provider/profile_provider.dart';
 import 'package:pocket_pose/data/remote/provider/socket_chat_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
+import 'package:pocket_pose/data/remote/provider/stage_talk_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/video_provider.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/screen/on_boarding_screen.dart';
@@ -39,6 +40,7 @@ Future<void> main() async {
     ChangeNotifierProvider(create: (_) => SocketChatProviderImpl()),
     ChangeNotifierProvider(create: (_) => StageProviderImpl()),
     ChangeNotifierProvider(create: (_) => SocketStageProviderImpl()),
+    ChangeNotifierProvider(create: (_) => StageTalkProviderImpl()),
   ], child: MyApp(showOnBoarding: showOnBoarding)));
 }
 

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -46,9 +46,11 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
     // 선택한 채팅방 채팅메세지 조회
     _chatProvider = Provider.of<ChatProviderImpl>(context, listen: false);
     _chatProvider.getChatDetailList(widget.chatRoomId, 0).then((value) {
-      for (var chat in value.data.messages) {
-        _messageList.add(chat);
-      }
+      setState(() {
+        for (var chat in value.data.messages) {
+          _messageList.add(chat);
+        }
+      });
     });
   }
 

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -11,10 +11,12 @@ import 'package:pocket_pose/ui/widget/chat/chat_detail_right_bubble_widget.dart'
 import 'package:provider/provider.dart';
 
 class ChatDetailScreen extends StatefulWidget {
-  const ChatDetailScreen({Key? key, required this.chatRoomId})
+  const ChatDetailScreen(
+      {Key? key, required this.chatRoomId, required this.opponentUserNickName})
       : super(key: key);
 
   final String chatRoomId;
+  final String opponentUserNickName;
 
   @override
   State<ChatDetailScreen> createState() => _ChatDetailScreenState();
@@ -213,9 +215,9 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
   AppBar _buildAppBar(BuildContext context) {
     return AppBar(
       centerTitle: true,
-      title: const Text(
-        "pochako",
-        style: TextStyle(
+      title: Text(
+        widget.opponentUserNickName,
+        style: const TextStyle(
             fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black),
       ),
       backgroundColor: AppColor.purpleColor3,

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -86,6 +86,9 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
             height: 3,
           ),
           _buildChatsArea(),
+          const SizedBox(
+            height: 10,
+          ),
           _buildChatTextField(context),
         ],
       ),

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -26,6 +26,7 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
   late KaKaoLoginProvider _loginProvider;
   late String _userId;
   bool _isEnter = false;
+  int _page = 0;
 
   final List<ChatDetailListItem> _messageList = [];
   final ScrollController _scrollController = ScrollController();
@@ -38,10 +39,11 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
     super.initState();
 
     _initUserId();
+    _scrollController.addListener(_scrollListener);
 
     // 선택한 채팅방 채팅메세지 조회
     _chatProvider = Provider.of<ChatProviderImpl>(context, listen: false);
-    _chatProvider.getChatDetailList(widget.chatRoomId).then((value) {
+    _chatProvider.getChatDetailList(widget.chatRoomId, 0).then((value) {
       for (var chat in value.data.messages) {
         _messageList.add(chat);
       }
@@ -248,6 +250,23 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
         setState(() {
           _messageList.insert(0, _socketChatProvider.chat!);
         });
+      });
+    }
+  }
+
+  _scrollListener() async {
+    if (_scrollController.offset >=
+            _scrollController.position.maxScrollExtent &&
+        !_scrollController.position.outOfRange) {
+      var response =
+          await _chatProvider.getChatDetailList(widget.chatRoomId, _page);
+      _page++;
+      var talkList = response.data.messages;
+
+      setState(() {
+        for (var element in talkList) {
+          _messageList.add(element);
+        }
       });
     }
   }

--- a/lib/ui/screen/chat/chat_room_list_screen.dart
+++ b/lib/ui/screen/chat/chat_room_list_screen.dart
@@ -64,8 +64,10 @@ class _ChatListRoomScreenState extends State<ChatRoomListScreen> {
                       : buildChatList(snapshot.data?.data.chatRooms ?? []),
                 );
               }
-              return const Center(
-                child: CircularProgressIndicator(),
+              return const Expanded(
+                child: Center(
+                  child: CircularProgressIndicator(),
+                ),
               );
             },
           ),

--- a/lib/ui/video_viewer/video_right_frame.dart
+++ b/lib/ui/video_viewer/video_right_frame.dart
@@ -44,7 +44,7 @@ class _VideoRightFrameState extends State<VideoRightFrame> {
               childWidget: Column(
                 children: <Widget>[
                   SvgPicture.asset(
-                    'assets/icons/ic_home_chat.svg',
+                    'assets/icons/ic_home_comment.svg',
                   ),
                   const Padding(padding: EdgeInsets.only(bottom: 2)),
                   Text(

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -98,11 +98,11 @@ class _CameraViewState extends State<CameraView> {
 
     _assetsAudioPlayer = AssetsAudioPlayer();
 
-    // 중간입장 처리
-    _onMidEnter();
+    // 입장 처리
+    _onEnter();
   }
 
-  void _onMidEnter() {
+  void _onEnter() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 플레이 상태인 경우
       if (!widget.isResultState) {

--- a/lib/ui/view/popo_play_view.dart
+++ b/lib/ui/view/popo_play_view.dart
@@ -120,18 +120,19 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
             ],
           ),
         ),
-        if (_isPlayer)
-          CameraView(
-            isResultState: widget.isResultState,
-            // 스켈레톤 그려주는 객체 전달
-            customPaintLeft: _customPaintLeft,
-            customPaintMid: _customPaintMid,
-            customPaintRight: _customPaintRight,
-            // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
-            onImage: (inputImage) {
+        CameraView(
+          isResultState: widget.isResultState,
+          // 스켈레톤 그려주는 객체 전달
+          customPaintLeft: _customPaintLeft,
+          customPaintMid: _customPaintMid,
+          customPaintRight: _customPaintRight,
+          // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
+          onImage: (inputImage) {
+            if (_isPlayer) {
               processImage(inputImage);
-            },
-          ),
+            }
+          },
+        ),
       ],
     );
   }

--- a/lib/ui/view/popo_result_view.dart
+++ b/lib/ui/view/popo_result_view.dart
@@ -86,19 +86,34 @@ class _PoPoResultViewState extends State<PoPoResultView> {
             ],
           ),
         ),
-        if (_isPlayer)
-          CameraView(
-            isResultState: widget.isResultState,
-            // 스켈레톤 그려주는 객체 전달
-            customPaintMid: _customPaintMid,
-            // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
-            onImage: (inputImage) {
-              // 플레이어만 스켈레톤 추출
-              if (_isPlayer) {
-                processImage(inputImage);
-              }
-            },
+        Positioned(
+          top: 115,
+          right: 10,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: _socketStageProvider.playerInfos.map((element) {
+              return Text(
+                "${element.player.nickname}: ${element.similarity}",
+                style: const TextStyle(
+                  fontSize: 10,
+                  color: Colors.white,
+                ),
+              );
+            }).toList(), // .toList() added here
           ),
+        ),
+        CameraView(
+          isResultState: widget.isResultState,
+          // 스켈레톤 그려주는 객체 전달
+          customPaintMid: _customPaintMid,
+          // 카메라에서 전해주는 이미지 받을 때마다 아래 함수 실행
+          onImage: (inputImage) {
+            // 플레이어만 스켈레톤 추출
+            if (_isPlayer) {
+              processImage(inputImage);
+            }
+          },
+        ),
       ],
     );
   }

--- a/lib/ui/widget/chat/chat_detail_left_bubble_widget.dart
+++ b/lib/ui/widget/chat/chat_detail_left_bubble_widget.dart
@@ -39,18 +39,18 @@ class ChatDetailLeftBubbleWidget extends StatelessWidget {
                   child: (chatDetail.sender.profileImg == null)
                       ? Image.asset(
                           'assets/images/charactor_popo_default.png',
-                          width: 50,
-                          height: 50,
+                          width: 45,
+                          height: 45,
                         )
                       : Image.network(
                           chatDetail.sender.profileImg!,
                           fit: BoxFit.cover,
-                          width: 50,
-                          height: 50,
+                          width: 45,
+                          height: 45,
                         ),
                 )
               : const SizedBox(
-                  width: 50,
+                  width: 45,
                 ),
           const SizedBox(
             width: 14,

--- a/lib/ui/widget/chat/chat_room_list_item_widget.dart
+++ b/lib/ui/widget/chat/chat_room_list_item_widget.dart
@@ -16,8 +16,10 @@ class ChatRoomListItemWidget extends StatelessWidget {
           Navigator.push(
             context,
             MaterialPageRoute(
-                builder: (context) =>
-                    ChatDetailScreen(chatRoomId: chatRoom.chatRoomId)),
+                builder: (context) => ChatDetailScreen(
+                      chatRoomId: chatRoom.chatRoomId,
+                      opponentUserNickName: chatRoom.opponentUser.nickname,
+                    )),
           );
         },
         child: Padding(

--- a/lib/ui/widget/stage/stage_live_talk_list_widget.dart
+++ b/lib/ui/widget/stage/stage_live_talk_list_widget.dart
@@ -18,7 +18,7 @@ class _StageLiveTalkListWidgetState extends State<StageLiveTalkListWidget> {
   final ScrollController _scrollController = ScrollController();
   late StageTalkProviderImpl _talkProvider;
   late StageProviderImpl _stageProvider;
-  var pageKey = 1;
+  var _page = 1;
 
   @override
   void initState() {
@@ -88,8 +88,8 @@ class _StageLiveTalkListWidgetState extends State<StageLiveTalkListWidget> {
             _scrollController.position.maxScrollExtent &&
         !_scrollController.position.outOfRange) {
       var response = await _talkProvider
-          .getTalkMessages(StageTalkMessageRequest(page: pageKey, size: 10));
-      pageKey++;
+          .getTalkMessages(StageTalkMessageRequest(page: _page, size: 10));
+      _page++;
       var talkList = response.data.messages ?? [];
 
       setState(() {


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/d68206be-c327-4c73-ad73-96744ddf58ee

## 💬 작업 설명
- 채팅 상세 목록과 스테이지 채팅 페이지네이션을 구현하였습니다.

## ✅ 한 일
1. 스테이지 실시간 채팅 페이지네이션
2. 채팅 페이지네이션
3. 채팅 상대방 ui 마진값 추가, 프로필 사이즈 줄이기, 채팅 앱바에 상대 닉네임 추가
4. 홈 화면의 댓글 아이콘 수정(ic_home_chat > ic_home_comment)
5. 스테이지 다른 사람이 캐치 시에 노래 안 나오는 오류 해결

## ☝️ 참고 하세요~
1. 영상에 채팅 목록 들어가서 채팅방 들어갈 때 이전 채팅 기록이 바로 안 나타나는데 이거 해결했습니다....! 영상은 이전에 찍은 거라 안 담겼습니다...
2. 이전 채팅 기록이 있는데도 채팅방에 이전 채팅 내용이 나타나지 않는 것은 아직 서버가 해당 내용 개발 전이기 때문입니다!(이전 채팅 기록이 있는 경우 아래와 같이 이전 채팅 내용이 보여야 합니다.)
<img width="462" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/bc8e9a69-d8e3-441c-ba1a-d5a91d46a42a">

## 🤓 다음에 할 일
1. 스테이지 카메라 없는 사람이 캐치했을 때 스켈레톤 추출되는 오류 확인
2. 스테이지 캐치-재캐치 시에 나는 null 오류 확인
3. 스테이지 플레이어 인원별 ui 다르게
4. 스테이지 동영상 녹화 후 업로드
5. 캐치, 카운트다운 사운드 변경
