### PR TITLE
[feat/fix] 채팅 날짜 헤더 추가 및 스테이지 소켓 오류 해결(HH-355)

### DIFF
--- a/lib/config/app_color.dart
+++ b/lib/config/app_color.dart
@@ -14,6 +14,7 @@ class AppColor {
   static Color grayColor3 = const Color(0x99999999);
   static Color grayColor4 = const Color(0xFFD8D8D8);
   static Color grayColor5 = const Color(0xFF7A7A7A);
+  static Color grayColor6 = const Color(0xFF989898);
   static Color blueColor = const Color(0xFF3959CD);
   static Color blueColor1 = const Color(0xFF97C7FF);
   static Color blueColor2 = const Color(0xFF0057FF);

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -94,6 +94,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool _isReaction = false;
   bool _isUserCountChange = false;
   bool _isCatchMidEnter = false;
+  bool _isReCatch = false;
   bool _isPlaySkeletonChange = false;
   bool _isMVPSkeletonChange = false;
 
@@ -112,6 +113,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   bool get isReaction => _isReaction;
   bool get isUserCountChange => _isUserCountChange;
   bool get isCatchMidEnter => _isCatchMidEnter;
+  bool get isReCatch => _isReCatch;
   bool get isPlaySkeletonChange => _isPlaySkeletonChange;
   bool get isMVPSkeletonChange => _isMVPSkeletonChange;
 
@@ -149,6 +151,11 @@ class SocketStageProviderImpl extends ChangeNotifier
   setIsCatchMidEnter(bool value) {
     _isCatchMidEnter = value;
     if (value) notifyListeners();
+  }
+
+  setIsReCatch(bool value) {
+    _isReCatch = value;
+    notifyListeners();
   }
 
   setIsPlaySkeletonChange(bool value) {
@@ -319,6 +326,9 @@ class SocketStageProviderImpl extends ChangeNotifier
         _players.clear();
         _players.addAll(socketResponse.data?.players ?? []);
         break;
+      case SocketType.CATCH_END_RESTART:
+        setIsReCatch(true);
+        break;
       case SocketType.PLAY_SKELETON:
         var socketResponse = BaseSocketResponse<SendSkeletonResponse>.fromJson(
             jsonDecode(frame.body.toString()),
@@ -401,9 +411,8 @@ class SocketStageProviderImpl extends ChangeNotifier
             builder: (context) => const PoPoWaitView());
       case SocketType.CATCH:
       case SocketType.CATCH_START:
-      case SocketType.CATCH_END_RESTART:
         return MaterialPageRoute<dynamic>(
-            builder: (context) => PoPoCatchView(type: stageType));
+            builder: (context) => const PoPoCatchView());
       case SocketType.PLAY:
       case SocketType.PLAY_START:
         return MaterialPageRoute<dynamic>(

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -191,11 +191,6 @@ class SocketStageProviderImpl extends ChangeNotifier
   }
 
   @override
-  void deactivateWebSocket() {
-    _stompClient?.deactivate();
-  }
-
-  @override
   void onSubscribe() {
     _stompClient?.subscribe(
         destination: AppUrl.socketSubscribeStageUrl,
@@ -276,6 +271,7 @@ class SocketStageProviderImpl extends ChangeNotifier
       _stompClient?.send(
           destination: AppUrl.socketExitUrl,
           headers: {'x-access-token': token});
+      _stompClient?.deactivate();
     }
   }
 

--- a/lib/domain/provider/socket_stage_provider.dart
+++ b/lib/domain/provider/socket_stage_provider.dart
@@ -2,7 +2,6 @@ import 'package:pocket_pose/data/entity/socket_request/send_skeleton_request.dar
 
 abstract class SocketStageProvider {
   void connectWebSocket();
-  void deactivateWebSocket();
   void onSubscribe();
   void sendMessage(String message);
   void sendReaction();

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -28,7 +28,10 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
   late KaKaoLoginProvider _loginProvider;
   late String _userId;
   bool _isEnter = false;
-  int _page = 0;
+  int _page = 1;
+  String? _curDate;
+  String? _nextDate;
+  bool _isHeaderVisible = false;
 
   final List<ChatDetailListItem> _messageList = [];
   final ScrollController _scrollController = ScrollController();
@@ -114,6 +117,19 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
             controller: _scrollController,
             itemCount: _messageList.length,
             itemBuilder: (BuildContext context, int index) {
+              // 날짜 헤더
+              _isHeaderVisible = false;
+
+              _curDate = _messageList[index].createdAt.split(' ')[0];
+              if (index < _messageList.length - 1) {
+                _nextDate = _messageList[index + 1].createdAt.split(' ')[0];
+              }
+              if (_curDate != null && _nextDate != null) {
+                _isHeaderVisible = (_curDate != _nextDate) ? true : false;
+              }
+              if (index == _messageList.length - 1) _isHeaderVisible = true;
+
+              // 말풍선 왼쪽 오른쪽 구분
               if (index < _messageList.length - 1 &&
                   _messageList[index + 1].sender.userId == _userId) {
                 _isNextSenderRight = true;
@@ -123,10 +139,14 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
                 _isNextSenderRight = false;
               }
               return _messageList[index].sender.userId == _userId
-                  ? ChatDetailRightBubbleWidget(chatDetail: _messageList[index])
+                  ? ChatDetailRightBubbleWidget(
+                      chatDetail: _messageList[index],
+                      headerVisiblity: _isHeaderVisible,
+                    )
                   : ChatDetailLeftBubbleWidget(
                       chatDetail: _messageList[index],
-                      profileVisiblity: _isNextSenderRight);
+                      profileVisiblity: _isNextSenderRight,
+                      headerVisiblity: _isHeaderVisible);
             },
           ),
         ),
@@ -271,8 +291,8 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
       var talkList = response.data.messages;
 
       setState(() {
-        for (var element in talkList) {
-          _messageList.add(element);
+        for (var chat in talkList) {
+          _messageList.add(chat);
         }
       });
     }

--- a/lib/ui/screen/popo_stage_screen.dart
+++ b/lib/ui/screen/popo_stage_screen.dart
@@ -101,7 +101,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
     if (_isEnter) {
       _socketStageProvider.exitStage();
-      _socketStageProvider.deactivateWebSocket();
       _isEnter = false;
     }
 

--- a/lib/ui/view/ml_kit_camera_view.dart
+++ b/lib/ui/view/ml_kit_camera_view.dart
@@ -183,9 +183,9 @@ class _CameraViewState extends State<CameraView> {
 
   @override
   void dispose() {
-    // AudioPlayerUtil().stop();
     _assetsAudioPlayer = null;
     _assetsAudioPlayer?.dispose();
+    _controller?.dispose;
     _stopTimer();
 
     super.dispose();

--- a/lib/ui/view/popo_catch_view.dart
+++ b/lib/ui/view/popo_catch_view.dart
@@ -13,8 +13,7 @@ import 'package:semicircle_indicator/semicircle_indicator.dart';
 import 'dart:math' as math;
 
 class PoPoCatchView extends StatefulWidget {
-  final SocketType type;
-  const PoPoCatchView({Key? key, required this.type}) : super(key: key);
+  const PoPoCatchView({Key? key}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _PoPoCatchViewState();
@@ -29,7 +28,6 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
   late Animation<double> _opacityAnimation;
   late StageProviderImpl _stageProvider;
   late SocketStageProviderImpl _socketStageProvider;
-  SocketType _prevStageType = SocketType.CATCH_START;
 
   @override
   Widget build(BuildContext context) {
@@ -39,9 +37,19 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
 
     _onMidEnter();
 
-    // 캐치 재진행인 경우 토스트 띄우고 카운트다운 재시작
-    if (_prevStageType != widget.type) {
-      _reCountDown();
+    // 캐치 재진행 토스트
+    if (_socketStageProvider.isReCatch) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _socketStageProvider.setIsReCatch(false);
+        Fluttertoast.showToast(
+          msg: "캐치를 아무도 안 했어요...😢",
+          toastLength: Toast.LENGTH_SHORT,
+          timeInSecForIosWeb: 1,
+          backgroundColor: Colors.black,
+          textColor: Colors.white,
+          fontSize: 16.0,
+        );
+      });
     }
 
     return Column(
@@ -98,21 +106,6 @@ class _PoPoCatchViewState extends State<PoPoCatchView>
         }
       });
     }
-  }
-
-  void _reCountDown() {
-    _prevStageType = widget.type;
-    _milliseconds = 0;
-    _catchCountDown = 0.0;
-    _startTimer();
-    Fluttertoast.showToast(
-      msg: "캐치를 아무도 안 했어요...😢",
-      toastLength: Toast.LENGTH_SHORT,
-      timeInSecForIosWeb: 1,
-      backgroundColor: Colors.black,
-      textColor: Colors.white,
-      fontSize: 16.0,
-    );
   }
 
   SizedBox _buildCatchButton() {

--- a/lib/ui/widget/chat/chat_detail_left_bubble_widget.dart
+++ b/lib/ui/widget/chat/chat_detail_left_bubble_widget.dart
@@ -5,22 +5,31 @@ import 'package:pocket_pose/domain/entity/chat_detail_list_item.dart';
 class ChatDetailLeftBubbleWidget extends StatelessWidget {
   final ChatDetailListItem chatDetail;
   final bool profileVisiblity;
+  final bool headerVisiblity;
 
   const ChatDetailLeftBubbleWidget(
-      {super.key, required this.chatDetail, required this.profileVisiblity});
+      {super.key,
+      required this.chatDetail,
+      required this.profileVisiblity,
+      required this.headerVisiblity});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.fromLTRB(
           16, profileVisiblity ? 7 : 3, 24, profileVisiblity ? 3 : 7),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.end,
+      child: Column(
         children: [
-          _buildUserProfileAndBubble(profileVisiblity),
-          const SizedBox(width: 8),
-          _buildTimeStamp(),
+          _buildDateHeader(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              _buildUserProfileAndBubble(profileVisiblity),
+              const SizedBox(width: 8),
+              _buildTimeStamp(),
+            ],
+          ),
         ],
       ),
     );
@@ -99,11 +108,47 @@ class ChatDetailLeftBubbleWidget extends StatelessWidget {
     );
   }
 
+  Widget _buildDateHeader() {
+    return Visibility(
+        visible: headerVisiblity,
+        child: Row(
+          children: [
+            Expanded(
+              child: Divider(
+                color: AppColor.grayColor6,
+                thickness: 0.5,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              _refomatDate(chatDetail.createdAt),
+              style: const TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w300,
+                  color: Colors.black),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Divider(
+                color: AppColor.grayColor6,
+                thickness: 0.5,
+              ),
+            ),
+          ],
+        ));
+  }
+
   String _refomatTimeStamp(String timeStamp) {
     var temp = timeStamp.split(' ');
     temp = temp[1].split(':');
     var ampm = int.parse(temp[0]) < 12 ? "오전" : "오후";
     var hour = (ampm == "오후") ? int.parse(temp[0].toString()) - 12 : temp[0];
     return "$ampm $hour:${temp[1]}";
+  }
+
+  String _refomatDate(String date) {
+    var temp = date.split(' ');
+    temp = temp[0].split('/');
+    return "${temp[0]}년 ${temp[1]}월 ${temp[2]}일";
   }
 }

--- a/lib/ui/widget/chat/chat_detail_right_bubble_widget.dart
+++ b/lib/ui/widget/chat/chat_detail_right_bubble_widget.dart
@@ -4,23 +4,60 @@ import 'package:pocket_pose/domain/entity/chat_detail_list_item.dart';
 
 class ChatDetailRightBubbleWidget extends StatelessWidget {
   final ChatDetailListItem chatDetail;
+  final bool headerVisiblity;
 
-  const ChatDetailRightBubbleWidget({super.key, required this.chatDetail});
+  const ChatDetailRightBubbleWidget(
+      {super.key, required this.chatDetail, required this.headerVisiblity});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 7, 24, 7),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
-        crossAxisAlignment: CrossAxisAlignment.end,
+      child: Column(
         children: [
-          _buildTimeStamp(),
-          const SizedBox(width: 8),
-          _buildBubble(),
+          _buildDateHeader(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              _buildTimeStamp(),
+              const SizedBox(width: 8),
+              _buildBubble(),
+            ],
+          ),
         ],
       ),
     );
+  }
+
+  Widget _buildDateHeader() {
+    return Visibility(
+        visible: headerVisiblity,
+        child: Row(
+          children: [
+            Expanded(
+              child: Divider(
+                color: AppColor.grayColor6,
+                thickness: 0.5,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              _refomatDate(chatDetail.createdAt),
+              style: const TextStyle(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w300,
+                  color: Colors.black),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Divider(
+                color: AppColor.grayColor6,
+                thickness: 0.5,
+              ),
+            ),
+          ],
+        ));
   }
 
   Flexible _buildBubble() {
@@ -66,5 +103,11 @@ class ChatDetailRightBubbleWidget extends StatelessWidget {
     var ampm = int.parse(temp[0]) < 12 ? "오전" : "오후";
     var hour = (ampm == "오후") ? int.parse(temp[0].toString()) - 12 : temp[0];
     return "$ampm $hour:${temp[1]}";
+  }
+
+  String _refomatDate(String date) {
+    var temp = date.split(' ');
+    temp = temp[0].split('/');
+    return "${temp[0]}년 ${temp[1]}월 ${temp[2]}일";
   }
 }


### PR DESCRIPTION
## 📱 작업 사진 
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/8b5fe69f-2e9b-4e83-8142-1eba2cf98e93" width="200">

## 💬 작업 설명
- 채팅 날짜 변경 시 헤더 생기도록 추가 개발하였습니다!
- 스테이지 캐치 안 해도 스켈레톤 추출되는 문제, 스테이지 퇴장 안 되는 문제 해결하였습니다.
- 스테이지 캐치-재캐치 반복 시 null 오류 나는 문제 해결하였습니다.

## ✅ 한 일
1. 채팅 헤더 추가
2. 스테이지 카메라 없는 사람이 캐치했을 때 스켈레톤 추출되는 오류 해결(스테이지 퇴장이 잘 안됐던 문제 해결)
3. 스테이지 캐치-재캐치 시에 나는 null 오류 확인(캐치-재캐치 로직 잘못 이해하고 있었음)

## ☝️ 참고 하세요~
1. 스테이지 퇴장 시 바로 소켓 연결이 끊기지 않고 2~5초 뒤 연결이 끊깁니다.

## 😥 어려웠던점
1. 로직이 복잡할 줄 알았는데(당근 클론 때 실패했어서...) 나름 금방 끝나서 넘 다행이었습니다...ㅎㅎ 당근 때는 무한 스크롤 라이브러리를 썼었고, 이번엔 그냥 스크롤 끝나면 새 데이터 불러오도록 구현했어서 잘 되는 거 같았습니다... 그래도 로직 고민한 흔적 남기기 ㅎㅎ
<img src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/1918fe44-2ad9-4f3a-8ff5-0cd6f88216c5" width="400">



## 🤓 다음에 할 일
1. 프로필화면에 채팅 연결
3. 스테이지 플레이어 인원별 ui 다르게
4. 스테이지 동영상 녹화 후 업로드
5. 캐치, 카운트다운 사운드 변경
