### PR TITLE
[refactor] Cached Video Player 적용 (HH-346)

### DIFF
--- a/lib/data/local/provider/multi_video_play_provider.dart
+++ b/lib/data/local/provider/multi_video_play_provider.dart
@@ -1,7 +1,7 @@
+import 'package:cached_video_player/cached_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/domain/entity/video_data.dart';
 import 'package:provider/provider.dart';
-import 'package:video_player/video_player.dart';
 
 import '../../remote/provider/video_provider.dart';
 
@@ -9,7 +9,7 @@ class MultiVideoPlayProvider with ChangeNotifier {
   final int pageSize = 3;
 
   // 홈: 0, 업로드: 1, 좋아요: 2, 검색: 3, 태그 검색: 4
-  late List<List<VideoPlayerController>> videoControllers = [
+  late List<List<CachedVideoPlayerController>> videoControllers = [
     [],
     [],
     [],
@@ -43,7 +43,7 @@ class MultiVideoPlayProvider with ChangeNotifier {
     for (final video in newVideoList) {
       debugPrint('페이지: 비디오 로딩중');
       videoControllers[screenNum]
-          .add(VideoPlayerController.network(video.videoUrl));
+          .add(CachedVideoPlayerController.network(video.videoUrl));
 
       videoFutures[screenNum]
           .add(videoControllers[screenNum].last.initialize().then((value) {

--- a/lib/ui/screen/home/home_upload_screen.dart
+++ b/lib/ui/screen/home/home_upload_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:cached_video_player/cached_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
@@ -10,7 +11,6 @@ import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/upload/custom_tag_text_field_controller.dart';
 import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
 import 'package:provider/provider.dart';
-import 'package:video_player/video_player.dart';
 
 class HomeUploadScreen extends StatefulWidget {
   const HomeUploadScreen({super.key, required this.uploadFile});
@@ -22,7 +22,7 @@ class HomeUploadScreen extends StatefulWidget {
 
 class _HomeUploadScreenState extends State<HomeUploadScreen> {
   final TextEditingController _titleTextController = TextEditingController();
-  VideoPlayerController? _videoPlayerController;
+  CachedVideoPlayerController? _videoPlayerController;
   late MultiVideoPlayProvider _multiVideoPlayProvider;
 
   late CustomTagTextFieldController _tagController;
@@ -52,7 +52,8 @@ class _HomeUploadScreenState extends State<HomeUploadScreen> {
 
   Future _initVideoPlayer() async {
     if (_videoPlayerController == null) {
-      _videoPlayerController = VideoPlayerController.file(widget.uploadFile);
+      _videoPlayerController =
+          CachedVideoPlayerController.file(widget.uploadFile);
       await _videoPlayerController!.initialize();
       await _videoPlayerController!.setLooping(true);
       await _videoPlayerController!.play();
@@ -95,7 +96,7 @@ class _HomeUploadScreenState extends State<HomeUploadScreen> {
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 3, 0, 0),
-              child: VideoPlayer(_videoPlayerController!),
+              child: CachedVideoPlayer(_videoPlayerController!),
             ),
             Padding(
               padding: EdgeInsets.only(

--- a/lib/ui/widget/video/video_player_widget.dart
+++ b/lib/ui/widget/video/video_player_widget.dart
@@ -1,9 +1,9 @@
+import 'package:cached_video_player/cached_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
 import 'package:pocket_pose/ui/frame/video/video_right_frame.dart';
 import 'package:pocket_pose/ui/frame/video/video_user_info_frame.dart';
 import 'package:provider/provider.dart';
-import 'package:video_player/video_player.dart';
 
 class VideoPlayerWidget extends StatefulWidget {
   const VideoPlayerWidget(
@@ -86,7 +86,7 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget>
               });
             }
           },
-          child: VideoPlayer(_multiVideoPlayProvider
+          child: CachedVideoPlayer(_multiVideoPlayProvider
               .videoControllers[widget.screenNum][widget.index]),
         ),
         Positioned.fill(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -145,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.6.2"
+  cached_video_player:
+    dependency: "direct main"
+    description:
+      name: cached_video_player
+      sha256: "13c25fc1af3bb239da83d9e965d119463a67a782fd9af3714ed86a1182ded20c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   camera:
     dependency: "direct main"
     description:
@@ -257,14 +265,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -584,14 +584,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.15.4"
   http:
     dependency: "direct main"
     description:
@@ -1285,46 +1277,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  video_player:
-    dependency: "direct main"
-    description:
-      name: video_player
-      sha256: "3fd106c74da32f336dc7feb65021da9b0207cb3124392935f1552834f7cce822"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.7.0"
-  video_player_android:
-    dependency: transitive
-    description:
-      name: video_player_android
-      sha256: f338a5a396c845f4632959511cad3542cdf3167e1b2a1a948ef07f7123c03608
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.9"
-  video_player_avfoundation:
-    dependency: transitive
-    description:
-      name: video_player_avfoundation
-      sha256: f5f5b7fe8c865be8a57fe80c2dca130772e1db775b7af4e5c5aa1905069cfc6c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.9"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: "1ca9acd7a0fb15fb1a990cb554e6f004465c6f37c99d2285766f08a4b2802988"
+      sha256: "318a6d20577e1c78cf0bf40670883cc571ea860c72a4f7426d7dacce4bdd4343"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "5.1.4"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
-      sha256: "44ce41424d104dfb7cf6982cc6b84af2b007a24d126406025bf40de5d481c74c"
+      sha256: fb3bbeaf0302cb0c31340ebd6075487939aa1fe3b379d1a8784ef852b679940e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.15"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   dio: ^5.0.3
   audio_session: ^0.1.15
   just_audio: ^0.9.34
-  video_player: ^2.7.0
+  cached_video_player: ^2.0.4 
   json_annotation: ^4.8.0
   change_app_package_name: ^1.1.0
   kakao_flutter_sdk_user: ^1.4.3


### PR DESCRIPTION
## 📱 작업 사진 
### 기존 Video Player (2023.08.28 9:20 녹화)
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/735ca31d-a38d-4487-8dc2-b7e1318f5d73

### Cached Video Player 적용 후 (2023.08.28 9:15 녹화)
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/a6992c9c-562c-4571-954f-7502d9c91558

## 💬 작업 설명
기존에 사용하던 Video Player 대신
비디오를 캐시해 한번 로드한 비디오는 빠르게 로드할 수 있는 기능이 추가된
Cached Video Player를 적용해 비디오 속도를 개선시켰습니다.

## 🧐 궁금한점
1. 이렇게나 빨라질 수 있다고..? 비디오 속도가 나지 않아 비디오를 캐시할 수 있는 방법에 관련해서 자료를 찾던중 발견한 패키지를 적용하니.. 이렇게 빨라졌습니다. 매우 간단하게 해결되어서 믿기지가 않네요..? 우선 두고 볼게요 더~

## ☝️ 참고 하세요~
1. 작업 사진에 올린 영상에서 포인트는 영상을 클릭했을 때, 또는 스크롤 했을 때 로딩이 생기지 않고 얼마나 빠르게 재생되는가입니다!
2. 너무 막 돌아다니면 영상이 검은색으로 나올 때도 있더라고요. 그럴때는 페이지를 나갔다가 돌아오면 대부분 잘 실행되는 걸 확인 했습니다

## 🤓 다음에 할 일
1. 화면 전환 애니메이션 추가
3. 스켈레톤 로더 추가(프로필 영상 내릴 때, 홈 영상 로딩 등)
4. 업로드 화면에 로더 추가