### PR TITLE
[feat][fix] 프로필 편집 페이지 개선 (HH-323)

### DIFF
--- a/lib/ui/screen/profile/profile_edit_screen.dart
+++ b/lib/ui/screen/profile/profile_edit_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/entity/request/profile_edit_request.dart';
@@ -50,22 +49,13 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
 
     _textControllers = [
       TextEditingController(
-        text: widget.profileResponse.profile.introduce == null ||
-                widget.profileResponse.profile.introduce == ''
-            ? '자기소개'
-            : widget.profileResponse.profile.introduce,
+        text: widget.profileResponse.profile.introduce,
       ),
       TextEditingController(
-        text: widget.profileResponse.profile.instagramId == null ||
-                widget.profileResponse.profile.instagramId == ''
-            ? 'Instagram'
-            : widget.profileResponse.profile.instagramId,
+        text: widget.profileResponse.profile.instagramId,
       ),
       TextEditingController(
-        text: widget.profileResponse.profile.twitterId == null ||
-                widget.profileResponse.profile.twitterId == ''
-            ? 'Twitter'
-            : widget.profileResponse.profile.twitterId,
+        text: widget.profileResponse.profile.twitterId,
       ),
     ];
 
@@ -205,29 +195,16 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                         ? Colors.black
                         : widget.profileResponse.profile.introduce == null ||
                                 widget.profileResponse.profile.introduce == ''
-                            ? Colors.black12
-                            : Colors.black45,
+                            ? Colors.grey
+                            : Colors.black,
                     fontSize: 14,
                   ),
                   onTap: () {
                     if (!_isClickeds[0]) {
                       setState(() {
-                        _textControllers[0].text =
-                            (widget.profileResponse.profile.introduce == null ||
-                                    widget.profileResponse.profile.introduce ==
-                                        ''
-                                ? '자기소개'
-                                : widget.profileResponse.profile.introduce)!;
-
                         _isClickeds[0] = true;
                       });
                     }
-                    Future.delayed(Duration.zero, () {
-                      _textControllers[0].selection =
-                          TextSelection.fromPosition(
-                        TextPosition(offset: _textControllers[0].text.length),
-                      );
-                    });
                   },
                 ),
               ),
@@ -295,32 +272,15 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                                               .instagramId ==
                                           ''
                                   ? Colors.black12
-                                  : Colors.black45,
+                                  : Colors.black,
                           fontSize: 14,
                         ),
                         onTap: () {
                           if (!_isClickeds[1]) {
                             setState(() {
-                              _textControllers[1].text =
-                                  (widget.profileResponse.profile.instagramId ==
-                                              null ||
-                                          widget.profileResponse.profile
-                                                  .instagramId ==
-                                              ''
-                                      ? 'Instagram'
-                                      : widget.profileResponse.profile
-                                          .instagramId)!;
-
                               _isClickeds[1] = true;
                             });
                           }
-                          Future.delayed(Duration.zero, () {
-                            _textControllers[1].selection =
-                                TextSelection.fromPosition(
-                              TextPosition(
-                                  offset: _textControllers[1].text.length),
-                            );
-                          });
                         },
                       ),
                     ),
@@ -365,31 +325,15 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                                               .twitterId ==
                                           ''
                                   ? Colors.black12
-                                  : Colors.black45,
+                                  : Colors.black,
                           fontSize: 14,
                         ),
                         onTap: () {
                           if (!_isClickeds[2]) {
                             setState(() {
-                              _textControllers[2].text = (widget.profileResponse
-                                              .profile.twitterId ==
-                                          null ||
-                                      widget.profileResponse.profile
-                                              .twitterId ==
-                                          ''
-                                  ? 'Twitter'
-                                  : widget.profileResponse.profile.twitterId)!;
-
                               _isClickeds[2] = true;
                             });
                           }
-                          Future.delayed(Duration.zero, () {
-                            _textControllers[2].selection =
-                                TextSelection.fromPosition(
-                              TextPosition(
-                                  offset: _textControllers[2].text.length),
-                            );
-                          });
                         },
                       ),
                     ),

--- a/lib/ui/screen/profile/profile_edit_screen.dart
+++ b/lib/ui/screen/profile/profile_edit_screen.dart
@@ -181,9 +181,11 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
               ),
               const SizedBox(height: 50.0),
               SizedBox(
-                height: 36,
+                height: 54,
                 child: TextField(
+                  maxLength: 10,
                   decoration: InputDecoration(
+                    labelText: '자기소개',
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(10.0),
                     ),
@@ -232,18 +234,6 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
               const SizedBox(
                 height: 8,
               ),
-              Row(
-                children: [
-                  SvgPicture.asset('assets/icons/ic_profile_edit_warning.svg'),
-                  const SizedBox(
-                    width: 4,
-                  ),
-                  Text(
-                    '10자 이내로 입력해 주세요.',
-                    style: TextStyle(color: AppColor.grayColor3, fontSize: 10),
-                  ),
-                ],
-              ),
               const SizedBox(height: 30.0),
               Row(
                 children: [
@@ -276,9 +266,11 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                   const SizedBox(width: 18.0),
                   Expanded(
                     child: SizedBox(
-                      height: 36,
+                      height: 54,
                       child: TextField(
+                        maxLength: 20,
                         decoration: InputDecoration(
+                          labelText: 'Instagram',
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(10.0),
                           ),
@@ -344,9 +336,11 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                   const SizedBox(width: 18.0),
                   Expanded(
                     child: SizedBox(
-                      height: 36,
+                      height: 54,
                       child: TextField(
+                        maxLength: 20,
                         decoration: InputDecoration(
+                          labelText: 'Twitter',
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(10.0),
                           ),

--- a/lib/ui/screen/profile/profile_edit_screen.dart
+++ b/lib/ui/screen/profile/profile_edit_screen.dart
@@ -93,30 +93,56 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
     return Scaffold(
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
-        title: const Text(
-          '프로필 편집',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-        ),
-        centerTitle: true,
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black,
-        leading: IconButton(
-          icon: Image.asset(
-            'assets/icons/ic_back.png',
+          title: const Text(
+            '프로필 편집',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
           ),
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
-        elevation: 0,
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(2.0),
-          child: Container(
-            height: 2.0,
-            color: AppColor.purpleColor,
+          centerTitle: true,
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          leading: IconButton(
+            icon: Image.asset(
+              'assets/icons/ic_back.png',
+            ),
+            onPressed: () {
+              Navigator.pop(context);
+            },
           ),
-        ),
-      ),
+          elevation: 0,
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(2.0),
+            child: Container(
+              height: 2.0,
+              color: AppColor.purpleColor,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: isButtonEnabled()
+                  ? () {
+                      // 버튼 클릭시 프로필 수정
+
+                      _profileProvider.patchProfile(ProfileEditRequest(
+                          introduce: _textControllers[0].text,
+                          instagramId: _textControllers[1].text,
+                          twitterId: _textControllers[2].text));
+
+                      Fluttertoast.showToast(msg: '수정되었습니다!');
+                      // profileResponse 새로고침
+                      _profileProvider.isGetProfilDone = false;
+                      Navigator.pop(context);
+                    }
+                  : null,
+              child: Text(
+                '수정',
+                style: TextStyle(
+                  color: isButtonEnabled()
+                      ? AppColor.purpleColor
+                      : AppColor.purpleColor3,
+                ),
+              ),
+            ),
+          ]),
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(35, 50, 35, 0),
@@ -154,14 +180,22 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                 ),
               ),
               const SizedBox(height: 50.0),
-              Container(
+              SizedBox(
                 height: 36,
-                padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(10),
-                  border: Border.all(color: AppColor.grayColor2),
-                ),
                 child: TextField(
+                  decoration: InputDecoration(
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: AppColor.grayColor4),
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: AppColor.purpleColor3),
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
+                  ),
                   controller: _textControllers[0],
                   cursorColor: Colors.black,
                   style: TextStyle(
@@ -193,9 +227,6 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                       );
                     });
                   },
-                  decoration: const InputDecoration(
-                    border: InputBorder.none,
-                  ),
                 ),
               ),
               const SizedBox(
@@ -244,14 +275,23 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                   ),
                   const SizedBox(width: 18.0),
                   Expanded(
-                    child: Container(
+                    child: SizedBox(
                       height: 36,
-                      padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(color: AppColor.grayColor2),
-                      ),
                       child: TextField(
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: AppColor.grayColor4),
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide:
+                                BorderSide(color: AppColor.purpleColor3),
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                        ),
                         controller: _textControllers[1],
                         cursorColor: Colors.black,
                         style: TextStyle(
@@ -290,9 +330,6 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                             );
                           });
                         },
-                        decoration: const InputDecoration(
-                          border: InputBorder.none,
-                        ),
                       ),
                     ),
                   ),
@@ -306,14 +343,23 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                   ),
                   const SizedBox(width: 18.0),
                   Expanded(
-                    child: Container(
+                    child: SizedBox(
                       height: 36,
-                      padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(color: AppColor.grayColor2),
-                      ),
                       child: TextField(
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: AppColor.grayColor4),
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide:
+                                BorderSide(color: AppColor.purpleColor3),
+                            borderRadius: BorderRadius.circular(10.0),
+                          ),
+                        ),
                         controller: _textControllers[2],
                         cursorColor: Colors.black,
                         style: TextStyle(
@@ -351,54 +397,14 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                             );
                           });
                         },
-                        decoration: const InputDecoration(
-                          border: InputBorder.none,
-                        ),
                       ),
                     ),
                   ),
                 ],
               ),
-              const SizedBox(
-                height: 150,
-              ),
+              const SizedBox(height: 50.0),
             ],
           ),
-        ),
-      ),
-      bottomSheet: Padding(
-        padding: const EdgeInsets.fromLTRB(35, 0, 35, 20),
-        child: Row(
-          children: [
-            Expanded(
-              child: ElevatedButton(
-                onPressed: isButtonEnabled()
-                    ? () {
-                        // 버튼 클릭시 프로필 수정
-
-                        _profileProvider.patchProfile(ProfileEditRequest(
-                            introduce: _textControllers[0].text,
-                            instagramId: _textControllers[1].text,
-                            twitterId: _textControllers[2].text));
-
-                        Fluttertoast.showToast(msg: '수정되었습니다!');
-                        // profileResponse 새로고침
-                        _profileProvider.isGetProfilDone = false;
-                        Navigator.pop(context);
-                      }
-                    : null,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: isButtonEnabled()
-                      ? AppColor.purpleColor
-                      : AppColor.grayColor3,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30.0),
-                  ),
-                ),
-                child: const Text('확인'),
-              ),
-            ),
-          ],
         ),
       ),
     );

--- a/lib/ui/widget/profile/profile_edit_img_name_widget.dart
+++ b/lib/ui/widget/profile/profile_edit_img_name_widget.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/entity/response/profile_response.dart';
+
+class ProfileEditImgNameWidget extends StatelessWidget {
+  const ProfileEditImgNameWidget({
+    super.key,
+    required this.profileResponse,
+  });
+
+  final ProfileResponse profileResponse;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(
+          width: 100,
+          height: 100,
+          child: ClipRRect(
+              borderRadius: BorderRadius.circular(50),
+              child: Image.network(
+                profileResponse.user.profileImg!,
+                loadingBuilder: (context, child, loadingProgress) {
+                  if (loadingProgress == null) return child;
+                  return Center(
+                    child: CircularProgressIndicator(
+                      color: AppColor.purpleColor,
+                    ),
+                  );
+                },
+                errorBuilder: (context, error, stackTrace) => Image.asset(
+                  'assets/images/charactor_popo_default.png',
+                  fit: BoxFit.cover,
+                ),
+                fit: BoxFit.cover,
+              )),
+        ),
+        Container(
+          margin: const EdgeInsets.fromLTRB(0, 20, 0, 14),
+          child: Text(
+            profileResponse.user.nickname,
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/82c8526b-e83b-4a80-a1b8-3a995c16ae27

## 💬 작업 설명
프로필 편집 페이지의 오류를 해결하고 새로운 기능을 추가해 개선되었습니다.

## ✅ 한 일
1. 프로필 편집 페이지의 확인 버튼을 앱바로 올림
2. 프로필 편집 페이지의 Textfield UI 수정
3. 프로필 편집 페이지의 Textfield에 글자수 제한 기능 추가
4. 프로필 편집 페이지의 Textfield 클릭시 해당 Textfield로 포커스 안되던 오류 해결
5. 프로필 편집 페이지의 Textfield 값이 null일 때 클릭하면 hintText가 나오던 오류 해결

## 😎 참고하세요!
1. 이제 api 수정되어서 빈 값으로 수정 가능합니다

## 🤓 다음에 할 일
1. 검색 페이지의 계정 검색에 자기소개 추가