### PR TITLE
[feat] 계정 검색에 자기소개 추가 (HH-365)

### DIFF
--- a/lib/data/remote/provider/search_provider.dart
+++ b/lib/data/remote/provider/search_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pocket_pose/data/entity/response/follow_list_response.dart';
 import 'package:pocket_pose/data/remote/repository/follow_repository.dart';
 import 'package:pocket_pose/data/remote/repository/search_repository.dart';
+import 'package:pocket_pose/domain/entity/search_user_data.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
 
 import '../../entity/request/videos_request.dart';
@@ -10,7 +11,7 @@ import '../../entity/response/videos_response.dart';
 class SearchProvider extends ChangeNotifier {
   List<String>? _tagsResponse;
   VideosResponse? _tagVideosResponse;
-  List<UserData>? _usersResponse;
+  List<SearchUserData>? _usersResponse;
   VideosResponse? _randomVideosResponse;
 
   bool? _isGetTagsSuccess;
@@ -21,7 +22,7 @@ class SearchProvider extends ChangeNotifier {
 
   List<String>? get tagResponse => _tagsResponse;
   VideosResponse? get tagVideosResponse => _tagVideosResponse;
-  List<UserData>? get usersResponse => _usersResponse;
+  List<SearchUserData>? get usersResponse => _usersResponse;
   VideosResponse? get randomVideosResponse => _randomVideosResponse;
 
   bool? get isGetSuccess => _isGetTagsSuccess;

--- a/lib/data/remote/repository/search_repository.dart
+++ b/lib/data/remote/repository/search_repository.dart
@@ -7,6 +7,7 @@ import 'package:pocket_pose/data/entity/response/follow_list_response.dart';
 import 'package:pocket_pose/data/entity/response/videos_response.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/entity/follow_data.dart';
+import 'package:pocket_pose/domain/entity/search_user_data.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
 
 import '../../../domain/entity/video_data.dart';
@@ -80,7 +81,7 @@ class SearchRepository {
     }
   }
 
-  Future<List<UserData>> getUserSearch(String key) async {
+  Future<List<SearchUserData>> getUserSearch(String key) async {
     final url =
         Uri.parse(AppUrl.searchUserUrl).replace(queryParameters: {'key': key});
 
@@ -94,11 +95,12 @@ class SearchRepository {
       final json = jsonDecode(utf8.decode(response.bodyBytes));
       debugPrint("검색 사용자 검색 성공! json: $json");
 
-      final List<dynamic> userDataJson = json['data']['userList'];
-      final List<UserData> userDataList =
-          userDataJson.map((userJson) => UserData.fromJson(userJson)).toList();
+      final List<dynamic> searchUserDataJson = json['data']['userList'];
+      final List<SearchUserData> searchUserDataList = searchUserDataJson
+          .map((userJson) => SearchUserData.fromJson(userJson))
+          .toList();
 
-      return userDataList;
+      return searchUserDataList;
     } else {
       throw Exception('검색 사용자 검색 실패');
     }

--- a/lib/domain/entity/search_user_data.dart
+++ b/lib/domain/entity/search_user_data.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/domain/entity/user_data.dart';
+
+part 'search_user_data.g.dart';
+
+@JsonSerializable()
+class SearchUserData {
+  final UserData user;
+  final String introduce;
+
+  SearchUserData({
+    required this.user,
+    required this.introduce,
+  });
+
+  factory SearchUserData.fromJson(Map<String, dynamic> json) =>
+      _$SearchUserDataFromJson(json);
+  Map<String, dynamic> toJson() => _$SearchUserDataToJson(this);
+}

--- a/lib/domain/entity/search_user_data.g.dart
+++ b/lib/domain/entity/search_user_data.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'search_user_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SearchUserData _$SearchUserDataFromJson(Map<String, dynamic> json) =>
+    SearchUserData(
+      user: UserData.fromJson(json),
+      introduce: json['introduce'] as String,
+    );
+
+Map<String, dynamic> _$SearchUserDataToJson(SearchUserData instance) =>
+    <String, dynamic>{
+      'user': instance.user,
+      'introduce': instance.introduce,
+    };

--- a/lib/ui/view/home/search_detail_view.dart
+++ b/lib/ui/view/home/search_detail_view.dart
@@ -65,6 +65,7 @@ class _SearchDetailViewState extends State<SearchDetailView>
         _searchProvider.isVideoLoadingDone = true;
       }
     }
+
     return _searchProvider.tagVideosResponse != null &&
         _searchProvider.usersResponse != null;
   }
@@ -106,9 +107,10 @@ class _SearchDetailViewState extends State<SearchDetailView>
         FutureBuilder<bool>(
             future: _initContent(),
             builder: (context, snapshot) {
+              debugPrint('검색: ${snapshot.connectionState}');
               if (snapshot.connectionState == ConnectionState.done) {
                 loading++;
-                if (loading >= 2) {
+                if (loading >= 1) {
                   return Expanded(
                       child: TabBarView(
                     controller: _tabController,

--- a/lib/ui/view/home/user_list_view.dart
+++ b/lib/ui/view/home/user_list_view.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
-import 'package:pocket_pose/domain/entity/user_data.dart';
+import 'package:pocket_pose/domain/entity/search_user_data.dart';
 
 class UserListView extends StatefulWidget {
   const UserListView({Key? key, required this.userList}) : super(key: key);
 
-  final List<UserData> userList;
+  final List<SearchUserData> userList;
 
   @override
   State<StatefulWidget> createState() => _UserListViewState();
@@ -40,7 +40,7 @@ class _UserListViewState extends State<UserListView> {
                   ClipRRect(
                       borderRadius: BorderRadius.circular(50),
                       child: Image.network(
-                        widget.userList[index].profileImg!,
+                        widget.userList[index].user.profileImg!,
                         loadingBuilder: (context, child, loadingProgress) {
                           if (loadingProgress == null) return child;
                           return Center(
@@ -65,21 +65,21 @@ class _UserListViewState extends State<UserListView> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        widget.userList[index].nickname,
+                        widget.userList[index].user.nickname,
                         style: const TextStyle(fontSize: 12),
                       ),
-                      // 자기소개
-                      // if (widget.followList[index].introduce.isNotEmpty)
-                      //   Column(
-                      //     crossAxisAlignment: CrossAxisAlignment.start,
-                      //     children: [
-                      //       const Padding(padding: EdgeInsets.only(bottom: 8)),
-                      //       Text(
-                      //         widget.followList[index].introduce,
-                      //         style: const TextStyle(fontSize: 14),
-                      //       ),
-                      //     ],
-                      //   ),
+                      //자기소개
+                      if (widget.userList[index].introduce.isNotEmpty)
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Padding(padding: EdgeInsets.only(bottom: 8)),
+                            Text(
+                              widget.userList[index].introduce,
+                              style: const TextStyle(fontSize: 14),
+                            ),
+                          ],
+                        ),
                     ],
                   ),
                 ],

--- a/lib/ui/widget/home/search_textfield_widget.dart
+++ b/lib/ui/widget/home/search_textfield_widget.dart
@@ -61,6 +61,7 @@ class _SearchTextFieldWidgetState extends State<SearchTextFieldWidget> {
                                   textFieldConfiguration:
                                       TextFieldConfiguration(
                                     controller: _textController,
+                                    cursorColor: Colors.black,
                                     decoration: InputDecoration(
                                       hintText: '계정 또는 태그로 검색하세요',
                                       hintStyle: const TextStyle(


### PR DESCRIPTION
## 📱 작업 사진
<img width="271" alt="image" src="https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/108c438e-411f-4baf-8ba5-c8a9c64bfb12">

## 💬 작업 설명
api 수정 후 계정 검색에 자기소개를 추가하고 검색창의 커서 색을 검정색으로 바꿨습니다.

## ✅ 한 일
1. 계정 검색에 자기소개 추가
2.  검색창의 커서 색 검정색으로 수정

## 💃 부탁 드립니다~
1. 테스트 영상 모두 삭제해주세요~ 앞으로는 발표 때 보여드려도 될만한 춤 영상만 올리는 걸로 합시다~!

## 🤓 다음에 할 일
1. 애니메이션 추가
