### PR TITLE
[feat] 프로필 화면에서 채팅방 생성 기능 추가(HH-391)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,8 +32,6 @@ Future<void> main() async {
 
   bool showOnBoarding = await LocalPrefProvider().getShowOnBoarding();
 
-  Firebase.apps.length;
-
   await Firebase.initializeApp();
 
   runApp(MultiProvider(providers: [

--- a/lib/ui/view/profile/profile_buttons_view.dart
+++ b/lib/ui/view/profile/profile_buttons_view.dart
@@ -3,11 +3,15 @@ import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:pocket_pose/data/entity/request/chat_room_request.dart';
 import 'package:pocket_pose/data/entity/response/profile_response.dart';
+import 'package:pocket_pose/data/remote/provider/chat_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/follow_provider.dart';
 import 'package:pocket_pose/data/remote/provider/profile_provider.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
+import 'package:pocket_pose/ui/screen/chat/chat_detail_screen.dart';
 import 'package:pocket_pose/ui/widget/custom_simple_dialog_widget.dart';
+import 'package:pocket_pose/ui/widget/page_route_with_animation.dart';
 import 'package:provider/provider.dart';
 
 import '../../../data/remote/provider/kakao_login_provider.dart';
@@ -28,6 +32,7 @@ class _ProfileButtonsWidgetState extends State<ProfileButtonsWidget> {
   late KaKaoLoginProvider _loginProvider;
   late FollowProvider _followProvider;
   late ProfileProvider _profileProvider;
+  late ChatProviderImpl _chatProvider;
   UserData? _user;
   int loading = 0;
   bool isLogin = false;
@@ -52,6 +57,7 @@ class _ProfileButtonsWidgetState extends State<ProfileButtonsWidget> {
     _loginProvider = Provider.of<KaKaoLoginProvider>(context, listen: false);
     _followProvider = Provider.of<FollowProvider>(context, listen: false);
     _profileProvider = Provider.of<ProfileProvider>(context, listen: false);
+    _chatProvider = Provider.of<ChatProviderImpl>(context, listen: false);
   }
 
   @override
@@ -84,10 +90,7 @@ class _ProfileButtonsWidgetState extends State<ProfileButtonsWidget> {
                                 if (!isLogin) {
                                   _loginProvider.showLoginBottomSheet();
                                 } else {
-                                  // 메시지 생성 처리
-                                  // 💛 tip 💛 - 사용하고 지워주세요 💛
-                                  // 프로필 사용자: widget.profileResponse.user
-                                  // 앱에 접속한 사용자: _user!
+                                  _startChat();
                                 }
                               },
                               style: OutlinedButton.styleFrom(
@@ -259,5 +262,23 @@ class _ProfileButtonsWidgetState extends State<ProfileButtonsWidget> {
             return Container();
           }
         });
+  }
+
+  _startChat() async {
+    // // 채팅방 생성
+    var result = await _chatProvider.putChatRoom(
+        ChatRoomRequest(opponentUserId: widget.profileResponse.user.userId));
+
+    // 채팅 상세 화면으로 이동
+    _showChatDetailScreen(result.data.chatRoomId);
+  }
+
+  _showChatDetailScreen(String chatRoomId) {
+    PageRouteWithSlideAnimation pageRouteWithAnimation =
+        PageRouteWithSlideAnimation(ChatDetailScreen(
+      chatRoomId: chatRoomId,
+      opponentUserNickName: widget.profileResponse.user.nickname,
+    ));
+    Navigator.push(context, pageRouteWithAnimation.slideRitghtToLeft());
   }
 }

--- a/lib/ui/view/profile/profile_buttons_view.dart
+++ b/lib/ui/view/profile/profile_buttons_view.dart
@@ -279,6 +279,6 @@ class _ProfileButtonsWidgetState extends State<ProfileButtonsWidget> {
       chatRoomId: chatRoomId,
       opponentUserNickName: widget.profileResponse.user.nickname,
     ));
-    Navigator.push(context, pageRouteWithAnimation.slideRitghtToLeft());
+    Navigator.push(context, pageRouteWithAnimation.slideLeftToRight());
   }
 }

--- a/lib/ui/widget/chat/chat_room_list_item_widget.dart
+++ b/lib/ui/widget/chat/chat_room_list_item_widget.dart
@@ -28,14 +28,18 @@ class ChatRoomListItemWidget extends StatelessWidget {
             children: [
               ClipRRect(
                 borderRadius: BorderRadius.circular(50),
-                child: Image.asset(
-                  (chatRoom.opponentUser.profileImg == null)
-                      ? 'assets/images/charactor_popo_default.png'
-                      : chatRoom.opponentUser.profileImg!,
-                  width: 40,
-                  height: 40,
-                  fit: BoxFit.contain,
-                ),
+                child: (chatRoom.opponentUser.profileImg == null)
+                    ? Image.asset(
+                        'assets/images/charactor_popo_default.png',
+                        width: 40,
+                        height: 40,
+                      )
+                    : Image.network(
+                        chatRoom.opponentUser.profileImg!,
+                        fit: BoxFit.cover,
+                        width: 40,
+                        height: 40,
+                      ),
               ),
               const SizedBox(
                 width: 14,

--- a/lib/ui/widget/chat/chat_room_list_item_widget.dart
+++ b/lib/ui/widget/chat/chat_room_list_item_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/domain/entity/chat_room_list_item.dart';
 import 'package:pocket_pose/ui/screen/chat/chat_detail_screen.dart';
+import 'package:pocket_pose/ui/widget/page_route_with_animation.dart';
 
 class ChatRoomListItemWidget extends StatelessWidget {
   final ChatRoomListItem chatRoom;
@@ -13,14 +14,12 @@ class ChatRoomListItemWidget extends StatelessWidget {
     return SafeArea(
       child: InkWell(
         onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-                builder: (context) => ChatDetailScreen(
-                      chatRoomId: chatRoom.chatRoomId,
-                      opponentUserNickName: chatRoom.opponentUser.nickname,
-                    )),
-          );
+          PageRouteWithSlideAnimation pageRouteWithAnimation =
+              PageRouteWithSlideAnimation(ChatDetailScreen(
+            chatRoomId: chatRoom.chatRoomId,
+            opponentUserNickName: chatRoom.opponentUser.nickname,
+          ));
+          Navigator.push(context, pageRouteWithAnimation.slideRitghtToLeft());
         },
         child: Padding(
           padding: const EdgeInsets.fromLTRB(24, 14, 24, 14),


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/4fd58e2f-3bb4-41e6-8baf-f87078032131

## 💬 작업 설명
- 프로필 화면에서 '메시지' 버튼을 누르면 채팅방이 생성되고, 바로 채팅 화면으로 이동하도록 설정하였습니다!
- 메시지 목록에서 생성된 채팅방을 확인할 수 있습니다.
- 프로필에서 채팅 상세 화면으로 넘어갈 때, 채팅 목록에서 채팅 상세 화면으로 넘어갈 때 화면 이동 애니메이션 적용했습니다.

## ✅ 한 일
1. 프로필 화면에서 '메시지' 버튼 누르면 채팅방 생성

## ☝️ 참고 하세요~
1. 채팅방 목록에서 최근 채팅 내용이 안 보이는 건 서버가 아직 작업중이라 그렇습니다.

## 💃 부탁 드립니다~
1. 채팅 잘 되는지 확인 부탁드립니다~ 채팅도 몇 개 보내놔 주세요!
    - 

## 🤓 다음에 할 일
1. 공유(링크)
2. 채팅 사용자 검색
3. Mvp 음악 연결
4. 공유(카카오)// 우선순위 여기까지고 이후부터는 달라질수도
5. 소켓 에러 연결
6. 스테이지 플레이어 인원별 ui 다르게
7. 스테이지 동영상 녹화 후 업로드
8. 캐치, 카운트다운 사운드 변경
9. 푸시알림
10. 리팩토링