### PR TITLE
[feat] 로그인 로그아웃시 푸시 알림을 위한 FCM 토큰 처리 (HH-390)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,7 +71,8 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
+    implementation platform('com.google.firebase:firebase-bom:29.0.2')
+    implementation 'com.google.firebase:firebase-analytics'
     implementation "androidx.lifecycle:lifecycle-runtime:2.0.0"
     implementation "androidx.lifecycle:lifecycle-extensions:2.0.0"
     annotationProcessor "androidx.lifecycle:lifecycle-compiler:2.0.0"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" /> 
 
 
    <application
@@ -20,7 +24,9 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
@@ -29,9 +35,17 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <meta-data
+              android:name="com.google.firebase.messaging.default_notification_channel_id"
+              android:value="high_importance_channel"
+              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="FLUTTER_NOTIFICATION_CLICK" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -9,6 +9,9 @@ class AppUrl {
   // 로그인 & 회원가입
   static const signInSignUpUrl = "$_apiBaseUrl/auth/login?type=kakao";
 
+  // 로그아웃
+  static const logOutUrl = "$_apiBaseUrl/auth/logout?type=kakao";
+
   // 비디오
   static const videoUrl = "$_apiBaseUrl/videos";
 

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -169,10 +169,10 @@ class KaKaoLoginProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<String?> getFCMToken() async {
+  Future<String> getFCMToken() async {
     final fcmToken = await _storage.read(key: _fcmTokenKey);
 
-    return fcmToken;
+    return fcmToken ?? '';
   }
 
   Future<void> removeFCMToken() async {

--- a/lib/data/remote/repository/kakao_login_repository.dart
+++ b/lib/data/remote/repository/kakao_login_repository.dart
@@ -26,7 +26,7 @@ class KaKaoLoginRepository {
 
     if (response.statusCode == 200) {
       final json = jsonDecode(utf8.decode(response.bodyBytes));
-      debugPrint("json: $json");
+      debugPrint("로그인 성공! json: $json");
 
       final user = UserData(
         userId: json['data']['userId'],
@@ -47,6 +47,35 @@ class KaKaoLoginRepository {
       );
     } else {
       throw Exception('Login failed');
+    }
+  }
+
+  Future<bool> logout() async {
+    final url = Uri.parse(AppUrl.logOutUrl);
+
+    await loginProvider.checkAccessToken();
+
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
+
+    final headers = <String, String>{
+      'Content-Type': 'application/json;charset=UTF-8',
+      if (accessToken != null && refreshToken != null)
+        "cookie": "x-access-token=$accessToken;x-refresh-token=$refreshToken"
+    };
+
+    final response = await http.delete(url, headers: headers);
+
+    if (response.statusCode == 200) {
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      debugPrint("로그아웃 성공! json: $json");
+
+      loginProvider.updateToken(response.headers);
+
+      return true;
+    } else {
+      debugPrint('카카오톡 로그인 실패');
+      return false;
     }
   }
 }

--- a/lib/data/remote/repository/kakao_login_repository.dart
+++ b/lib/data/remote/repository/kakao_login_repository.dart
@@ -10,13 +10,15 @@ import 'package:pocket_pose/domain/entity/user_data.dart';
 class KaKaoLoginRepository {
   KaKaoLoginProvider loginProvider = KaKaoLoginProvider();
 
-  Future<KaKaoLoginResponse> login(String kakaoAccessToken) async {
+  Future<KaKaoLoginResponse> login(
+      String kakaoAccessToken, String fcmToken) async {
     final url = Uri.parse(AppUrl.signInSignUpUrl);
     final headers = {
       'Content-Type': 'application/json;charset=UTF-8',
     };
     final body = jsonEncode({
       'kakaoAccessToken': kakaoAccessToken,
+      'fcmNotificationToken': fcmToken
     });
 
     final response = await http.post(url, headers: headers, body: body);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,8 @@ import assets_audio_player_web
 import audio_session
 import file_selector_macos
 import firebase_core
+import firebase_messaging
+import flutter_local_notifications
 import flutter_secure_storage_macos
 import just_audio
 import package_info_plus
@@ -23,6 +25,8 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -321,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "6f07cba3f7b3448d42d015bfd3d53fe12e5b36da2423f23838efc1d5fb31a263"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.8"
   deep_pick:
     dependency: transitive
     description:
@@ -457,6 +465,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.6+5"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: "6c1a2a047d6f165b7c5f947467ac5138731a2af82c7af1c12d691dbb834f6b73"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.6.7"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: bcba58d28f8cda607a323240c6d314c2c62b62ebfbb0f2d704ebefef07b52b5f
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.6"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "962d09ec9dfa486cbbc218258ad41e8ec7997a2eba46919049496e1cafd960c5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.6"
   fixnum:
     dependency: transitive
     description:
@@ -526,6 +558,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "3002092e5b8ce2f86c3361422e52e6db6776c23ee21e0b2f71b892bf4259ef04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.1.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0+1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -900,18 +956,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -1305,10 +1361,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1361,10 +1417,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   textfield_tags:
     dependency: "direct main"
     description:
@@ -1373,6 +1429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "1cfd8ddc2d1cfd836bc93e67b9be88c3adaeca6f40a00ca999104c30693cdca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2"
   timing:
     dependency: transitive
     description:
@@ -1525,6 +1589,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1566,5 +1638,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   uni_links: ^0.5.1
   share_plus: ^7.1.0
   flutterfire_cli: ^0.2.7
+  firebase_messaging: ^14.6.7
+  flutter_local_notifications: ^15.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진 
변경 없습니다.

## 💬 작업 설명
푸시 알림을 위해 FCM 토큰을 사용하기 위해
로그인 할 때는 FCM 토큰을 생성 후 FlutterSecureStorage에 저장하고,
로그아웃을 할 때는 FCM 토큰을 FlutterSecureStorage에서 삭제합니다.

## ✅ 한 일
1. 로그인 api post 요청을 보낼 때 FCM 토큰 추가
2. 로그아웃 api 연결
3. FCM을 위한 안드로이드 기본 설정
4. FCM 토큰을 가져오고 저장, 삭제하는 기능 개발

> ### FlutterSecureStorage에 저장되어 있는 FCM 토큰을 가져오는 방법
> 
> 1. KaKaoLoginProvider를 생성한다.
> `KaKaoLoginProvider _loginProvider = Provider.of<KaKaoLoginProvider >(context, listen: false);`
> 
> 2. FCM 토큰을 가져온다.
> `_loginProvider.getFCMToken();`

## ☝️ 참고 하세요~
1. FCM 기본 설정은 [이 글](https://velog.io/@leedool3003/Flutter-FCM-Firebase-Cloud-Messagin-%EC%97%B0%EB%8F%99)의 1, 2까지 했다고 생각하시면 됩니다~

## 🤓 다음에 할 일
1. 버튼 클릭 애니메이션 추가
