### PR TITLE
[feat] 버튼 패딩 추가, 애니메이션 적용, 아이콘 변경 (HH-388)

### DIFF
--- a/lib/ui/screen/home/home_screen.dart
+++ b/lib/ui/screen/home/home_screen.dart
@@ -65,16 +65,17 @@ class _HomeScreenState extends State<HomeScreen> {
             UploadButtonWidget(
               context: context,
             ),
-            GestureDetector(
-                child: Container(
-                    margin: const EdgeInsets.fromLTRB(0, 0, 14, 0),
-                    child: SvgPicture.asset('assets/icons/ic_home_search.svg')),
-                onTap: () {
-                  PageRouteWithSlideAnimation pageRouteWithAnimation =
-                      PageRouteWithSlideAnimation(const HomeSearchScreen());
-                  Navigator.push(
-                      context, pageRouteWithAnimation.slideRitghtToLeft());
-                }),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(0, 0, 14, 0),
+              child: GestureDetector(
+                  child: SvgPicture.asset('assets/icons/ic_home_search.svg'),
+                  onTap: () {
+                    PageRouteWithSlideAnimation pageRouteWithAnimation =
+                        PageRouteWithSlideAnimation(const HomeSearchScreen());
+                    Navigator.push(
+                        context, pageRouteWithAnimation.slideRitghtToLeft());
+                  }),
+            ),
           ],
         ),
         extendBodyBehindAppBar: true, //body 위에 appbar

--- a/lib/ui/screen/home/home_search_screen.dart
+++ b/lib/ui/screen/home/home_search_screen.dart
@@ -92,8 +92,9 @@ class _HomeSearchScreenState extends State<HomeSearchScreen>
           backgroundColor: Colors.white,
           foregroundColor: Colors.black,
           leading: IconButton(
-            icon: Image.asset(
-              'assets/icons/ic_back.png',
+            icon: Icon(
+              Icons.arrow_back_ios_new_rounded,
+              color: AppColor.purpleColor,
             ),
             onPressed: () {
               Navigator.pop(context);

--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -19,9 +19,13 @@ class MainScreen extends StatefulWidget {
   State<MainScreen> createState() => _MainScreenState();
 }
 
-class _MainScreenState extends State<MainScreen> {
+class _MainScreenState extends State<MainScreen>
+    with SingleTickerProviderStateMixin {
   late MultiVideoPlayProvider _multiVideoPlayProvider;
   late KaKaoLoginProvider _loginProvider;
+
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
 
   int _bottomNavIndex = 0;
   bool isLogin = false;
@@ -43,6 +47,14 @@ class _MainScreenState extends State<MainScreen> {
     _multiVideoPlayProvider.mainContext = context;
 
     _initIsLoginAndScreens();
+
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _scaleAnimation = Tween<double>(begin: 1.0, end: 0.9).animate(
+      CurvedAnimation(parent: _animationController, curve: Curves.easeInOut),
+    );
   }
 
   Future<void> _initIsLoginAndScreens() async {
@@ -91,6 +103,10 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   void _onFloatingButtonClicked() async {
+    _animationController.forward().then((_) {
+      _animationController.reverse();
+    });
+
     if (await _loginProvider.checkAccessToken()) {
       _multiVideoPlayProvider.pauseVideo(0);
       _showPoPoStageScreen();
@@ -119,8 +135,14 @@ class _MainScreenState extends State<MainScreen> {
         backgroundColor: Colors.black,
         splashColor: AppColor.mainPurpleColor,
         onPressed: _onFloatingButtonClicked,
-        child: SvgPicture.asset(
-          'assets/icons/ic_bottom_popo.svg',
+        child: AnimatedBuilder(
+          animation: _animationController,
+          builder: (context, child) {
+            return Transform.scale(
+              scale: _scaleAnimation.value,
+              child: SvgPicture.asset('assets/icons/ic_bottom_popo.svg'),
+            );
+          },
         ),
       ),
       resizeToAvoidBottomInset: false,

--- a/lib/ui/screen/profile/follow_tab_screen.dart
+++ b/lib/ui/screen/profile/follow_tab_screen.dart
@@ -46,8 +46,9 @@ class _FollowTabScreenState extends State<FollowTabScreen>
         backgroundColor: Colors.white,
         foregroundColor: Colors.black,
         leading: IconButton(
-          icon: Image.asset(
-            'assets/icons/ic_back.png',
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+            color: AppColor.purpleColor,
           ),
           onPressed: () {
             Navigator.pop(context);

--- a/lib/ui/screen/profile/profile_edit_screen.dart
+++ b/lib/ui/screen/profile/profile_edit_screen.dart
@@ -91,8 +91,9 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
           backgroundColor: Colors.white,
           foregroundColor: Colors.black,
           leading: IconButton(
-            icon: Image.asset(
-              'assets/icons/ic_back.png',
+            icon: Icon(
+              Icons.arrow_back_ios_new_rounded,
+              color: AppColor.purpleColor,
             ),
             onPressed: () {
               Navigator.pop(context);

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -37,8 +37,9 @@ class _ProfileSettingScreenState extends State<ProfileSettingScreen> {
         backgroundColor: Colors.white,
         foregroundColor: Colors.black,
         leading: IconButton(
-          icon: Image.asset(
-            'assets/icons/ic_back.png',
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+            color: AppColor.purpleColor,
           ),
           onPressed: () {
             Navigator.pop(context);

--- a/lib/ui/widget/profile/profile_tapbar_widget.dart
+++ b/lib/ui/widget/profile/profile_tapbar_widget.dart
@@ -79,9 +79,10 @@ class ProfileTapbarWidget extends StatelessWidget {
                   Navigator.pop(context);
                 },
                 child: Container(
-                  margin: const EdgeInsets.fromLTRB(20, 40, 0, 0),
-                  child: Image.asset(
-                    'assets/icons/ic_back.png',
+                  margin: const EdgeInsets.fromLTRB(16, 40, 0, 0),
+                  child: Icon(
+                    Icons.arrow_back_ios_new_rounded,
+                    color: AppColor.purpleColor,
                   ),
                 ),
               ),


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/989da7ab-b859-4072-aabd-3519f0c55619

## 💬 작업 설명
버튼을 수정했습니다.

## ✅ 한 일
1. 버튼에 패딩 줘서 잘 눌리게 수정
2. 포포 입장하는 버튼에 애니메이션 추가(작아졌다가 커짐)
3. 뒤로가기 아이콘 변경(이전에 사용하던 svg 아이콘이 화질이 안좋아서 기본 아이콘으로 변경했습니다.)

## 🧐 궁금한점
1. 포포 입장 버튼을 누르면 소리가 났으면 좋겠는데 어떠신가요? 뭔가 삐끼삐끼~촤아악 하는 소리? ㅎㅎ (그 디제이 할 때 원 돌리는 거 있잖아요)

## 🤓 다음에 할 일
1. 스켈레톤 로더 추가
2. 업로드 화면에 로더 추가
