### PR TITLE
[feat] 좋아요, 댓글, 공유 아이콘에 패딩 추가, [fix] 자기소개를 nullable로 수정 (HH-388)

### DIFF
--- a/lib/data/remote/repository/search_repository.dart
+++ b/lib/data/remote/repository/search_repository.dart
@@ -8,8 +8,6 @@ import 'package:pocket_pose/data/entity/response/videos_response.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/entity/follow_data.dart';
 import 'package:pocket_pose/domain/entity/search_user_data.dart';
-import 'package:pocket_pose/domain/entity/user_data.dart';
-
 import '../../../domain/entity/video_data.dart';
 import '../../entity/request/videos_request.dart';
 

--- a/lib/domain/entity/search_user_data.dart
+++ b/lib/domain/entity/search_user_data.dart
@@ -6,7 +6,7 @@ part 'search_user_data.g.dart';
 @JsonSerializable()
 class SearchUserData {
   final UserData user;
-  final String introduce;
+  final String? introduce;
 
   SearchUserData({
     required this.user,

--- a/lib/domain/entity/search_user_data.g.dart
+++ b/lib/domain/entity/search_user_data.g.dart
@@ -9,7 +9,7 @@ part of 'search_user_data.dart';
 SearchUserData _$SearchUserDataFromJson(Map<String, dynamic> json) =>
     SearchUserData(
       user: UserData.fromJson(json),
-      introduce: json['introduce'] as String,
+      introduce: json['introduce'] as String?,
     );
 
 Map<String, dynamic> _$SearchUserDataToJson(SearchUserData instance) =>

--- a/lib/ui/loader/user_list_loader.dart
+++ b/lib/ui/loader/user_list_loader.dart
@@ -21,8 +21,8 @@ class UserListLoader extends StatelessWidget {
             children: [
               Container(
                 color: Colors.yellow,
-                height: 50,
-                width: 50,
+                height: 40,
+                width: 40,
               ),
               const SizedBox(width: 14),
               Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
@@ -30,13 +30,13 @@ class UserListLoader extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.all(14),
                   color: AppColor.blueColor2,
-                  height: 15,
+                  height: 10,
                   width: 100,
                 ),
                 const SizedBox(height: 14),
                 Container(
                   color: Colors.pink,
-                  height: 15,
+                  height: 10,
                   width: 200,
                 ),
               ])
@@ -48,22 +48,22 @@ class UserListLoader extends StatelessWidget {
             children: [
               Container(
                 color: Colors.yellow,
-                height: 50,
-                width: 50,
+                height: 40,
+                width: 40,
               ),
               const SizedBox(width: 14),
               Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
                 const SizedBox(height: 2),
                 Container(
                   padding: const EdgeInsets.all(14),
-                  color: Colors.pink,
-                  height: 15,
+                  color: AppColor.blueColor2,
+                  height: 10,
                   width: 100,
                 ),
                 const SizedBox(height: 14),
                 Container(
                   color: Colors.pink,
-                  height: 15,
+                  height: 10,
                   width: 200,
                 ),
               ])
@@ -75,22 +75,22 @@ class UserListLoader extends StatelessWidget {
             children: [
               Container(
                 color: Colors.yellow,
-                height: 50,
-                width: 50,
+                height: 40,
+                width: 40,
               ),
               const SizedBox(width: 14),
               Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
                 const SizedBox(height: 2),
                 Container(
                   padding: const EdgeInsets.all(14),
-                  color: Colors.pink,
-                  height: 15,
+                  color: AppColor.blueColor2,
+                  height: 10,
                   width: 100,
                 ),
                 const SizedBox(height: 14),
                 Container(
                   color: Colors.pink,
-                  height: 15,
+                  height: 10,
                   width: 200,
                 ),
               ])

--- a/lib/ui/view/home/user_list_view.dart
+++ b/lib/ui/view/home/user_list_view.dart
@@ -69,13 +69,13 @@ class _UserListViewState extends State<UserListView> {
                         style: const TextStyle(fontSize: 12),
                       ),
                       //자기소개
-                      if (widget.userList[index].introduce.isNotEmpty)
+                      if (widget.userList[index].introduce != null)
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             const Padding(padding: EdgeInsets.only(bottom: 8)),
                             Text(
-                              widget.userList[index].introduce,
+                              widget.userList[index].introduce!,
                               style: const TextStyle(fontSize: 14),
                             ),
                           ],

--- a/lib/ui/view/video/video_right_view.dart
+++ b/lib/ui/view/video/video_right_view.dart
@@ -29,38 +29,46 @@ class _VideoRightFrameState extends State<VideoRightFrame> {
         _multiVideoPlayProvider.videos[widget.screenNum][widget.index];
 
     return Positioned(
-      right: 12,
+      right: 12, // 12
       bottom: 100,
       child: SizedBox(
         width: 60,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            LikeButtonWidget(screenNum: widget.screenNum, index: widget.index),
-            const Padding(padding: EdgeInsets.only(bottom: 14)),
-            CommentButtonView(
-              screenNum: widget.screenNum,
-              index: widget.index,
-              onRefresh: () {
-                setState(() {});
-              },
-              videoId: video.uuid,
-              commentCount: video.commentCount,
-              childWidget: Column(
-                children: <Widget>[
-                  SvgPicture.asset(
-                    'assets/icons/ic_home_comment.svg',
-                  ),
-                  const Padding(padding: EdgeInsets.only(bottom: 2)),
-                  Text(
-                    '${video.commentCount}',
-                    style: const TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ],
+            Padding(
+              padding: const EdgeInsets.fromLTRB(14, 14, 14, 7),
+              child: LikeButtonWidget(
+                  screenNum: widget.screenNum, index: widget.index),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(14, 7, 14, 7),
+              child: CommentButtonView(
+                screenNum: widget.screenNum,
+                index: widget.index,
+                onRefresh: () {
+                  setState(() {});
+                },
+                videoId: video.uuid,
+                commentCount: video.commentCount,
+                childWidget: Column(
+                  children: <Widget>[
+                    SvgPicture.asset(
+                      'assets/icons/ic_home_comment.svg',
+                    ),
+                    const Padding(padding: EdgeInsets.only(bottom: 2)),
+                    Text(
+                      '${video.commentCount}',
+                      style: const TextStyle(color: Colors.white, fontSize: 12),
+                    ),
+                  ],
+                ),
               ),
             ),
-            const Padding(padding: EdgeInsets.only(bottom: 14)),
-            const ShareButtonWidget()
+            const Padding(
+              padding: EdgeInsets.fromLTRB(14, 7, 14, 7),
+              child: ShareButtonWidget(),
+            )
           ],
         ),
       ),


### PR DESCRIPTION
## 📱 작업 사진 
변경 없습니다.

## 💬 작업 설명
좋아요, 댓글, 공유 아이콘에 패딩을 추가해 클릭이 더 잘 되도록 하였고
자기소개가 null 값이 불가능했는데 null이 가능해져서.... nullable한 데이터 자료형으로 수정했습니다.

## ✅ 한 일
1. 좋아요, 댓글, 공유 아이콘에 패딩 추가
2. 자기소개 nullable로 수정

## 🤓 다음에 할 일
1. 스켈레톤 로더 추가
2. 업로드 화면에 로더 추가