### PR TITLE
[feat] 화면 로더 추가 (HH-388)

### DIFF
--- a/assets/images/dance_popo_left.svg
+++ b/assets/images/dance_popo_left.svg
@@ -1,0 +1,403 @@
+<svg width="322" height="363" viewBox="0 0 322 363" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_822_758)">
+<mask id="path-1-inside-1_822_758" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M256.511 152.594C255.898 95.8182 213.572 50 161.449 50C109.326 50 67.0004 95.8182 66.3867 152.594H80.1351C80.7478 104.11 116.92 65.0136 161.451 65.0136C205.983 65.0136 242.155 104.11 242.768 152.594H256.511Z"/>
+</mask>
+<g filter="url(#filter1_i_822_758)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M256.511 152.594C255.898 95.8182 213.572 50 161.449 50C109.326 50 67.0004 95.8182 66.3867 152.594H80.1351C80.7478 104.11 116.92 65.0136 161.451 65.0136C205.983 65.0136 242.155 104.11 242.768 152.594H256.511Z" fill="white"/>
+</g>
+<path d="M256.511 152.594V153.594H257.522L257.511 152.583L256.511 152.594ZM66.3867 152.594L65.3868 152.583L65.3759 153.594H66.3867V152.594ZM80.1351 152.594V153.594H81.1226L81.135 152.606L80.1351 152.594ZM242.768 152.594L241.768 152.606L241.78 153.594H242.768V152.594ZM257.511 152.583C256.893 95.3436 214.201 49 161.449 49V51C212.943 51 254.903 96.2928 255.512 152.604L257.511 152.583ZM161.449 49C108.698 49 66.0055 95.3436 65.3868 152.583L67.3867 152.604C67.9953 96.2928 109.955 51 161.449 51V49ZM66.3867 153.594H80.1351V151.594H66.3867V153.594ZM161.451 64.0136C116.292 64.0136 79.7538 103.634 79.1352 152.581L81.135 152.606C81.7419 104.586 117.548 66.0136 161.451 66.0136V64.0136ZM243.768 152.581C243.149 103.634 206.611 64.0136 161.451 64.0136V66.0136C205.355 66.0136 241.161 104.586 241.768 152.606L243.768 152.581ZM242.768 153.594H256.511V151.594H242.768V153.594Z" fill="#BFC1F4" mask="url(#path-1-inside-1_822_758)"/>
+<g filter="url(#filter2_i_822_758)">
+<ellipse cx="85.1795" cy="185.828" rx="34.6795" ry="40.4594" fill="white"/>
+</g>
+<path d="M119.359 185.828C119.359 207.972 103.987 225.788 85.1795 225.788C66.3722 225.788 51 207.972 51 185.828C51 163.684 66.3722 145.869 85.1795 145.869C103.987 145.869 119.359 163.684 119.359 185.828Z" stroke="#BFC1F4"/>
+<g filter="url(#filter3_i_822_758)">
+<ellipse cx="236.906" cy="185.828" rx="34.6795" ry="40.4594" fill="white"/>
+</g>
+<path d="M271.086 185.828C271.086 207.972 255.713 225.788 236.906 225.788C218.099 225.788 202.727 207.972 202.727 185.828C202.727 163.684 218.099 145.869 236.906 145.869C255.713 145.869 271.086 163.684 271.086 185.828Z" stroke="#BFC1F4"/>
+<g filter="url(#filter4_ii_822_758)">
+<rect x="128.531" y="220.508" width="24.5647" height="86.6988" fill="#8D91F3"/>
+</g>
+<rect x="129.031" y="221.008" width="23.5647" height="85.6988" stroke="#BFC1F4"/>
+<g filter="url(#filter5_ii_822_758)">
+<rect x="176.211" y="220.508" width="24.5647" height="86.6988" fill="#8D91F3"/>
+</g>
+<rect x="176.711" y="221.008" width="23.5647" height="85.6988" stroke="#BFC1F4"/>
+<g filter="url(#filter6_i_822_758)">
+<path d="M249.902 152.594C259.854 178.92 259.212 193.449 249.902 219.063" stroke="#EFE372" stroke-width="5" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter7_i_822_758)">
+<path d="M73.6172 152.594C63.6654 178.92 64.3079 193.449 73.6172 219.063" stroke="#EFE372" stroke-width="5" stroke-linecap="round"/>
+</g>
+<mask id="path-13-inside-2_822_758" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M61.2865 198.13C61.8529 198.044 62.4329 198 63.0233 198C67.9619 198 72.1744 201.109 73.8101 205.477L109.082 224.196L100.985 239.453L65.6874 220.72C64.8323 220.922 63.9403 221.029 63.0233 221.029C56.6639 221.029 51.5086 215.874 51.5086 209.515C51.5086 207.354 52.1039 205.332 53.1395 203.604C51.344 201.853 50 199.731 50 198.019C50 195.587 54.777 196.671 58.9749 197.623C59.7793 197.805 60.5623 197.983 61.2865 198.13Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M61.2865 198.13C61.8529 198.044 62.4329 198 63.0233 198C67.9619 198 72.1744 201.109 73.8101 205.477L109.082 224.196L100.985 239.453L65.6874 220.72C64.8323 220.922 63.9403 221.029 63.0233 221.029C56.6639 221.029 51.5086 215.874 51.5086 209.515C51.5086 207.354 52.1039 205.332 53.1395 203.604C51.344 201.853 50 199.731 50 198.019C50 195.587 54.777 196.671 58.9749 197.623C59.7793 197.805 60.5623 197.983 61.2865 198.13Z" fill="#8D91F3"/>
+<path d="M63.0233 198L63.0233 197H63.0233V198ZM61.2865 198.13L61.0874 199.11L61.2609 199.145L61.4361 199.119L61.2865 198.13ZM73.8101 205.477L72.8736 205.827L73.0066 206.182L73.3413 206.36L73.8101 205.477ZM109.082 224.196L109.965 224.665L110.434 223.782L109.551 223.313L109.082 224.196ZM100.985 239.453L100.516 240.336L101.4 240.805L101.868 239.921L100.985 239.453ZM65.6874 220.72L66.1562 219.836L65.8234 219.66L65.4569 219.747L65.6874 220.72ZM51.5086 209.515L52.5086 209.515V209.515H51.5086ZM53.1395 203.604L53.9972 204.118L54.4036 203.44L53.8377 202.888L53.1395 203.604ZM58.9749 197.623L58.7537 198.598L58.7537 198.598L58.9749 197.623ZM63.0233 197C62.3827 197 61.7527 197.048 61.1369 197.141L61.4361 199.119C61.9532 199.041 62.4832 199 63.0233 199V197ZM74.7466 205.126C72.9694 200.381 68.3924 197 63.0233 197L63.0233 199C67.5315 199 71.3794 201.838 72.8736 205.827L74.7466 205.126ZM109.551 223.313L74.2789 204.593L73.3413 206.36L108.613 225.079L109.551 223.313ZM101.868 239.921L109.965 224.665L108.199 223.727L100.102 238.984L101.868 239.921ZM65.2186 221.603L100.516 240.336L101.454 238.569L66.1562 219.836L65.2186 221.603ZM63.0233 222.029C64.0185 222.029 64.9878 221.913 65.9179 221.693L65.4569 219.747C64.6768 219.931 63.8621 220.029 63.0233 220.029V222.029ZM50.5086 209.515C50.5086 216.426 56.1116 222.029 63.0233 222.029V220.029C57.2162 220.029 52.5086 215.322 52.5086 209.515L50.5086 209.515ZM52.2817 203.09C51.1557 204.969 50.5086 207.168 50.5086 209.515H52.5086C52.5086 207.54 53.0522 205.695 53.9972 204.118L52.2817 203.09ZM53.8377 202.888C52.991 202.062 52.267 201.164 51.7608 200.294C51.247 199.411 51 198.63 51 198.019H49C49 199.12 49.425 200.256 50.0321 201.3C50.6467 202.356 51.4925 203.394 52.4413 204.32L53.8377 202.888ZM51 198.019C51 197.886 51.03 197.842 51.0366 197.833C51.0468 197.818 51.0854 197.77 51.2142 197.713C51.5077 197.584 52.0428 197.51 52.8633 197.551C54.4763 197.632 56.624 198.115 58.7537 198.598L59.1961 196.648C57.1279 196.179 54.7882 195.645 52.9631 195.553C52.0646 195.509 51.1432 195.56 50.4098 195.882C50.0252 196.051 49.6578 196.31 49.3903 196.697C49.1193 197.09 49 197.545 49 198.019H51ZM58.7537 198.598C59.5555 198.78 60.3501 198.96 61.0874 199.11L61.4856 197.15C60.7746 197.006 60.003 196.831 59.1961 196.648L58.7537 198.598Z" fill="#B9BBEC" mask="url(#path-13-inside-2_822_758)"/>
+<g filter="url(#filter8_ii_822_758)">
+<path d="M160.31 266.747C55.7907 265.444 77.9465 174.991 85.8939 138.867C89.5065 117.914 94.5636 103.465 98.176 83.2349C98.9553 102.397 103.233 114.302 109.013 110.689C114.793 107.077 127.798 80.3449 127.798 80.3449C127.798 80.3449 129.965 96.9622 135.023 96.9622C140.08 96.9622 145.138 86.8473 145.138 86.8473C151.525 106.355 153.074 106.355 158.09 106.355H158.143C163.2 106.355 167.216 107.387 179.095 78.8999C183.142 94.9521 182.764 112.546 200.047 115.747C215.975 118.697 223.737 91.9579 224.278 84.8735C224.024 83.8033 223.889 83.2348 223.889 83.2348C224.243 82.9776 224.374 83.6159 224.278 84.8735C225.791 91.2407 231.536 115.368 238.339 143.202C246.286 175.713 264.829 268.051 160.31 266.747Z" fill="#8D91F3"/>
+<path d="M85.8939 138.867C77.9465 174.991 55.7907 265.444 160.31 266.747C264.83 268.051 246.286 175.713 238.339 143.202C230.392 110.69 223.889 83.2348 223.889 83.2348C226.235 81.5288 218.802 119.221 200.047 115.747C182.764 112.546 183.142 94.9521 179.095 78.8999C167.216 107.387 163.2 106.355 158.143 106.355C153.085 106.355 151.548 106.424 145.138 86.8473C145.138 86.8473 140.08 96.9622 135.023 96.9622C129.965 96.9622 127.798 80.3449 127.798 80.3449C127.798 80.3449 114.793 107.077 109.013 110.689C103.233 114.302 98.9553 102.397 98.176 83.2349C94.5636 103.465 89.5065 117.914 85.8939 138.867Z" stroke="#BFC1F4"/>
+<path d="M161.451 258.068C78.9117 257.135 96.4083 192.431 102.684 166.59C105.537 151.603 109.531 141.266 112.384 126.795C112.999 140.502 116.378 149.018 120.942 146.434C125.506 143.85 135.776 124.728 135.776 124.728C135.776 124.728 137.488 136.615 141.482 136.615C145.476 136.615 149.47 129.379 149.47 129.379C154.514 143.334 155.737 143.334 159.698 143.333H159.74C163.734 143.333 166.905 144.072 176.286 123.694C179.482 135.177 179.183 147.762 192.832 150.052C205.41 152.162 211.539 133.035 211.967 127.967C211.766 127.202 211.66 126.795 211.66 126.795C211.939 126.611 212.043 127.068 211.967 127.967C213.162 132.522 217.698 149.781 223.071 169.691C229.347 192.948 243.991 259 161.451 258.068Z" fill="#B5B8F4"/>
+<path d="M160.993 258.07C99.3148 257.378 112.389 209.372 117.079 190.2C119.211 179.08 122.195 171.411 124.327 160.675C124.787 170.844 127.311 177.163 130.722 175.246C134.133 173.328 141.807 159.141 141.807 159.141C141.807 159.141 143.086 167.96 146.071 167.96C149.055 167.96 152.039 162.592 152.039 162.592C155.809 172.945 156.723 172.945 159.682 172.945H159.714C162.698 172.945 165.068 173.493 172.078 158.374C174.466 166.893 174.243 176.231 184.442 177.93C193.841 179.495 198.421 165.304 198.741 161.544C198.591 160.976 198.511 160.674 198.511 160.674C198.72 160.538 198.798 160.877 198.741 161.544C199.633 164.923 203.024 177.728 207.038 192.501C211.728 209.756 222.671 258.762 160.993 258.07Z" fill="#C8C9EF"/>
+</g>
+<g filter="url(#filter9_ii_822_758)">
+<path d="M153.597 307.929C153.597 313.515 147.002 312.987 135.032 312.987C123.061 312.987 116.75 313.515 116.75 307.929C116.75 302.343 123.061 292.757 135.032 292.757C147.002 292.757 153.597 302.343 153.597 307.929Z" fill="#8D91F3"/>
+</g>
+<path d="M153.097 307.929C153.097 309.217 152.722 310.085 152.042 310.707C151.34 311.349 150.252 311.784 148.715 312.061C146.139 312.524 142.531 312.511 137.909 312.494C136.99 312.49 136.031 312.487 135.032 312.487C134.031 312.487 133.072 312.49 132.155 312.494C127.553 312.511 124.007 312.524 121.492 312.061C119.993 311.785 118.942 311.351 118.267 310.713C117.611 310.093 117.25 309.224 117.25 307.929C117.25 305.297 118.753 301.624 121.757 298.6C124.744 295.593 129.19 293.257 135.032 293.257C140.875 293.257 145.393 295.593 148.453 298.605C151.529 301.632 153.097 305.303 153.097 307.929Z" stroke="#BFC1F4"/>
+<g filter="url(#filter10_ii_822_758)">
+<path d="M201.499 307.929C201.499 313.515 194.905 312.987 182.934 312.987C170.964 312.987 164.652 313.515 164.652 307.929C164.652 302.343 170.964 292.757 182.934 292.757C194.905 292.757 201.499 302.343 201.499 307.929Z" fill="#8D91F3"/>
+</g>
+<path d="M200.999 307.929C200.999 309.217 200.625 310.085 199.945 310.707C199.242 311.349 198.154 311.784 196.617 312.061C194.042 312.524 190.433 312.511 185.811 312.494C184.892 312.49 183.933 312.487 182.934 312.487C181.933 312.487 180.974 312.49 180.058 312.494C175.455 312.511 171.909 312.524 169.395 312.061C167.895 311.785 166.845 311.351 166.169 310.713C165.513 310.093 165.152 309.224 165.152 307.929C165.152 305.297 166.655 301.624 169.659 298.6C172.647 295.593 177.092 293.257 182.934 293.257C188.777 293.257 193.295 295.593 196.355 298.605C199.431 301.632 200.999 305.303 200.999 307.929Z" stroke="#BFC1F4"/>
+<g filter="url(#filter11_i_822_758)">
+<circle cx="183.442" cy="185.828" r="14.4498" fill="white"/>
+<line x1="183.445" y1="178.325" x2="193.56" y2="178.325" stroke="white" stroke-width="2"/>
+<line x1="189.508" y1="174.268" x2="189.508" y2="184.383" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter12_i_822_758)">
+<g filter="url(#filter13_ii_822_758)">
+<path d="M192 185.5C192 190.53 188.446 194 183.091 194C177.735 194 174 190.53 174 185.5C174 180.47 177.735 177 183.091 177C188.446 177 192 180.47 192 185.5Z" fill="#565656"/>
+</g>
+<line x1="180" y1="183.058" x2="190.115" y2="183.058" stroke="white" stroke-width="2"/>
+<line x1="186.062" y1="179" x2="186.062" y2="189.115" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter14_diii_822_758)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M116.34 103.459C107.97 115.6 110.282 132.477 122.054 142.223C133.826 151.97 150.838 151.091 161.204 140.603L116.34 103.459Z" fill="#565656"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M208.199 103.459C216.569 115.6 214.257 132.477 202.485 142.223C190.713 151.97 173.701 151.091 163.335 140.603L208.199 103.459Z" fill="#565656"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M162.488 214.214L162.796 214.728L177.246 206.058L176.217 204.343L162.488 212.58L148.759 204.343L147.73 206.058L162.18 214.728L162.488 214.214Z" fill="black"/>
+<g filter="url(#filter15_ii_822_758)">
+<rect x="140.086" y="130.919" width="5.77992" height="5.77992" fill="white"/>
+</g>
+<g filter="url(#filter16_ii_822_758)">
+<rect x="147.312" y="135.254" width="2.88996" height="2.88996" fill="white"/>
+</g>
+<g filter="url(#filter17_ii_822_758)">
+<rect x="192.109" y="130.919" width="5.77992" height="5.77992" fill="white"/>
+</g>
+<g filter="url(#filter18_ii_822_758)">
+<rect x="199.332" y="135.254" width="2.88996" height="2.88996" fill="white"/>
+</g>
+<g filter="url(#filter19_i_822_758)">
+<path d="M224.167 190.507C222.975 186.727 214.062 183.959 213.058 183.636L211.924 183.304L206.896 203.736C206.68 203.469 206.442 203.219 206.184 202.99C205.258 202.242 204.183 201.683 203.026 201.345C201.869 201.007 200.652 200.898 199.449 201.025C194.806 201.385 191.091 204.582 191.163 208.15C191.189 208.907 191.376 209.65 191.714 210.334C192.051 211.018 192.532 211.628 193.125 212.125C194.141 212.986 195.365 213.586 196.686 213.87C197.747 214.109 198.84 214.185 199.925 214.095C204.093 213.776 207.499 211.167 208.108 208.063L212.472 190.329C213.489 190.688 214.871 191.225 216.313 191.881C217.761 192.442 219.082 193.269 220.201 194.317C221.085 195.219 220.128 196.32 220.051 196.409C219.371 197.026 218.622 197.57 217.818 198.029C217.582 198.167 217.411 198.387 217.34 198.643C217.268 198.899 217.301 199.171 217.433 199.404C217.564 199.637 217.783 199.813 218.045 199.895C218.307 199.977 218.592 199.959 218.841 199.845C219.118 199.664 225.92 196.051 224.167 190.507Z" fill="#C67EFF"/>
+</g>
+<g filter="url(#filter20_i_822_758)">
+<path d="M100.983 192.594C101.949 188.751 110.683 185.459 111.666 185.077L112.778 184.678L119.009 204.776C119.208 204.497 119.431 204.233 119.676 203.989C120.556 203.188 121.595 202.565 122.73 202.16C123.866 201.754 125.074 201.573 126.282 201.628C130.938 201.712 134.837 204.683 134.976 208.249C134.995 209.006 134.852 209.76 134.556 210.462C134.259 211.165 133.816 211.802 133.253 212.334C132.29 213.253 131.103 213.925 129.802 214.286C128.757 214.589 127.671 214.729 126.582 214.703C122.402 214.632 118.848 212.23 118.056 209.167L112.648 191.723C111.653 192.141 110.306 192.76 108.906 193.501C107.493 194.147 106.224 195.051 105.169 196.162C104.34 197.115 105.36 198.158 105.443 198.242C106.158 198.818 106.938 199.316 107.768 199.726C108.011 199.851 108.195 200.06 108.281 200.311C108.368 200.562 108.351 200.837 108.234 201.077C108.117 201.317 107.908 201.506 107.652 201.603C107.395 201.7 107.11 201.699 106.855 201.6C106.567 201.436 99.5624 198.233 100.983 192.594Z" fill="#F3ECA6"/>
+</g>
+<mask id="path-38-inside-3_822_758" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M248.694 238.498L227.259 215L214.498 226.64L225.202 238.374L215.246 244.056C214.386 243.88 213.491 243.8 212.575 243.828C206.219 244.024 201.224 249.335 201.42 255.691C201.615 262.047 206.926 267.042 213.282 266.847C218.219 266.695 222.335 263.458 223.835 259.041L245.869 246.466C247.441 246.195 250 244.348 249.998 242.5C249.998 240.904 249.657 238.874 248.694 238.498Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M248.694 238.498L227.259 215L214.498 226.64L225.202 238.374L215.246 244.056C214.386 243.88 213.491 243.8 212.575 243.828C206.219 244.024 201.224 249.335 201.42 255.691C201.615 262.047 206.926 267.042 213.282 266.847C218.219 266.695 222.335 263.458 223.835 259.041L245.869 246.466C247.441 246.195 250 244.348 249.998 242.5C249.998 240.904 249.657 238.874 248.694 238.498Z" fill="url(#paint0_linear_822_758)"/>
+<path d="M248.694 238.498L247.955 239.172L248.112 239.345L248.33 239.43L248.694 238.498ZM227.259 215L227.998 214.326L227.324 213.587L226.585 214.261L227.259 215ZM214.498 226.64L213.824 225.901L213.086 226.575L213.759 227.314L214.498 226.64ZM225.202 238.374L225.698 239.242L226.783 238.623L225.941 237.7L225.202 238.374ZM215.246 244.056L215.046 245.036L215.415 245.111L215.742 244.924L215.246 244.056ZM212.575 243.828L212.606 244.828L212.606 244.828L212.575 243.828ZM201.42 255.691L202.419 255.66L201.42 255.691ZM213.282 266.847L213.313 267.846L213.313 267.846L213.282 266.847ZM223.835 259.041L223.339 258.173L223.01 258.36L222.888 258.719L223.835 259.041ZM245.869 246.466L245.699 245.48L245.526 245.51L245.373 245.597L245.869 246.466ZM249.998 242.5L248.998 242.5L248.998 242.501L249.998 242.5ZM249.433 237.824L227.998 214.326L226.52 215.674L247.955 239.172L249.433 237.824ZM226.585 214.261L213.824 225.901L215.172 227.379L227.933 215.739L226.585 214.261ZM213.759 227.314L224.463 239.048L225.941 237.7L215.237 225.966L213.759 227.314ZM224.706 237.505L214.751 243.187L215.742 244.924L225.698 239.242L224.706 237.505ZM215.447 243.076C214.511 242.885 213.539 242.798 212.545 242.829L212.606 244.828C213.444 244.802 214.261 244.875 215.046 245.036L215.447 243.076ZM212.545 242.829C205.636 243.041 200.208 248.813 200.42 255.722L202.419 255.66C202.241 249.856 206.802 245.006 212.606 244.828L212.545 242.829ZM200.42 255.722C200.632 262.63 206.405 268.059 213.313 267.846L213.252 265.847C207.447 266.026 202.597 261.465 202.419 255.66L200.42 255.722ZM213.313 267.846C218.68 267.682 223.152 264.161 224.782 259.363L222.888 258.719C221.517 262.754 217.758 265.709 213.252 265.847L213.313 267.846ZM224.331 259.91L246.364 247.334L245.373 245.597L223.339 258.173L224.331 259.91ZM248.998 242.501C248.999 242.986 248.63 243.657 247.868 244.319C247.128 244.962 246.258 245.384 245.699 245.48L246.039 247.451C247.052 247.277 248.247 246.639 249.18 245.829C250.09 245.038 250.999 243.861 250.998 242.499L248.998 242.501ZM248.33 239.43C248.302 239.418 248.356 239.427 248.456 239.587C248.554 239.745 248.655 239.983 248.743 240.305C248.918 240.947 248.998 241.759 248.998 242.5H250.998C250.998 241.645 250.908 240.644 250.672 239.778C250.554 239.346 250.389 238.907 250.152 238.528C249.917 238.152 249.568 237.766 249.057 237.567L248.33 239.43Z" fill="url(#paint1_linear_822_758)" mask="url(#path-38-inside-3_822_758)"/>
+<g filter="url(#filter21_i_822_758)">
+<path d="M128 184.276C131.491 183.946 134.943 183.745 138.368 184.674C140.416 185.23 142.438 186.081 144.395 186.9C145.227 187.249 145.889 187.89 146.605 188.427" stroke="#565656" stroke-width="3" stroke-linecap="round"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_822_758" x="0" y="0" width="321.586" height="363" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="25"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.337255 0 0 0 0 0.360784 0 0 0 0 0.917647 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_822_758"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_822_758" result="shape"/>
+</filter>
+<filter id="filter1_i_822_758" x="65.3867" y="49" width="191.125" height="103.594" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter2_i_822_758" x="50.5" y="143.369" width="69.3594" height="82.9189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter3_i_822_758" x="202.227" y="143.369" width="69.3594" height="82.9189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter4_ii_822_758" x="127.531" y="219.508" width="26.2664" height="88.6988" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.7" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter5_ii_822_758" x="175.211" y="219.508" width="26.2664" height="88.6988" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.7" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter6_i_822_758" x="246.402" y="149.093" width="13.2266" height="72.4705" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter7_i_822_758" x="62.8906" y="149.093" width="13.2266" height="72.4705" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter8_ii_822_758" x="67.8594" y="67.3197" width="177.508" height="199.941" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-10" dy="-10"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="-3"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter9_ii_822_758" x="115.75" y="291.757" width="38.3477" height="21.7431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter10_ii_822_758" x="163.652" y="291.757" width="38.3477" height="21.7431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter11_i_822_758" x="167.992" y="170.378" width="29.8984" height="29.8996" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter12_i_822_758" x="173" y="176" width="19" height="18" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter13_ii_822_758" x="173" y="176" width="19.5" height="18.5" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter14_diii_822_758" x="107.344" y="100.459" width="109.852" height="53.5713" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_822_758"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_822_758" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.35"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.979167 0 0 0 0 0.983333 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_822_758" result="effect3_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect3_innerShadow_822_758" result="effect4_innerShadow_822_758"/>
+</filter>
+<filter id="filter15_ii_822_758" x="139.586" y="130.419" width="6.28125" height="6.27991" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter16_ii_822_758" x="146.812" y="134.754" width="3.39062" height="3.38995" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter17_ii_822_758" x="191.609" y="130.419" width="6.28125" height="6.27991" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter18_ii_822_758" x="198.832" y="134.754" width="3.39062" height="3.38995" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_822_758" result="effect2_innerShadow_822_758"/>
+</filter>
+<filter id="filter19_i_822_758" x="190.164" y="182.304" width="34.293" height="31.8279" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter20_i_822_758" x="99.793" y="183.678" width="35.1836" height="31.0281" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<filter id="filter21_i_822_758" x="125.5" y="181.5" width="22.6055" height="8.42694" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_822_758"/>
+</filter>
+<linearGradient id="paint0_linear_822_758" x1="224.5" y1="220.5" x2="248" y2="260.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8D91F3" stop-opacity="0"/>
+<stop offset="0.214926" stop-color="#8D91F3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_822_758" x1="225.706" y1="215" x2="235.5" y2="231" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BFC1F4" stop-opacity="0"/>
+<stop offset="1" stop-color="#BFC1F4"/>
+</linearGradient>
+</defs>
+</svg>

--- a/assets/images/dance_popo_right.svg
+++ b/assets/images/dance_popo_right.svg
@@ -1,0 +1,403 @@
+<svg width="322" height="363" viewBox="0 0 322 363" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_823_877)">
+<mask id="path-1-inside-1_823_877" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M65.0745 152.594C65.6882 95.8182 108.014 50 160.137 50C212.26 50 254.586 95.8182 255.199 152.594H241.451C240.838 104.11 204.666 65.0136 160.135 65.0136C115.603 65.0136 79.431 104.11 78.8183 152.594H65.0745Z"/>
+</mask>
+<g filter="url(#filter1_i_823_877)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M65.0745 152.594C65.6882 95.8182 108.014 50 160.137 50C212.26 50 254.586 95.8182 255.199 152.594H241.451C240.838 104.11 204.666 65.0136 160.135 65.0136C115.603 65.0136 79.431 104.11 78.8183 152.594H65.0745Z" fill="white"/>
+</g>
+<path d="M65.0745 152.594V153.594H64.0636L64.0745 152.583L65.0745 152.594ZM255.199 152.594L256.199 152.583L256.21 153.594H255.199V152.594ZM241.451 152.594V153.594H240.463L240.451 152.606L241.451 152.594ZM78.8183 152.594L79.8182 152.606L79.8057 153.594H78.8183V152.594ZM64.0745 152.583C64.6932 95.3436 107.385 49 160.137 49V51C108.643 51 66.6831 96.2928 66.0744 152.604L64.0745 152.583ZM160.137 49C212.888 49 255.58 95.3436 256.199 152.583L254.199 152.604C253.591 96.2928 211.631 51 160.137 51V49ZM255.199 153.594H241.451V151.594H255.199V153.594ZM160.135 64.0136C205.294 64.0136 241.832 103.634 242.451 152.581L240.451 152.606C239.844 104.586 204.038 66.0136 160.135 66.0136V64.0136ZM77.8183 152.581C78.4369 103.634 114.975 64.0136 160.135 64.0136V66.0136C116.231 66.0136 80.425 104.586 79.8182 152.606L77.8183 152.581ZM78.8183 153.594H65.0745V151.594H78.8183V153.594Z" fill="#BFC1F4" mask="url(#path-1-inside-1_823_877)"/>
+<g filter="url(#filter2_i_823_877)">
+<ellipse cx="34.6795" cy="40.4594" rx="34.6795" ry="40.4594" transform="matrix(-1 0 0 1 271.086 145.369)" fill="white"/>
+</g>
+<path d="M202.227 185.828C202.227 207.972 217.599 225.788 236.406 225.788C255.214 225.788 270.586 207.972 270.586 185.828C270.586 163.684 255.214 145.869 236.406 145.869C217.599 145.869 202.227 163.684 202.227 185.828Z" stroke="#BFC1F4"/>
+<g filter="url(#filter3_i_823_877)">
+<ellipse cx="34.6795" cy="40.4594" rx="34.6795" ry="40.4594" transform="matrix(-1 0 0 1 119.359 145.369)" fill="white"/>
+</g>
+<path d="M50.5003 185.828C50.5003 207.972 65.8726 225.788 84.6799 225.788C103.487 225.788 118.859 207.972 118.859 185.828C118.859 163.684 103.487 145.869 84.6799 145.869C65.8726 145.869 50.5003 163.684 50.5003 185.828Z" stroke="#BFC1F4"/>
+<g filter="url(#filter4_ii_823_877)">
+<rect width="24.5647" height="86.6988" transform="matrix(-1 0 0 1 193.055 220.508)" fill="#8D91F3"/>
+</g>
+<rect x="-0.5" y="0.5" width="23.5647" height="85.6988" transform="matrix(-1 0 0 1 192.055 220.508)" stroke="#BFC1F4"/>
+<g filter="url(#filter5_ii_823_877)">
+<rect width="24.5647" height="86.6988" transform="matrix(-1 0 0 1 145.375 220.508)" fill="#8D91F3"/>
+</g>
+<rect x="-0.5" y="0.5" width="23.5647" height="85.6988" transform="matrix(-1 0 0 1 144.375 220.508)" stroke="#BFC1F4"/>
+<g filter="url(#filter6_i_823_877)">
+<path d="M71.6836 152.594C61.7318 178.92 62.3743 193.449 71.6836 219.063" stroke="#EFE372" stroke-width="5" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter7_i_823_877)">
+<path d="M247.969 152.594C257.921 178.92 257.278 193.449 247.969 219.063" stroke="#EFE372" stroke-width="5" stroke-linecap="round"/>
+</g>
+<mask id="path-13-inside-2_823_877" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M260.299 198.13C259.733 198.044 259.153 198 258.563 198C253.624 198 249.412 201.109 247.776 205.477L212.504 224.196L220.601 239.453L255.899 220.72C256.754 220.922 257.646 221.029 258.563 221.029C264.922 221.029 270.077 215.874 270.077 209.515C270.077 207.354 269.482 205.332 268.446 203.604C270.242 201.853 271.586 199.731 271.586 198.019C271.586 195.587 266.809 196.671 262.611 197.623C261.807 197.805 261.024 197.983 260.299 198.13Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M260.299 198.13C259.733 198.044 259.153 198 258.563 198C253.624 198 249.412 201.109 247.776 205.477L212.504 224.196L220.601 239.453L255.899 220.72C256.754 220.922 257.646 221.029 258.563 221.029C264.922 221.029 270.077 215.874 270.077 209.515C270.077 207.354 269.482 205.332 268.446 203.604C270.242 201.853 271.586 199.731 271.586 198.019C271.586 195.587 266.809 196.671 262.611 197.623C261.807 197.805 261.024 197.983 260.299 198.13Z" fill="#8D91F3"/>
+<path d="M258.563 198L258.563 197H258.563V198ZM260.299 198.13L260.499 199.11L260.325 199.145L260.15 199.119L260.299 198.13ZM247.776 205.477L248.712 205.827L248.579 206.182L248.245 206.36L247.776 205.477ZM212.504 224.196L211.621 224.665L211.152 223.782L212.035 223.313L212.504 224.196ZM220.601 239.453L221.07 240.336L220.186 240.805L219.717 239.921L220.601 239.453ZM255.899 220.72L255.43 219.836L255.763 219.66L256.129 219.747L255.899 220.72ZM270.077 209.515L269.077 209.515V209.515H270.077ZM268.446 203.604L267.589 204.118L267.182 203.44L267.748 202.888L268.446 203.604ZM262.611 197.623L262.832 198.598L262.832 198.598L262.611 197.623ZM258.563 197C259.203 197 259.833 197.048 260.449 197.141L260.15 199.119C259.633 199.041 259.103 199 258.563 199V197ZM246.839 205.126C248.617 200.381 253.194 197 258.563 197L258.563 199C254.054 199 250.207 201.838 248.712 205.827L246.839 205.126ZM212.035 223.313L247.307 204.593L248.245 206.36L212.973 225.079L212.035 223.313ZM219.717 239.921L211.621 224.665L213.387 223.727L221.484 238.984L219.717 239.921ZM256.367 221.603L221.07 240.336L220.132 238.569L255.43 219.836L256.367 221.603ZM258.563 222.029C257.567 222.029 256.598 221.913 255.668 221.693L256.129 219.747C256.909 219.931 257.724 220.029 258.563 220.029V222.029ZM271.077 209.515C271.077 216.426 265.474 222.029 258.563 222.029V220.029C264.37 220.029 269.077 215.322 269.077 209.515L271.077 209.515ZM269.304 203.09C270.43 204.969 271.077 207.168 271.077 209.515H269.077C269.077 207.54 268.534 205.695 267.589 204.118L269.304 203.09ZM267.748 202.888C268.595 202.062 269.319 201.164 269.825 200.294C270.339 199.411 270.586 198.63 270.586 198.019H272.586C272.586 199.12 272.161 200.256 271.554 201.3C270.939 202.356 270.093 203.394 269.145 204.32L267.748 202.888ZM270.586 198.019C270.586 197.886 270.556 197.842 270.549 197.833C270.539 197.818 270.501 197.77 270.372 197.713C270.078 197.584 269.543 197.51 268.723 197.551C267.11 197.632 264.962 198.115 262.832 198.598L262.39 196.648C264.458 196.179 266.798 195.645 268.623 195.553C269.521 195.509 270.443 195.56 271.176 195.882C271.561 196.051 271.928 196.31 272.196 196.697C272.467 197.09 272.586 197.545 272.586 198.019H270.586ZM262.832 198.598C262.03 198.78 261.236 198.96 260.499 199.11L260.1 197.15C260.811 197.006 261.583 196.831 262.39 196.648L262.832 198.598Z" fill="#B9BBEC" mask="url(#path-13-inside-2_823_877)"/>
+<g filter="url(#filter8_ii_823_877)">
+<path d="M161.276 266.747C265.795 265.444 243.639 174.991 235.692 138.867C232.079 117.914 227.022 103.465 223.41 83.2349C222.631 102.397 218.352 114.302 212.573 110.689C206.793 107.077 193.788 80.3449 193.788 80.3449C193.788 80.3449 191.62 96.9622 186.563 96.9622C181.505 96.9622 176.448 86.8473 176.448 86.8473C170.061 106.355 168.512 106.355 163.496 106.355H163.443C158.386 106.355 154.37 107.387 142.491 78.8999C138.443 94.9521 138.822 112.546 121.539 115.747C105.611 118.697 97.8494 91.9579 97.3077 84.8735C97.5619 83.8033 97.6966 83.2348 97.6966 83.2348C97.3429 82.9776 97.2116 83.6159 97.3077 84.8735C95.7953 91.2407 90.0503 115.368 83.2467 143.202C75.2996 175.713 56.7564 268.051 161.276 266.747Z" fill="#8D91F3"/>
+<path d="M235.692 138.867C243.639 174.991 265.795 265.444 161.276 266.747C56.7564 268.051 75.2996 175.713 83.2467 143.202C91.1938 110.69 97.6966 83.2348 97.6966 83.2348C95.3509 81.5288 102.784 119.221 121.539 115.747C138.822 112.546 138.443 94.9521 142.491 78.8999C154.37 107.387 158.386 106.355 163.443 106.355C168.501 106.355 170.038 106.424 176.448 86.8473C176.448 86.8473 181.505 96.9622 186.563 96.9622C191.62 96.9622 193.788 80.3449 193.788 80.3449C193.788 80.3449 206.793 107.077 212.573 110.689C218.352 114.302 222.631 102.397 223.41 83.2349C227.022 103.465 232.079 117.914 235.692 138.867Z" stroke="#BFC1F4"/>
+<path d="M160.135 258.068C242.674 257.135 225.178 192.431 218.902 166.59C216.049 151.603 212.055 141.266 209.202 126.795C208.587 140.502 205.208 149.018 200.644 146.434C196.08 143.85 185.81 124.728 185.81 124.728C185.81 124.728 184.098 136.615 180.104 136.615C176.11 136.615 172.116 129.379 172.116 129.379C167.072 143.334 165.849 143.334 161.888 143.333H161.846C157.852 143.333 154.681 144.072 145.3 123.694C142.104 135.177 142.403 147.762 128.754 150.052C116.176 152.162 110.046 133.035 109.619 127.967C109.819 127.202 109.926 126.795 109.926 126.795C109.647 126.611 109.543 127.068 109.619 127.967C108.424 132.522 103.887 149.781 98.5147 169.691C92.2388 192.948 77.5952 259 160.135 258.068Z" fill="#B5B8F4"/>
+<path d="M160.593 258.07C222.271 257.378 209.197 209.372 204.507 190.2C202.375 179.08 199.391 171.411 197.259 160.675C196.799 170.844 194.275 177.163 190.864 175.246C187.453 173.328 179.779 159.141 179.779 159.141C179.779 159.141 178.5 167.96 175.515 167.96C172.531 167.96 169.547 162.592 169.547 162.592C165.777 172.945 164.863 172.945 161.904 172.945H161.872C158.888 172.945 156.518 173.493 149.508 158.374C147.12 166.893 147.343 176.231 137.144 177.93C127.745 179.495 123.165 165.304 122.845 161.544C122.995 160.976 123.075 160.674 123.075 160.674C122.866 160.538 122.788 160.877 122.845 161.544C121.953 164.923 118.562 177.728 114.548 192.501C109.858 209.756 98.9154 258.762 160.593 258.07Z" fill="#C8C9EF"/>
+</g>
+<g filter="url(#filter9_ii_823_877)">
+<path d="M167.989 307.929C167.989 313.515 174.584 312.987 186.554 312.987C198.525 312.987 204.836 313.515 204.836 307.929C204.836 302.343 198.525 292.757 186.554 292.757C174.584 292.757 167.989 302.343 167.989 307.929Z" fill="#8D91F3"/>
+</g>
+<path d="M168.489 307.929C168.489 309.217 168.864 310.085 169.544 310.707C170.246 311.349 171.334 311.784 172.871 312.061C175.447 312.524 179.055 312.511 183.677 312.494C184.596 312.49 185.555 312.487 186.554 312.487C187.555 312.487 188.514 312.49 189.431 312.494C194.033 312.511 197.579 312.524 200.093 312.061C201.593 311.785 202.644 311.351 203.319 310.713C203.975 310.093 204.336 309.224 204.336 307.929C204.336 305.297 202.833 301.624 199.829 298.6C196.841 295.593 192.396 293.257 186.554 293.257C180.711 293.257 176.193 295.593 173.133 298.605C170.057 301.632 168.489 305.303 168.489 307.929Z" stroke="#BFC1F4"/>
+<g filter="url(#filter10_ii_823_877)">
+<path d="M120.087 307.929C120.087 313.515 126.681 312.987 138.652 312.987C150.622 312.987 156.934 313.515 156.934 307.929C156.934 302.343 150.622 292.757 138.652 292.757C126.681 292.757 120.087 302.343 120.087 307.929Z" fill="#8D91F3"/>
+</g>
+<path d="M120.587 307.929C120.587 309.217 120.961 310.085 121.641 310.707C122.344 311.349 123.432 311.784 124.969 312.061C127.544 312.524 131.153 312.511 135.775 312.494C136.694 312.49 137.653 312.487 138.652 312.487C139.653 312.487 140.612 312.49 141.528 312.494C146.131 312.511 149.677 312.524 152.191 312.061C153.691 311.785 154.741 311.351 155.417 310.713C156.073 310.093 156.434 309.224 156.434 307.929C156.434 305.297 154.93 301.624 151.927 298.6C148.939 295.593 144.494 293.257 138.652 293.257C132.809 293.257 128.291 295.593 125.231 298.605C122.155 301.632 120.587 305.303 120.587 307.929Z" stroke="#BFC1F4"/>
+<g filter="url(#filter11_i_823_877)">
+<circle cx="14.4498" cy="14.4498" r="14.4498" transform="matrix(-1 0 0 1 152.594 171.378)" fill="white"/>
+<line y1="-1" x2="10.1149" y2="-1" transform="matrix(-1 0 0 1 138.141 179.325)" stroke="white" stroke-width="2"/>
+<line y1="-1" x2="10.1149" y2="-1" transform="matrix(4.37114e-08 1 1 -4.37114e-08 133.078 174.268)" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter12_i_823_877)">
+<g filter="url(#filter13_ii_823_877)">
+<path d="M129.586 185.5C129.586 190.53 133.14 194 138.495 194C143.851 194 147.586 190.53 147.586 185.5C147.586 180.47 143.851 177 138.495 177C133.14 177 129.586 180.47 129.586 185.5Z" fill="#565656"/>
+</g>
+<line y1="-1" x2="10.1149" y2="-1" transform="matrix(-1 0 0 1 141.586 184.058)" stroke="white" stroke-width="2"/>
+<line y1="-1" x2="10.1149" y2="-1" transform="matrix(4.37114e-08 1 1 -4.37114e-08 136.523 179)" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter14_diii_823_877)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M205.246 103.459C213.616 115.6 211.304 132.477 199.532 142.223C187.76 151.97 170.748 151.091 160.382 140.603L205.246 103.459Z" fill="#565656"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M113.387 103.459C105.017 115.6 107.329 132.477 119.101 142.223C130.873 151.97 147.885 151.091 158.251 140.603L113.387 103.459Z" fill="#565656"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M159.098 214.214L158.79 214.728L144.34 206.058L145.369 204.343L159.098 212.58L172.826 204.343L173.855 206.058L159.406 214.728L159.098 214.214Z" fill="black"/>
+<g filter="url(#filter15_ii_823_877)">
+<rect width="5.77992" height="5.77992" transform="matrix(-1 0 0 1 181.5 130.919)" fill="white"/>
+</g>
+<g filter="url(#filter16_ii_823_877)">
+<rect width="2.88996" height="2.88996" transform="matrix(-1 0 0 1 174.273 135.254)" fill="white"/>
+</g>
+<g filter="url(#filter17_ii_823_877)">
+<rect width="5.77992" height="5.77992" transform="matrix(-1 0 0 1 129.477 130.919)" fill="white"/>
+</g>
+<g filter="url(#filter18_ii_823_877)">
+<rect width="2.88996" height="2.88996" transform="matrix(-1 0 0 1 122.254 135.254)" fill="white"/>
+</g>
+<g filter="url(#filter19_i_823_877)">
+<path d="M97.4185 190.507C98.6107 186.727 107.524 183.959 108.528 183.636L109.662 183.304L114.69 203.736C114.906 203.469 115.144 203.219 115.402 202.99C116.328 202.242 117.402 201.683 118.56 201.345C119.717 201.007 120.934 200.898 122.137 201.025C126.779 201.385 130.495 204.582 130.423 208.15C130.397 208.907 130.21 209.65 129.872 210.334C129.535 211.018 129.054 211.628 128.461 212.125C127.445 212.986 126.22 213.586 124.9 213.87C123.839 214.109 122.746 214.185 121.661 214.095C117.492 213.776 114.087 211.167 113.478 208.063L109.114 190.329C108.097 190.688 106.715 191.225 105.273 191.881C103.825 192.442 102.504 193.269 101.385 194.317C100.501 195.219 101.458 196.32 101.535 196.409C102.215 197.026 102.964 197.57 103.768 198.029C104.004 198.167 104.174 198.387 104.246 198.643C104.318 198.899 104.284 199.171 104.153 199.404C104.022 199.637 103.803 199.813 103.541 199.895C103.279 199.977 102.994 199.959 102.745 199.845C102.468 199.664 95.6656 196.051 97.4185 190.507Z" fill="#C67EFF"/>
+</g>
+<g filter="url(#filter20_i_823_877)">
+<path d="M220.603 192.594C219.637 188.751 210.903 185.459 209.92 185.077L208.808 184.678L202.577 204.776C202.378 204.497 202.155 204.233 201.91 203.989C201.03 203.188 199.991 202.565 198.856 202.16C197.72 201.754 196.512 201.573 195.304 201.628C190.648 201.712 186.749 204.683 186.61 208.249C186.591 209.006 186.734 209.76 187.03 210.462C187.327 211.165 187.77 211.802 188.333 212.334C189.295 213.253 190.483 213.925 191.784 214.286C192.828 214.589 193.915 214.729 195.004 214.703C199.184 214.632 202.738 212.23 203.53 209.167L208.938 191.723C209.932 192.141 211.28 192.76 212.68 193.501C214.093 194.147 215.362 195.051 216.417 196.162C217.246 197.115 216.226 198.158 216.143 198.242C215.428 198.818 214.648 199.316 213.818 199.726C213.575 199.851 213.391 200.06 213.305 200.311C213.218 200.562 213.235 200.837 213.352 201.077C213.469 201.317 213.678 201.506 213.934 201.603C214.191 201.7 214.476 201.699 214.731 201.6C215.019 201.436 222.024 198.233 220.603 192.594Z" fill="#F3ECA6"/>
+</g>
+<mask id="path-38-inside-3_823_877" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M72.8922 238.498L94.3271 215L107.088 226.64L96.3841 238.374L106.34 244.056C107.2 243.88 108.094 243.8 109.011 243.828C115.367 244.024 120.362 249.335 120.166 255.691C119.971 262.047 114.66 267.042 108.304 266.847C103.367 266.695 99.2514 263.458 97.7509 259.041L75.7171 246.466C74.1446 246.195 71.5861 244.348 71.5876 242.5C71.5876 240.904 71.9285 238.874 72.8922 238.498Z"/>
+</mask>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M72.8922 238.498L94.3271 215L107.088 226.64L96.3841 238.374L106.34 244.056C107.2 243.88 108.094 243.8 109.011 243.828C115.367 244.024 120.362 249.335 120.166 255.691C119.971 262.047 114.66 267.042 108.304 266.847C103.367 266.695 99.2514 263.458 97.7509 259.041L75.7171 246.466C74.1446 246.195 71.5861 244.348 71.5876 242.5C71.5876 240.904 71.9285 238.874 72.8922 238.498Z" fill="url(#paint0_linear_823_877)"/>
+<path d="M72.8922 238.498L73.631 239.172L73.4736 239.345L73.256 239.43L72.8922 238.498ZM94.3271 215L93.5883 214.326L94.2623 213.587L95.0011 214.261L94.3271 215ZM107.088 226.64L107.762 225.901L108.5 226.575L107.826 227.314L107.088 226.64ZM96.3841 238.374L95.8884 239.242L94.8032 238.623L95.6453 237.7L96.3841 238.374ZM106.34 244.056L106.54 245.036L106.171 245.111L105.844 244.924L106.34 244.056ZM109.011 243.828L108.98 244.828L108.98 244.828L109.011 243.828ZM120.166 255.691L119.167 255.66L120.166 255.691ZM108.304 266.847L108.273 267.846L108.273 267.846L108.304 266.847ZM97.7509 259.041L98.2466 258.173L98.5758 258.36L98.6978 258.719L97.7509 259.041ZM75.7171 246.466L75.8869 245.48L76.0601 245.51L76.2128 245.597L75.7171 246.466ZM71.5876 242.5L72.5876 242.5L72.5876 242.501L71.5876 242.5ZM72.1534 237.824L93.5883 214.326L95.0659 215.674L73.631 239.172L72.1534 237.824ZM95.0011 214.261L107.762 225.901L106.414 227.379L93.6532 215.739L95.0011 214.261ZM107.826 227.314L97.1228 239.048L95.6453 237.7L106.349 225.966L107.826 227.314ZM96.8797 237.505L106.835 243.187L105.844 244.924L95.8884 239.242L96.8797 237.505ZM106.139 243.076C107.075 242.885 108.047 242.798 109.041 242.829L108.98 244.828C108.142 244.802 107.325 244.875 106.54 245.036L106.139 243.076ZM109.041 242.829C115.95 243.041 121.378 248.813 121.166 255.722L119.167 255.66C119.345 249.856 114.784 245.006 108.98 244.828L109.041 242.829ZM121.166 255.722C120.954 262.63 115.181 268.059 108.273 267.846L108.334 265.847C114.139 266.026 118.989 261.465 119.167 255.66L121.166 255.722ZM108.273 267.846C102.906 267.682 98.4343 264.161 96.8041 259.363L98.6978 258.719C100.068 262.754 103.828 265.709 108.334 265.847L108.273 267.846ZM97.2553 259.91L75.2215 247.334L76.2128 245.597L98.2466 258.173L97.2553 259.91ZM72.5876 242.501C72.5872 242.986 72.956 243.657 73.7181 244.319C74.4576 244.962 75.3282 245.384 75.8869 245.48L75.5473 247.451C74.5336 247.277 73.3386 246.639 72.4061 245.829C71.4961 245.038 70.5865 243.861 70.5876 242.499L72.5876 242.501ZM73.256 239.43C73.2844 239.418 73.23 239.427 73.1299 239.587C73.0317 239.745 72.931 239.983 72.8433 240.305C72.6681 240.947 72.5876 241.759 72.5876 242.5H70.5876C70.5876 241.645 70.6776 240.644 70.9138 239.778C71.0317 239.346 71.1969 238.907 71.4337 238.528C71.6685 238.152 72.0181 237.766 72.5284 237.567L73.256 239.43Z" fill="url(#paint1_linear_823_877)" mask="url(#path-38-inside-3_823_877)"/>
+<g filter="url(#filter21_i_823_877)">
+<path d="M193.586 184.276C190.095 183.946 186.643 183.745 183.218 184.674C181.169 185.23 179.148 186.081 177.191 186.9C176.359 187.249 175.697 187.89 174.981 188.427" stroke="#565656" stroke-width="3" stroke-linecap="round"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_823_877" x="0" y="0" width="321.586" height="363" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="25"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.337255 0 0 0 0 0.360784 0 0 0 0 0.917647 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_823_877"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_823_877" result="shape"/>
+</filter>
+<filter id="filter1_i_823_877" x="64.0742" y="49" width="191.125" height="103.594" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter2_i_823_877" x="201.727" y="143.369" width="69.3594" height="82.9189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter3_i_823_877" x="50" y="143.369" width="69.3594" height="82.9189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter4_ii_823_877" x="167.488" y="219.508" width="26.2664" height="88.6988" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.7" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter5_ii_823_877" x="119.809" y="219.508" width="26.2664" height="88.6988" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.7" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter6_i_823_877" x="60.957" y="149.093" width="13.2266" height="72.4705" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter7_i_823_877" x="244.469" y="149.093" width="13.2266" height="72.4705" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter8_ii_823_877" x="66.2188" y="67.3197" width="177.508" height="199.941" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-10" dy="-10"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="-3"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter9_ii_823_877" x="166.988" y="291.757" width="38.3477" height="21.7431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter10_ii_823_877" x="119.086" y="291.757" width="38.3477" height="21.7431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter11_i_823_877" x="122.695" y="170.378" width="29.8984" height="29.8996" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter12_i_823_877" x="128.586" y="176" width="19" height="18" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter13_ii_823_877" x="128.586" y="176" width="19.5" height="18.5" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter14_diii_823_877" x="104.391" y="100.459" width="109.852" height="53.5713" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_823_877"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_823_877" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.35"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.979167 0 0 0 0 0.983333 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_823_877" result="effect3_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect3_innerShadow_823_877" result="effect4_innerShadow_823_877"/>
+</filter>
+<filter id="filter15_ii_823_877" x="175.219" y="130.419" width="6.28125" height="6.27991" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter16_ii_823_877" x="170.883" y="134.754" width="3.39062" height="3.38995" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter17_ii_823_877" x="123.195" y="130.419" width="6.28125" height="6.27991" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter18_ii_823_877" x="118.863" y="134.754" width="3.39062" height="3.38995" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="-0.3"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_823_877" result="effect2_innerShadow_823_877"/>
+</filter>
+<filter id="filter19_i_823_877" x="96.1289" y="182.304" width="34.293" height="31.8279" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter20_i_823_877" x="185.609" y="183.678" width="35.1836" height="31.0281" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<filter id="filter21_i_823_877" x="172.48" y="181.5" width="22.6055" height="8.42694" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1" dy="-1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_823_877"/>
+</filter>
+<linearGradient id="paint0_linear_823_877" x1="97.0859" y1="220.5" x2="73.5859" y2="260.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8D91F3" stop-opacity="0"/>
+<stop offset="0.214926" stop-color="#8D91F3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_823_877" x1="95.8797" y1="215" x2="86.0859" y2="231" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BFC1F4" stop-opacity="0"/>
+<stop offset="1" stop-color="#BFC1F4"/>
+</linearGradient>
+</defs>
+</svg>

--- a/lib/ui/loader/upload_spinner_loader.dart
+++ b/lib/ui/loader/upload_spinner_loader.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'dart:async';
+
+import 'package:flutter_svg/flutter_svg.dart';
+
+class UploadSpinner extends StatefulWidget {
+  const UploadSpinner({
+    key,
+  }) : super(key: key);
+
+  @override
+  _UploadSpinnerState createState() => _UploadSpinnerState();
+}
+
+class _UploadSpinnerState extends State<UploadSpinner> {
+  bool _showLeftImage = true;
+  late Timer _imageChangeTimer;
+  late Timer _imageScaleTimer;
+  double _imageScale = 1.0; // 이미지 크기 조절용 변수
+
+  @override
+  void initState() {
+    super.initState();
+    // 0.4초마다 _toggleImage 함수를 호출하여 이미지를 변경
+    _imageChangeTimer =
+        Timer.periodic(const Duration(milliseconds: 800), _toggleImage);
+    // 0.2초마다 _toggleImageScale 함수를 호출하여 이미지 크기를 변경
+    _imageScaleTimer =
+        Timer.periodic(const Duration(milliseconds: 200), _toggleImageScale);
+  }
+
+  void _toggleImage(Timer timer) {
+    setState(() {
+      _showLeftImage = !_showLeftImage;
+    });
+  }
+
+  void _toggleImageScale(Timer timer) {
+    setState(() {
+      _imageScale = (_imageScale == 1.0) ? 0.97 : 1.0;
+    });
+  }
+
+  @override
+  void dispose() {
+    _imageChangeTimer.cancel();
+    _imageScaleTimer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: const Color.fromARGB(1, 32, 32, 32).withOpacity(0.87),
+      child: Stack(
+        children: [
+          const SpinKitRipple(
+            size: 500.0,
+            color: Color.fromARGB(255, 181, 181, 181),
+          ),
+          Center(
+            child: Transform.scale(
+              scale: _imageScale,
+              child: SizedBox(
+                width: 300,
+                child: SvgPicture.asset(
+                  _showLeftImage
+                      ? 'assets/images/dance_popo_left.svg'
+                      : 'assets/images/dance_popo_right.svg',
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/screen/home/home_search_screen.dart
+++ b/lib/ui/screen/home/home_search_screen.dart
@@ -107,19 +107,22 @@ class _HomeSearchScreenState extends State<HomeSearchScreen>
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.done) {
                 if (_searchProvider.randomVideosResponse != null) {
-                  return Column(children: <Widget>[
-                    SearchTextFieldWidget(setScreen: setScreen),
-                    _isSearched
-                        ? Flexible(
-                            child: SearchDetailView(
-                            value: _value,
-                          ))
-                        : Flexible(
-                            child: SearchView(
-                                screenNum: 3,
-                                videoList: _searchProvider
-                                    .randomVideosResponse!.videoList))
-                  ]);
+                  return Container(
+                    color: Colors.white,
+                    child: Column(children: <Widget>[
+                      SearchTextFieldWidget(setScreen: setScreen),
+                      _isSearched
+                          ? Flexible(
+                              child: SearchDetailView(
+                              value: _value,
+                            ))
+                          : Flexible(
+                              child: SearchView(
+                                  screenNum: 3,
+                                  videoList: _searchProvider
+                                      .randomVideosResponse!.videoList))
+                    ]),
+                  );
                 } else {
                   return Container(color: Colors.white);
                 }

--- a/lib/ui/screen/home/home_upload_screen.dart
+++ b/lib/ui/screen/home/home_upload_screen.dart
@@ -7,6 +7,7 @@ import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/entity/request/video_upload_request.dart';
 import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/video_upload_provider_impl.dart';
+import 'package:pocket_pose/ui/loader/upload_spinner_loader.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/upload/custom_tag_text_field_controller.dart';
 import 'package:pocket_pose/ui/widget/upload/upload_tag_text_field_widget.dart';
@@ -120,7 +121,7 @@ class _HomeUploadScreenState extends State<HomeUploadScreen> {
                 child: SizedBox(
                     width: 50,
                     height: 50,
-                    child: Center(child: CircularProgressIndicator())),
+                    child: Center(child: UploadSpinner())),
               ),
             ),
           ],

--- a/lib/ui/screen/profile/follow_tab_screen.dart
+++ b/lib/ui/screen/profile/follow_tab_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/entity/response/profile_response.dart';
 import 'package:pocket_pose/data/remote/provider/follow_provider.dart';
+import 'package:pocket_pose/ui/loader/user_list_loader.dart';
 import 'package:pocket_pose/ui/view/profile/follow_user_list_view.dart';
 import 'package:provider/provider.dart';
 
@@ -93,20 +94,9 @@ class _FollowTabScreenState extends State<FollowTabScreen>
                               ),
                       ],
                     )
-                  :
-                  // 프로필 목록 로딩 인디케이터
-                  Center(
-                      child: CircularProgressIndicator(
-                        color: AppColor.purpleColor,
-                      ),
-                    );
+                  : Container(color: Colors.white);
             } else {
-              // 프로필 목록 로딩 인디케이터
-              return Center(
-                child: CircularProgressIndicator(
-                  color: AppColor.purpleColor,
-                ),
-              );
+              return Container(color: Colors.white);
             }
           }),
     );

--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
@@ -162,30 +163,29 @@ class _ProfileScreenState extends State<ProfileScreen>
                   : Container(
                       color: Colors.white,
                       child: Center(
-                        child: CircularProgressIndicator(
-                          color: AppColor.purpleColor,
-                        ),
-                      ),
+                          child: SpinKitPumpingHeart(
+                        color: Colors.pink[100],
+                        size: 50.0,
+                      )),
                     );
             } else {
               return Container(
                 color: Colors.white,
                 child: Center(
-                  child: CircularProgressIndicator(
-                    color: AppColor.purpleColor,
-                  ),
-                ),
+                    child: SpinKitPumpingHeart(
+                  color: Colors.pink[100],
+                  size: 50.0,
+                )),
               );
             }
           } else {
-            // 로딩 인디케이터 수정
             return Container(
               color: Colors.white,
               child: Center(
-                child: CircularProgressIndicator(
-                  color: AppColor.purpleColor,
-                ),
-              ),
+                  child: SpinKitPumpingHeart(
+                color: Colors.pink[100],
+                size: 50.0,
+              )),
             );
           }
         });

--- a/lib/ui/screen/profile/profile_setting_screen.dart
+++ b/lib/ui/screen/profile/profile_setting_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
+import 'package:pocket_pose/ui/loader/upload_spinner_loader.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/custom_simple_dialog_widget.dart';
 import 'package:provider/provider.dart';


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/b919bf5a-6d94-4800-b087-418747c1381b

https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/980c305d-2a90-42c1-b317-d4d4ba30c921

## 💬 작업 설명

## ✅ 한 일
1. 프로필 로더 추가
2. 동영상 업로드 로더 추가
3. 검색 페이지의 검색창 뒷배경 하얀색으로 변경

## ☝️ 참고 하세요~
1. 아놔 로딩 겁나 귀여운데.. 어지간한 영상 아니면 로딩이 짧게 나오는게 아쉽네요.... 영상 길이에 따라 로딩 시간이 달라지는데 제가 비디오를 캐시로 처리한 뒤부터 영상 업로드가 엄청나게 빠릅니다 흑.. 대략 1초..
2. 비디오의 음표 로더는 그대로 두겠습니다

## 🤓 다음에 할 일
1. 모든 프로필 클릭시 사용자 프로필로 이동하도록 기능 추가
