### PR TITLE
[feat] 채팅 백그라운드/포그라운드 푸시 알림 + 리다이렉션 개발 (HH-411)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,20 @@
               android:name="com.google.firebase.messaging.default_notification_channel_id"
               android:value="high_importance_channel"
               />
+              <!--FCM 설정 -->
+              <service
+                android:name=".java.MyFirebaseMessagingService"
+                android:exported="false">
+                <intent-filter>
+                    <action android:name="com.google.firebase.MESSAGING_EVENT" />
+                </intent-filter>
+            </service>
+            <meta-data
+                android:name="firebase_messaging_auto_init_enabled"
+                android:value="false" />
+            <meta-data
+                android:name="firebase_analytics_collection_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
-              />
+              />         
             <meta-data
               android:name="com.google.firebase.messaging.default_notification_channel_id"
               android:value="high_importance_channel"
@@ -74,6 +74,17 @@
                     android:scheme="kakaof03a21b3fa588715cb55730113dea1ab" />
             </intent-filter>
         </activity>
+         <!-- scheduled notifications 화면에 출력할려면 추가 -->
+            <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+            <!--재부팅시,업데이트시,재시작시 -->
+            <receiver android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+                <intent-filter>
+                    <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                    <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                    <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                    <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+                    </intent-filter>
+            </receiver>   
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" /> 
 
-
    <application
         android:hardwareAccelerated="false"
         android:largeHeap="true"
@@ -39,14 +38,6 @@
               android:name="com.google.firebase.messaging.default_notification_channel_id"
               android:value="high_importance_channel"
               />
-              <!--FCM 설정 -->
-              <service
-                android:name=".java.MyFirebaseMessagingService"
-                android:exported="false">
-                <intent-filter>
-                    <action android:name="com.google.firebase.MESSAGING_EVENT" />
-                </intent-filter>
-            </service>
             <meta-data
                 android:name="firebase_messaging_auto_init_enabled"
                 android:value="false" />

--- a/lib/config/fcm/notification_service.dart
+++ b/lib/config/fcm/notification_service.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:pocket_pose/config/fcm/remote_notifications_ervice.dart';
+import 'package:pocket_pose/main.dart';
+
+NotificationService notificationService = NotificationService();
+
+class NotificationService {
+  static final NotificationService _notificationService =
+      NotificationService._internal();
+
+  factory NotificationService() {
+    return _notificationService;
+  }
+
+  NotificationService._internal();
+
+  static const channelId = 'popo_notification';
+  static const channelName = 'popo_notification';
+
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    RemoteNotificationService();
+    const AndroidInitializationSettings initializationSettingsAndroid =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    const DarwinInitializationSettings initializationSettingsIOS =
+        DarwinInitializationSettings(
+      requestSoundPermission: false,
+      requestBadgePermission: false,
+      requestAlertPermission: false,
+    );
+
+    const InitializationSettings initializationSettings =
+        InitializationSettings(
+      android: initializationSettingsAndroid,
+      iOS: initializationSettingsIOS,
+      macOS: null,
+    );
+
+    await flutterLocalNotificationsPlugin.initialize(
+      initializationSettings,
+      onDidReceiveBackgroundNotificationResponse:
+          onDidReceiveBackgroundNotificationResponse,
+      onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
+    );
+  }
+
+  final AndroidNotificationDetails _androidNotificationDetails =
+      const AndroidNotificationDetails(
+    channelId,
+    channelName,
+    channelDescription: 'popo description',
+    playSound: true,
+    priority: Priority.high,
+    importance: Importance.max,
+  );
+
+  Future<void> showNotifications(RemoteMessage message) async {
+    RemoteNotification? notification = message.notification;
+    await flutterLocalNotificationsPlugin.show(
+        notification.hashCode,
+        notification?.title,
+        notification?.body,
+        payload: jsonEncode(message.data),
+        NotificationDetails(android: _androidNotificationDetails));
+  }
+
+  Future<void> showForegroundNotifications(RemoteMessage message) async {
+    RemoteNotification? notification = message.notification;
+    await flutterLocalNotificationsPlugin.show(
+        notification.hashCode,
+        notification?.title,
+        notification?.body,
+        payload: jsonEncode(message.data),
+        NotificationDetails(android: _androidNotificationDetails));
+  }
+
+  Future<void> scheduleNotifications(RemoteMessage message) async {
+    RemoteNotification? notification = message.notification;
+    await flutterLocalNotificationsPlugin.show(
+        notification.hashCode,
+        notification?.title,
+        notification?.body,
+        payload: jsonEncode(message.data),
+        NotificationDetails(android: _androidNotificationDetails));
+  }
+
+  Future<void> cancelNotifications(int id) async {
+    await flutterLocalNotificationsPlugin.cancel(id);
+  }
+
+  Future<void> cancelAllNotifications() async {
+    await flutterLocalNotificationsPlugin.cancelAll();
+  }
+}
+
+void onDidReceiveBackgroundNotificationResponse(details) {
+  if (details.payload != null) {
+    try {
+      Map<String, dynamic> notificationPayload = jsonDecode(details.payload!);
+      setNotificationHandler(notificationPayload);
+    } catch (error) {
+      debugPrint('mmm Notification payload error $error');
+    }
+  }
+}
+
+void onDidReceiveNotificationResponse(details) async {
+  if (details.payload != null) {
+    try {
+      Map<String, dynamic> notificationPayload = jsonDecode(details.payload!);
+      setNotificationHandler(notificationPayload);
+    } catch (error) {
+      debugPrint('mmm Notification payload error $error');
+    }
+  }
+}

--- a/lib/config/fcm/remote_notifications_ervice.dart
+++ b/lib/config/fcm/remote_notifications_ervice.dart
@@ -1,0 +1,26 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:pocket_pose/config/fcm/notification_service.dart';
+
+class RemoteNotificationService {
+  RemoteNotificationService() {
+    FirebaseMessaging messaging = FirebaseMessaging.instance;
+    initNotificationSettings(messaging);
+  }
+
+  Future<void> initNotificationSettings(FirebaseMessaging messaging) async {
+    await FirebaseMessaging.instance.setAutoInitEnabled(true);
+    await messaging.requestPermission(
+      alert: true,
+      announcement: false,
+      badge: true,
+      carPlay: false,
+      criticalAlert: false,
+      provisional: false,
+      sound: true,
+    );
+
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
+      notificationService.showForegroundNotifications(message);
+    });
+  }
+}

--- a/lib/config/fcm/remote_notifications_ervice.dart
+++ b/lib/config/fcm/remote_notifications_ervice.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:pocket_pose/config/fcm/notification_service.dart';
+import 'package:pocket_pose/main.dart';
 
 class RemoteNotificationService {
   RemoteNotificationService() {
@@ -22,5 +23,16 @@ class RemoteNotificationService {
     FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
       notificationService.showForegroundNotifications(message);
     });
+
+    FirebaseMessaging.onMessageOpenedApp.listen((message) {
+      setNotificationHandler(message.data);
+    });
+
+    // FirebaseMessaging.onBackgroundMessage((message) {
+
+    //     setNotificationHandler(message.data);
+
+    //   return Future.value();
+    // });
   }
 }

--- a/lib/config/fcm/remote_notifications_ervice.dart
+++ b/lib/config/fcm/remote_notifications_ervice.dart
@@ -27,12 +27,5 @@ class RemoteNotificationService {
     FirebaseMessaging.onMessageOpenedApp.listen((message) {
       setNotificationHandler(message.data);
     });
-
-    // FirebaseMessaging.onBackgroundMessage((message) {
-
-    //     setNotificationHandler(message.data);
-
-    //   return Future.value();
-    // });
   }
 }

--- a/lib/config/share/kakao_link_with_dynamic_link.dart
+++ b/lib/config/share/kakao_link_with_dynamic_link.dart
@@ -34,7 +34,9 @@ class KakaoLinkWithDynamicLink {
             'https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/5f67a84c-f834-4214-86ed-873cc599f31b'),
       ),
       social: Social(
-          likeCount: videoData.likeCount, viewCount: videoData.viewCount),
+          likeCount: videoData.likeCount,
+          viewCount: videoData.viewCount,
+          commentCount: videoData.commentCount),
     );
   }
 }

--- a/lib/data/remote/repository/chat_repository_impl.dart
+++ b/lib/data/remote/repository/chat_repository_impl.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/base_response.dart';
 import 'package:pocket_pose/data/entity/request/chat_room_request.dart';
@@ -11,17 +10,18 @@ import 'package:pocket_pose/data/entity/response/chat_detail_list_response.dart'
 import 'package:pocket_pose/data/entity/response/chat_room_list_response.dart';
 import 'package:pocket_pose/data/entity/response/chat_room_response.dart';
 import 'package:pocket_pose/data/entity/response/chat_search_user_list_response.dart';
+import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/repository/chat_repository.dart';
 
 class ChatRepositoryImpl implements ChatRepository {
+  KaKaoLoginProvider loginProvider = KaKaoLoginProvider();
+
   @override
   Future<BaseResponse<ChatRoomResponse>> putChatRoom(
       ChatRoomRequest request) async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {
@@ -44,11 +44,9 @@ class ChatRepositoryImpl implements ChatRepository {
 
   @override
   Future<BaseResponse<ChatRoomListResponse>> getChatRoomList() async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {
@@ -71,11 +69,9 @@ class ChatRepositoryImpl implements ChatRepository {
   @override
   Future<BaseResponse<ChatDetailListResponse>> getChatDetailList(
       String chatRoomId, int page) async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {
@@ -100,11 +96,9 @@ class ChatRepositoryImpl implements ChatRepository {
   @override
   Future<BaseResponse<ChatSearchUserListResponse>>
       getChatSearchUserList() async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {

--- a/lib/data/remote/repository/stage_repository_impl.dart
+++ b/lib/data/remote/repository/stage_repository_impl.dart
@@ -2,22 +2,22 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/base_response.dart';
 import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
 import 'package:pocket_pose/data/entity/response/stage_enter_response.dart';
 import 'package:pocket_pose/data/entity/response/stage_user_list_response.dart';
+import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/repository/stage_repository.dart';
 
 class StageRepositoryImpl implements StageRepository {
+  KaKaoLoginProvider loginProvider = KaKaoLoginProvider();
+
   @override
   Future<BaseResponse<StageUserListResponse>> getUserList() async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {
@@ -39,11 +39,9 @@ class StageRepositoryImpl implements StageRepository {
   @override
   Future<BaseResponse<StageEnterResponse>> getStageEnter(
       StageEnterRequest request) async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {
@@ -66,11 +64,9 @@ class StageRepositoryImpl implements StageRepository {
 
   @override
   Future<void> getStageCatch() async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {

--- a/lib/data/remote/repository/stage_talk_repository_impl.dart
+++ b/lib/data/remote/repository/stage_talk_repository_impl.dart
@@ -2,22 +2,22 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/base_response.dart';
 import 'package:pocket_pose/data/entity/request/stage_talk_message_request.dart';
 import 'package:pocket_pose/data/entity/response/stage_talk_message_response.dart';
+import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/repository/stage_talk_repository.dart';
 
 class StageTalkRepositoryImpl implements StageTalkRepository {
+  KaKaoLoginProvider loginProvider = KaKaoLoginProvider();
+
   @override
   Future<BaseResponse<StageTalkMessageResponse>> getTalkMessages(
       StageTalkMessageRequest request) async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {

--- a/lib/data/remote/repository/video_upload_repository_impl.dart
+++ b/lib/data/remote/repository/video_upload_repository_impl.dart
@@ -2,22 +2,22 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pocket_pose/config/api_url.dart';
 import 'package:pocket_pose/data/entity/base_response.dart';
 import 'package:pocket_pose/data/entity/request/video_upload_request.dart';
 import 'package:pocket_pose/data/entity/response/video_upload_response.dart';
+import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/repository/video_upload_repository.dart';
 
 class VideoUploadRepositoryImpl implements VideoUploadRepository {
+  KaKaoLoginProvider loginProvider = KaKaoLoginProvider();
+
   @override
   Future<BaseResponse<VideoUploadResponse>> postVideoUpload(
       VideoUploadRequest request) async {
-    const storage = FlutterSecureStorage();
-    const storageKey = 'kakaoAccessToken';
-    const refreshTokenKey = 'kakaoRefreshToken';
-    String accessToken = await storage.read(key: storageKey) ?? "";
-    String refreshToken = await storage.read(key: refreshTokenKey) ?? "";
+    await loginProvider.checkAccessToken();
+    final accessToken = loginProvider.accessToken;
+    final refreshToken = loginProvider.refreshToken;
 
     var dio = Dio();
     try {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,9 +44,7 @@ Future<void> main() async {
   );
   await notificationService.init();
   DynamicLink().setup();
-  FirebaseMessaging.onMessageOpenedApp.listen((message) {
-    setNotificationHandler(message.data);
-  });
+  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (_) => MultiVideoPlayProvider()),
@@ -102,4 +100,10 @@ void setNotificationHandler(Map<String, dynamic>? map) async {
       debugPrint('mmm Notification payload error $error');
     }
   }
+}
+
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  print("mmm ${message.data}");
+  await Firebase.initializeApp()
+      .then((_) => setNotificationHandler(message.data));
 }

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -28,7 +28,7 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
   late SocketChatProviderImpl _socketChatProvider;
   late ChatProviderImpl _chatProvider;
   late KaKaoLoginProvider _loginProvider;
-  late String _userId;
+  String _userId = "";
   bool _isEnter = false;
   int _page = 1;
   String? _curDate;

--- a/lib/ui/screen/chat/chat_detail_screen.dart
+++ b/lib/ui/screen/chat/chat_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/entity/socket_request/send_chat_request.dart';
+import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/chat_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/data/remote/provider/socket_chat_provider_impl.dart';
@@ -23,6 +24,7 @@ class ChatDetailScreen extends StatefulWidget {
 }
 
 class _ChatDetailScreenState extends State<ChatDetailScreen> {
+  late MultiVideoPlayProvider _multiVideoPlayProvider;
   late SocketChatProviderImpl _socketChatProvider;
   late ChatProviderImpl _chatProvider;
   late KaKaoLoginProvider _loginProvider;
@@ -44,6 +46,10 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
     super.initState();
 
     _initUserId();
+
+    _multiVideoPlayProvider = Provider.of(context, listen: false);
+    _multiVideoPlayProvider.pauseVideo(0);
+
     _scrollController.addListener(_scrollListener);
 
     // 선택한 채팅방 채팅메세지 조회
@@ -61,6 +67,7 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
   void dispose() {
     super.dispose();
 
+    _multiVideoPlayProvider.playVideo(0);
     _scrollController.dispose();
   }
 

--- a/lib/ui/screen/chat/chat_room_list_screen.dart
+++ b/lib/ui/screen/chat/chat_room_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
+import 'package:pocket_pose/data/entity/base_response.dart';
 import 'package:pocket_pose/data/entity/response/chat_room_list_response.dart';
 import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/chat_provider_impl.dart';
@@ -20,7 +21,7 @@ class ChatRoomListScreen extends StatefulWidget {
 class _ChatListRoomScreenState extends State<ChatRoomListScreen> {
   late MultiVideoPlayProvider _multiVideoPlayProvider;
   late ChatProviderImpl _chatProvider;
-  Future<ChatRoomListResponse>? chatList;
+  Future<BaseResponse<ChatRoomListResponse>>? chatList;
 
   @override
   void initState() {
@@ -39,6 +40,7 @@ class _ChatListRoomScreenState extends State<ChatRoomListScreen> {
   @override
   Widget build(BuildContext context) {
     _chatProvider = Provider.of<ChatProviderImpl>(context, listen: false);
+    chatList = _chatProvider.getChatRoomList();
 
     return Scaffold(
       appBar: _buildAppBar(context),
@@ -54,7 +56,7 @@ class _ChatListRoomScreenState extends State<ChatRoomListScreen> {
           ChatSearchUserTextFieldWidget(
               showChatDetailScreen: showChatDetailScreen),
           FutureBuilder(
-            future: _chatProvider.getChatRoomList(),
+            future: chatList,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 return Expanded(
@@ -90,7 +92,10 @@ class _ChatListRoomScreenState extends State<ChatRoomListScreen> {
       itemCount: chatRooms.length,
       itemBuilder: (context, index) {
         final chatRoom = chatRooms[index];
-        return ChatRoomListItemWidget(chatRoom: chatRoom);
+        return ChatRoomListItemWidget(
+          chatRoom: chatRoom,
+          showChatDetailScreen: showChatDetailScreen,
+        );
       },
       separatorBuilder: (context, index) => const SizedBox(
         width: 40,
@@ -127,7 +132,9 @@ class _ChatListRoomScreenState extends State<ChatRoomListScreen> {
     ));
     Navigator.push(context, pageRouteWithAnimation.slideRitghtToLeft())
         .then((value) {
-      setState(() {});
+      setState(() {
+        chatList = _chatProvider.getChatRoomList();
+      });
     });
   }
 }

--- a/lib/ui/widget/chat/chat_room_list_item_widget.dart
+++ b/lib/ui/widget/chat/chat_room_list_item_widget.dart
@@ -1,25 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/domain/entity/chat_room_list_item.dart';
-import 'package:pocket_pose/ui/screen/chat/chat_detail_screen.dart';
-import 'package:pocket_pose/ui/widget/page_route_with_animation.dart';
 
 class ChatRoomListItemWidget extends StatelessWidget {
   final ChatRoomListItem chatRoom;
+  final Function showChatDetailScreen;
 
-  const ChatRoomListItemWidget({super.key, required this.chatRoom});
+  const ChatRoomListItemWidget(
+      {super.key, required this.chatRoom, required this.showChatDetailScreen});
 
   @override
   Widget build(BuildContext context) {
     return SafeArea(
       child: InkWell(
         onTap: () {
-          PageRouteWithSlideAnimation pageRouteWithAnimation =
-              PageRouteWithSlideAnimation(ChatDetailScreen(
-            chatRoomId: chatRoom.chatRoomId,
-            opponentUserNickName: chatRoom.opponentUser.nickname,
-          ));
-          Navigator.push(context, pageRouteWithAnimation.slideRitghtToLeft());
+          // 채팅 상세 화면으로 이동
+          showChatDetailScreen(
+            chatRoom.chatRoomId,
+            chatRoom.opponentUser.nickname,
+          );
         },
         child: Padding(
           padding: const EdgeInsets.fromLTRB(24, 14, 24, 14),

--- a/lib/ui/widget/chat/chat_search_user_list_item_widget.dart
+++ b/lib/ui/widget/chat/chat_search_user_list_item_widget.dart
@@ -16,15 +16,6 @@ class ChatSearchUserListItemWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     var chatProvider = Provider.of<ChatProviderImpl>(context, listen: false);
 
-    // showChatDetailScreen(String chatRoomId) {
-    //   PageRouteWithSlideAnimation pageRouteWithAnimation =
-    //       PageRouteWithSlideAnimation(ChatDetailScreen(
-    //     chatRoomId: chatRoomId,
-    //     opponentUserNickName: chatUser.nickname,
-    //   ));
-    //   Navigator.push(context, pageRouteWithAnimation.slideRitghtToLeft());
-    // }
-
     return SafeArea(
       child: InkWell(
         onTap: () async {


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/61674991/83fc767c-5bce-4363-bc74-c7372df98839

## 💬 작업 설명
- 채팅 받을 때 푸시알림이 보이고, 푸시알림 클릭 시 채팅 상세 화면으로 이동하는 로직을 개발했습니다.

## ✅ 한 일
1. 알림 권한 설정
2. 푸시알림 백그라운드에서 받기
3. 푸시알림 포그라운드에서 받기
4. 포그라운드 푸시알림 리다이렉션
5. 백그라운드 푸시알림 리다이렉션
6. 푸시알림 클릭하여 채팅 상세화면 이동 시 홈 화면 노래 정지 기능 추가
7. 액세스 토큰 발급 방법 변경

## 😥 어려웠던점
1. 푸시 알림이 백그라운드/포그라운드/앱 종료 후마다 푸시 알림 받는 동작 로직이 다르고... 또 알림 클릭 시 동작하는 코드도 3 경우 모두 달라서 처리하기 힘들었습니다...

## ☝️ 참고 하세요~
1. 백그라운드/포그라운드에서 푸시 알림 받기 + 리다이렉션은 잘 되는데 앱 종료 후에는 푸시알림 받기만 되고 클릭했을 때 리다이렉션이 아직 안 됩니다... 그냥 홈 화면이 보입니다. 브랜치가 무거워질 거 같아서 이쯤 개발하고 푸시 먼저 합니다.
2. 푸시알림 클릭 시 동작할 코드는 main.dart 아래의 setNotificationHandler에 있는 switch문에 작성해주시면 됩니다.
    > void setNotificationHandler(Map<String, dynamic>? map) async {
  if (map != null) {
    try {
      switch (map['type']) {
        case "SEND_CHAT_MESSAGE":
          Get.to(
              transition: Transition.rightToLeft,
              () => ChatDetailScreen(
                    chatRoomId: map['chatRoomId'],
                    opponentUserNickName: map['opponentUserNickname'],
                  ));
          break;
      }
    } catch (error) {
      debugPrint('mmm Notification payload error $error');
    }
  }
}

## 🤓 다음에 할 일
1. 앱 종료 후 푸시알림 리다이렉션
2. 스테이지 중간 점수 연결
3. 스테이지 소켓 최적화
4. 소켓 에러 연결
5. 포포 스테이지 사운드 변경/추가
    1. 입장: 사운드 추가
    2. 대기: 사운드 추가
    3. 캐치: 미리듣기 노래 작게 재생
    4. 플레이: 노래 재생
    5. 결과: 1초 박수소리 + 이후 노래 재생
6. 리팩토링
7. 온보딩 에러 수정