### PR TITLE
[feat] 댓글 푸시 알림 기능 개발 (HH-427)

### DIFF
--- a/lib/ui/screen/main_screen.dart
+++ b/lib/ui/screen/main_screen.dart
@@ -37,7 +37,10 @@ class _MainScreenState extends State<MainScreen>
     return _bottomNavIndex;
   }
 
-  List<Widget> _screens = [const HomeScreen(), const ProfileScreen()];
+  List<Widget> _screens = [
+    const HomeScreen(),
+    const ProfileScreen(isNavigation: true)
+  ];
 
   @override
   void initState() {
@@ -84,7 +87,9 @@ class _MainScreenState extends State<MainScreen>
       setState(() {
         _screens = [
           const HomeScreen(),
-          isLogin ? const ProfileScreen() : const NotLoginWidget(),
+          isLogin
+              ? const ProfileScreen(isNavigation: true)
+              : const NotLoginWidget(),
         ];
       });
     }
@@ -102,7 +107,9 @@ class _MainScreenState extends State<MainScreen>
         isLogin = false;
         _screens = [
           const HomeScreen(),
-          isLogin ? const ProfileScreen() : const NotLoginWidget(),
+          isLogin
+              ? const ProfileScreen(isNavigation: true)
+              : const NotLoginWidget(),
         ];
       } else {
         isLogin = true;
@@ -110,7 +117,9 @@ class _MainScreenState extends State<MainScreen>
 
       _screens = [
         const HomeScreen(),
-        isLogin ? const ProfileScreen() : const NotLoginWidget(),
+        isLogin
+            ? const ProfileScreen(isNavigation: true)
+            : const NotLoginWidget(),
       ];
     } else {
       // 홈 페이지 클릭

--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -12,10 +12,12 @@ import 'package:provider/provider.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
+    this.isNavigation,
     this.userId,
     Key? key,
   }) : super(key: key);
 
+  final bool? isNavigation;
   final String? userId;
   @override
   State<ProfileScreen> createState() => _ProfileScreenState();
@@ -27,8 +29,6 @@ class _ProfileScreenState extends State<ProfileScreen>
   late ProfileProvider _profileProvider;
   late MultiVideoPlayProvider _multiVideoPlayProvider;
   late String? _userId;
-
-  bool isNotBottomNavi = false;
 
   int loading = 0;
 
@@ -56,9 +56,9 @@ class _ProfileScreenState extends State<ProfileScreen>
           setState(() {
             if (_userId != null) {
               // navigation이 아닌 곳에서 자신의 프로필을 조회한 경우
-              if (_userId == user.userId) {
-                isNotBottomNavi = true;
-              }
+              // if (_userId == user.userId) {
+              //   isNotBottomNavi = true;
+              // }
             }
             _userId ??= user.userId;
           });
@@ -94,9 +94,9 @@ class _ProfileScreenState extends State<ProfileScreen>
     return GestureDetector(
       onHorizontalDragUpdate: (details) {
         if (_profileProvider.profileResponse != null &&
-            (_profileProvider.profileResponse!.profile.isMe &&
-                    isNotBottomNavi ||
-                !_profileProvider.profileResponse!.profile.isMe) &&
+            (!_profileProvider.profileResponse!.profile.isMe ||
+                _profileProvider.profileResponse!.profile.isMe &&
+                    (widget.isNavigation == null || !widget.isNavigation!)) &&
             details.primaryDelta! > 10) {
           // 왼쪽에서 오른쪽으로 드래그했을 때 pop
           Navigator.of(context).pop();
@@ -117,7 +117,7 @@ class _ProfileScreenState extends State<ProfileScreen>
                                 ProfileTapbarWidget(
                                   profileResponse:
                                       _profileProvider.profileResponse!,
-                                  isNotBottomNavi: isNotBottomNavi,
+                                  isBottomNavi: widget.isNavigation ?? false,
                                 ),
                                 ProfileUserInfoWidget(
                                     profileResponse:

--- a/lib/ui/screen/share_screen.dart
+++ b/lib/ui/screen/share_screen.dart
@@ -75,9 +75,9 @@ class _ShareScreenState extends State<ShareScreen> {
       child: Scaffold(
         appBar: AppBar(
           leading: IconButton(
-            icon: Icon(
+            icon: const Icon(
               Icons.arrow_back_ios_new_rounded,
-              color: AppColor.purpleColor,
+              color: Colors.white,
             ),
             onPressed: () async {
               if (widget.commentId != null) {

--- a/lib/ui/screen/share_screen.dart
+++ b/lib/ui/screen/share_screen.dart
@@ -54,8 +54,22 @@ class _ShareScreenState extends State<ShareScreen> {
     return GestureDetector(
       onHorizontalDragUpdate: (details) {
         if (details.primaryDelta! > 10) {
-          // 왼쪽에서 오른쪽으로 드래그했을 때 pop
-          Navigator.of(context).pop();
+          if (widget.commentId != null) {
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => const MainScreen(index: 1)),
+              (route) => false,
+            );
+          } else {
+            _multiVideoPlayProvider.resetVideoPlayer(0);
+
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(builder: (context) => const MainScreen()),
+              (route) => false,
+            );
+          }
         }
       },
       child: Scaffold(

--- a/lib/ui/widget/profile/profile_tapbar_widget.dart
+++ b/lib/ui/widget/profile/profile_tapbar_widget.dart
@@ -10,11 +10,11 @@ class ProfileTapbarWidget extends StatelessWidget {
   const ProfileTapbarWidget({
     super.key,
     required this.profileResponse,
-    required this.isNotBottomNavi,
+    required this.isBottomNavi,
   });
 
   final ProfileResponse profileResponse;
-  final bool isNotBottomNavi;
+  final bool isBottomNavi;
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +25,7 @@ class ProfileTapbarWidget extends StatelessWidget {
           children: [
             Visibility(
               visible: !profileResponse.profile.isMe ||
-                  (profileResponse.profile.isMe && isNotBottomNavi),
+                  (profileResponse.profile.isMe && !isBottomNavi),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/43cdec5f-d527-43b5-beaf-b91453dcd5c9

## 💬 작업 설명
댓글 푸시 알림 기능을 개발하고 공유 페이지의 뒤로가기 기능을 수정했습니다.

## ✅ 한 일
1. 댓글 푸시알림 리다이렉션 기능 개발
2. 댓글 푸시 알림 리다이렉션 페이지에서 빠져 나오면 프로필 페이지 보이는 기능 개발
3. 프로필 탭바 리팩토링
4. 공유 페이지에 드래그해서 화면 pop 기능 개발
5. 공유 페이지 뒤로가기 아이콘 흰색으로 변경
6. 공유 화면 뒤로가기와 탭바가 상황에 맞게 동작하지 않는 오류 해결
7. 댓글에서 프로필 갔다가 나왔을 때 홈 영상 다시 재생되는 기능 개발

## 🔧 보완할 점
1. 댓글에서 프로필 눌러서 생성하면 프로필 여러개가 생성되는 오류가 있어 일단 없앴습니다. (팔로우 페이지와 마찬가지) 이참에 프로필 페이지를 무한으로 생성할 수 있도록 기능을 다시 수정해볼까 합니다. 커밍순

## ☝️ 참고 하세요~

> ### 다음의 커밋을 실수로 develop에 바로 push 해버렸습니다 😅
> ✨ [feat] 댓글 푸시알림 리다이렉션 기능 개발 (HH-427)
> ✨ [feat] 댓글 푸시 알림 리다이렉션 페이지에서 빠져 나오면 프로필 페이지 보이는 기능 개발 (HH-427)
> ♻️ [refactor] 프로필 탭바 리팩토링 (HH-427)
> ✏️ [fix] bottom navigation이 아닌 곳에서 열린 프로필만 드래그 해서 pop 기능 추가 (HH-427)
> ✨ [feat] 공유 페이지에 드래그해서 화면 pop 기능 개발 (HH-427)
> ✏️ [fix] 댓글에서 프로필 클릭시 해당 사용자의 프로필로 이동하지 않는 오류 해결 (HH-427)
> ✨ [feat] 댓글에서 프로필 갔다가 나왔을 때 홈 영상 다시 재생되는 기능 개발 (HH-427)
> 🐛 [bug] 댓글에서 프로필 눌러서 생성하면 프로필 여러개가 생성되는 오류가 있어 일단 기능 없앰 (HH-427)


## 🤓 다음에 할 일
1. 검색에서 프로필 눌렀을 때 영상 재생되는 오류 해결
2. 팔로우 페이지, 댓글에서 프로필 생성 로직 개발
