### PR TITLE
[feat] 스테이지 중간 점수 연결 및 배경 전환 오류 수정 (HH-419)

### DIFF
--- a/lib/data/entity/socket_response/stage_mid_score_response.dart
+++ b/lib/data/entity/socket_response/stage_mid_score_response.dart
@@ -1,0 +1,24 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:pocket_pose/data/entity/base_object.dart';
+import 'package:pocket_pose/domain/entity/stage_player_info_list_item.dart';
+
+part 'stage_mid_score_response.g.dart';
+
+@JsonSerializable()
+class StageMidScoreResponse extends BaseObject<StageMidScoreResponse> {
+  int mvpPlayerNum;
+  List<StagePlayerInfoListItem> playerInfos;
+
+  StageMidScoreResponse(
+      {required this.mvpPlayerNum, required this.playerInfos});
+
+  factory StageMidScoreResponse.fromJson(Map<String, dynamic> json) =>
+      _$StageMidScoreResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StageMidScoreResponseToJson(this);
+
+  @override
+  fromJson(json) {
+    return StageMidScoreResponse.fromJson(json);
+  }
+}

--- a/lib/data/entity/socket_response/stage_mid_score_response.g.dart
+++ b/lib/data/entity/socket_response/stage_mid_score_response.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stage_mid_score_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StageMidScoreResponse _$StageMidScoreResponseFromJson(
+        Map<String, dynamic> json) =>
+    StageMidScoreResponse(
+      mvpPlayerNum: json['mvpPlayerNum'] as int,
+      playerInfos: (json['playerInfos'] as List<dynamic>)
+          .map((e) =>
+              StagePlayerInfoListItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$StageMidScoreResponseToJson(
+        StageMidScoreResponse instance) =>
+    <String, dynamic>{
+      'mvpPlayerNum': instance.mvpPlayerNum,
+      'playerInfos': instance.playerInfos,
+    };

--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -10,6 +10,7 @@ import 'package:pocket_pose/data/entity/socket_request/send_skeleton_request.dar
 import 'package:pocket_pose/data/entity/socket_response/catch_end_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/catch_start_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/send_skeleton_response.dart';
+import 'package:pocket_pose/data/entity/socket_response/stage_mid_score_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/stage_mvp_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/talk_message_response.dart';
 import 'package:pocket_pose/data/entity/socket_response/user_count_response.dart';
@@ -87,6 +88,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   Map<PoseLandmarkType, PoseLandmark>? player0;
   Map<PoseLandmarkType, PoseLandmark>? player1;
   Map<PoseLandmarkType, PoseLandmark>? player2;
+  List<StagePlayerInfoListItem>? midScores;
   Map<PoseLandmarkType, PoseLandmark>? mvpSkeleton;
 
   SocketType _socketType = SocketType.WAIT;
@@ -325,6 +327,12 @@ class SocketStageProviderImpl extends ChangeNotifier
         }
         break;
       case SocketType.MID_SCORE:
+        var socketResponse = BaseSocketResponse<StageMidScoreResponse>.fromJson(
+            jsonDecode(frame.body.toString()),
+            StageMidScoreResponse.fromJson(
+                jsonDecode(frame.body.toString())['data']));
+        midScores = socketResponse.data?.playerInfos ?? [];
+        notifyListeners();
         break;
       case SocketType.PLAY_END:
         player0 = null;

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -155,15 +155,18 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   BoxDecoration _buildBackgroundImage(SocketType type) {
     String bgImage;
     switch (type) {
+      case SocketType.MVP_END:
       case SocketType.WAIT:
         bgImage = 'assets/images/bg_stage_wait.jpeg';
         break;
       case SocketType.CATCH:
       case SocketType.CATCH_START:
+      case SocketType.CATCH_END:
       case SocketType.PLAY:
       case SocketType.PLAY_START:
         bgImage = 'assets/images/bg_stage_comm.png';
         break;
+      case SocketType.PLAY_END:
       case SocketType.MVP:
       case SocketType.MVP_START:
         bgImage = 'assets/images/bg_stage_result.png';

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -169,7 +169,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         bgImage = 'assets/images/bg_stage_result.png';
         break;
       default:
-        bgImage = 'assets/images/bg_stage_wait.png';
+        bgImage = 'assets/images/bg_stage_wait.jpeg';
         break;
     }
 
@@ -186,9 +186,14 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
     return AppBar(
       centerTitle: true,
-      title: const Text(
-        "PoPo 스테이지",
-        style: TextStyle(fontSize: 18),
+      title: GestureDetector(
+        onTap: () {
+          _stageProvider.getStageEnter(StageEnterRequest(page: 0, size: 10));
+        },
+        child: const Text(
+          "PoPo 스테이지",
+          style: TextStyle(fontSize: 18),
+        ),
       ),
       backgroundColor: Colors.transparent,
       elevation: 0.0,

--- a/lib/ui/view/stage/popo_play_view.dart
+++ b/lib/ui/view/stage/popo_play_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
+import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
 import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/ui/view/stage/ml_kit_camera_play_view.dart';
@@ -87,8 +88,12 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              getProfile(widget.players[0].profileImg,
-                  widget.players[0].nickname, StagePlayScore.perfect),
+              getProfile(
+                  widget.players[0].profileImg,
+                  widget.players[0].nickname,
+                  getStagePlayScore(
+                      context.select<SocketStageProviderImpl, double?>(
+                          (provider) => provider.midScores?[0].similarity))),
             ],
           ),
         );
@@ -101,10 +106,18 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              getProfile(widget.players[1].profileImg,
-                  widget.players[1].nickname, StagePlayScore.good),
-              getProfile(widget.players[0].profileImg,
-                  widget.players[0].nickname, StagePlayScore.perfect),
+              getProfile(
+                  widget.players[1].profileImg,
+                  widget.players[1].nickname,
+                  getStagePlayScore(
+                      context.select<SocketStageProviderImpl, double?>(
+                          (provider) => provider.midScores?[1].similarity))),
+              getProfile(
+                  widget.players[0].profileImg,
+                  widget.players[0].nickname,
+                  getStagePlayScore(
+                      context.select<SocketStageProviderImpl, double?>(
+                          (provider) => provider.midScores?[0].similarity))),
             ],
           ),
         );
@@ -116,12 +129,24 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              getProfile(widget.players[1].profileImg,
-                  widget.players[1].nickname, StagePlayScore.good),
-              getProfile(widget.players[0].profileImg,
-                  widget.players[0].nickname, StagePlayScore.perfect),
-              getProfile(widget.players[2].profileImg,
-                  widget.players[2].nickname, StagePlayScore.excellent),
+              getProfile(
+                  widget.players[1].profileImg,
+                  widget.players[1].nickname,
+                  getStagePlayScore(
+                      context.select<SocketStageProviderImpl, double?>(
+                          (provider) => provider.midScores?[1].similarity))),
+              getProfile(
+                  widget.players[0].profileImg,
+                  widget.players[0].nickname,
+                  getStagePlayScore(
+                      context.select<SocketStageProviderImpl, double?>(
+                          (provider) => provider.midScores?[0].similarity))),
+              getProfile(
+                  widget.players[2].profileImg,
+                  widget.players[2].nickname,
+                  getStagePlayScore(
+                      context.select<SocketStageProviderImpl, double?>(
+                          (provider) => provider.midScores?[2].similarity))),
             ],
           ),
         );
@@ -161,6 +186,23 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
         getScoreNeonText(score),
       ],
     );
+  }
+
+  StagePlayScore getStagePlayScore(double? similarity) {
+    if (similarity == null) return StagePlayScore.none;
+    if (similarity < -1) {
+      return StagePlayScore.bad;
+    } else if (similarity < 0.2) {
+      return StagePlayScore.good;
+    } else if (similarity < 0.4) {
+      return StagePlayScore.great;
+    } else if (similarity < 0.6) {
+      return StagePlayScore.perfect;
+    } else if (similarity < 0.8) {
+      return StagePlayScore.excellent;
+    } else {
+      return StagePlayScore.none;
+    }
   }
 
   Widget getScoreNeonText(StagePlayScore score) {

--- a/lib/ui/view/stage/popo_play_view.dart
+++ b/lib/ui/view/stage/popo_play_view.dart
@@ -8,8 +8,6 @@ import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/ui/view/stage/ml_kit_camera_play_view.dart';
 import 'package:provider/provider.dart';
 
-enum StagePlayScore { bad, good, great, excellent, perfect, none }
-
 // ml_kit_skeleton_custom_view
 class PoPoPlayView extends StatefulWidget {
   final List<StagePlayerListItem> players;
@@ -91,9 +89,8 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
               getProfile(
                   widget.players[0].profileImg,
                   widget.players[0].nickname,
-                  getStagePlayScore(
-                      context.select<SocketStageProviderImpl, double?>(
-                          (provider) => provider.midScores?[0].similarity))),
+                  context.select<SocketStageProviderImpl, double?>(
+                      (provider) => provider.midScores?[0].similarity)),
             ],
           ),
         );
@@ -109,15 +106,13 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
               getProfile(
                   widget.players[1].profileImg,
                   widget.players[1].nickname,
-                  getStagePlayScore(
-                      context.select<SocketStageProviderImpl, double?>(
-                          (provider) => provider.midScores?[1].similarity))),
+                  context.select<SocketStageProviderImpl, double?>(
+                      (provider) => provider.midScores?[1].similarity)),
               getProfile(
                   widget.players[0].profileImg,
                   widget.players[0].nickname,
-                  getStagePlayScore(
-                      context.select<SocketStageProviderImpl, double?>(
-                          (provider) => provider.midScores?[0].similarity))),
+                  context.select<SocketStageProviderImpl, double?>(
+                      (provider) => provider.midScores?[0].similarity)),
             ],
           ),
         );
@@ -132,21 +127,18 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
               getProfile(
                   widget.players[1].profileImg,
                   widget.players[1].nickname,
-                  getStagePlayScore(
-                      context.select<SocketStageProviderImpl, double?>(
-                          (provider) => provider.midScores?[1].similarity))),
+                  context.select<SocketStageProviderImpl, double?>(
+                      (provider) => provider.midScores?[1].similarity)),
               getProfile(
                   widget.players[0].profileImg,
                   widget.players[0].nickname,
-                  getStagePlayScore(
-                      context.select<SocketStageProviderImpl, double?>(
-                          (provider) => provider.midScores?[0].similarity))),
+                  context.select<SocketStageProviderImpl, double?>(
+                      (provider) => provider.midScores?[0].similarity)),
               getProfile(
                   widget.players[2].profileImg,
                   widget.players[2].nickname,
-                  getStagePlayScore(
-                      context.select<SocketStageProviderImpl, double?>(
-                          (provider) => provider.midScores?[2].similarity))),
+                  context.select<SocketStageProviderImpl, double?>(
+                      (provider) => provider.midScores?[2].similarity)),
             ],
           ),
         );
@@ -155,7 +147,7 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     }
   }
 
-  Column getProfile(String? profileImg, String nickName, StagePlayScore score) {
+  Column getProfile(String? profileImg, String nickName, double? score) {
     return Column(
       children: [
         ClipRRect(
@@ -188,52 +180,28 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     );
   }
 
-  StagePlayScore getStagePlayScore(double? similarity) {
-    if (similarity == null) return StagePlayScore.none;
-    if (similarity < -1) {
-      return StagePlayScore.bad;
-    } else if (similarity < 0.4) {
-      return StagePlayScore.good;
-    } else if (similarity < 0.6) {
-      return StagePlayScore.great;
-    } else if (similarity < 0.8) {
-      return StagePlayScore.perfect;
-    } else if (similarity <= 1.0) {
-      return StagePlayScore.excellent;
-    } else {
-      return StagePlayScore.none;
-    }
-  }
-
-  Widget getScoreNeonText(StagePlayScore score) {
+  Widget getScoreNeonText(double? similarity) {
     String scoreText = "";
     Color scoreNeonColor = Colors.transparent;
-    switch (score) {
-      case StagePlayScore.bad:
-        scoreText = "Bad";
-        scoreNeonColor = Colors.red;
-        break;
-      case StagePlayScore.good:
-        scoreText = "Good";
-        scoreNeonColor = AppColor.purpleColor2;
-        break;
-      case StagePlayScore.great:
-        scoreText = "Great";
-        scoreNeonColor = AppColor.greenColor;
-        break;
-      case StagePlayScore.excellent:
-        scoreText = "Excellent";
-        scoreNeonColor = AppColor.blueColor2;
-        break;
-      case StagePlayScore.perfect:
-        scoreText = "Perfect";
-        scoreNeonColor = AppColor.yellowColor2;
-        break;
-      case StagePlayScore.none:
-        scoreText = "";
-        break;
-    }
 
+    if (similarity == null) {
+      scoreText = "";
+    } else if (similarity < -1) {
+      scoreText = "Bad";
+      scoreNeonColor = Colors.red;
+    } else if (similarity < 0.4) {
+      scoreText = "Good";
+      scoreNeonColor = AppColor.purpleColor2;
+    } else if (similarity < 0.6) {
+      scoreText = "Great";
+      scoreNeonColor = AppColor.greenColor;
+    } else if (similarity < 0.8) {
+      scoreText = "Excellent";
+      scoreNeonColor = AppColor.blueColor2;
+    } else if (similarity <= 1.0) {
+      scoreText = "Perfect";
+      scoreNeonColor = AppColor.yellowColor2;
+    }
     return SizedBox(
       width: 90,
       child: Text(

--- a/lib/ui/view/stage/popo_play_view.dart
+++ b/lib/ui/view/stage/popo_play_view.dart
@@ -192,13 +192,13 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     if (similarity == null) return StagePlayScore.none;
     if (similarity < -1) {
       return StagePlayScore.bad;
-    } else if (similarity < 0.2) {
-      return StagePlayScore.good;
     } else if (similarity < 0.4) {
-      return StagePlayScore.great;
+      return StagePlayScore.good;
     } else if (similarity < 0.6) {
-      return StagePlayScore.perfect;
+      return StagePlayScore.great;
     } else if (similarity < 0.8) {
+      return StagePlayScore.perfect;
+    } else if (similarity <= 1.0) {
       return StagePlayScore.excellent;
     } else {
       return StagePlayScore.none;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -1012,18 +1012,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -1425,10 +1425,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1481,10 +1481,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.1"
   textfield_tags:
     dependency: "direct main"
     description:
@@ -1661,14 +1661,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1710,5 +1702,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
## 📱 작업 사진 
x(기존과 동일)

## 💬 작업 설명
- 스테이지 중간 점수 연결하였습니다.
- 스테이지 배경 전환 시 흰 화면이 나오는 오류를 수정하였습니다.
- 스테이지 앱 바의 "PoPo 스테이지" 텍스트 클릭 시 본인이 한 번 더 입장하도록 하였습니다(비밀 입장). 이제 다른 분들도 자유롭게 스테이지 진행하실 수 있습니다~!

## ✅ 한 일
1. 스테이지 중간 점수 연결
2. 스테이지 배경 전환 오류 수정
3. 스테이지 비밀 입장 기능 추가

## 🔧 보완할 점
1. 중간 점수 보일 때 애니메이션 추가

## 🤓 다음에 할 일
1. 스테이지 최적화 한 번 더 하겠습니다...
2. 스테이지 중간 점수 애니메이션
3. 앱 종료 후 푸시알림 수신 + 리다이렉션
4. 소켓 에러 연결
5. 리팩토링
6. 온보딩 에러 수정
