### PR TITLE
[feat] 포포 스테이지 녹화 기능 보완 (HH-414)

### DIFF
--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -89,80 +89,14 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                                 visible: _isRecording,
                                 replacement: IconButton(
                                   onPressed: () async {
-                                    // 녹화 중이 아닐 때
-                                    // 포그라운드 서비스 시작
-                                    await PoPoForegroundService.startService();
-
-                                    _isRecording = await FlutterScreenRecording
-                                        .startRecordScreen(
-                                      "녹화: my_screen_recording",
-                                      titleNotification: "Recording Screen",
-                                      messageNotification:
-                                          "Tap to stop recording",
-                                    );
-
-                                    if (_isRecording) {
-                                      debugPrint("녹화: 녹화가 시작되었습니다.");
-                                    } else {
-                                      debugPrint("녹화: 녹화 시작에 실패했습니다.");
-                                    }
-
-                                    setState(() {});
+                                    _startRecording();
                                   },
                                   icon: const Icon(Icons.adjust_rounded,
                                       color: Colors.white),
                                 ),
                                 child: IconButton(
                                   onPressed: () async {
-                                    _isRecording = false;
-
-                                    setState(() {});
-
-                                    // 포그라운드 서비스 종료
-                                    await PoPoForegroundService.stopService();
-                                    String recordedPath =
-                                        await FlutterScreenRecording
-                                            .stopRecordScreen;
-
-                                    if (recordedPath.isNotEmpty) {
-                                      File recordedFile = File(recordedPath);
-                                      if (await recordedFile.exists() ==
-                                          false) {
-                                        Fluttertoast.showToast(
-                                            msg: "녹화 오류.. 다시 시도해주세요 🥲");
-                                      } else {
-                                        // 업로드 다이얼로그 생성
-                                        showDialog(
-                                          context: context,
-                                          builder: (BuildContext context) {
-                                            return VideoUploadDialog(
-                                              title: '📸 업로드',
-                                              message:
-                                                  '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
-                                              file: recordedFile,
-                                              onCancel: () {
-                                                Navigator.pop(context);
-                                              },
-                                              onConfirm: () async {
-                                                // 업로드 스크린 생성
-                                                Navigator.push(
-                                                  context,
-                                                  MaterialPageRoute(
-                                                    builder: (context) =>
-                                                        HomeUploadScreen(
-                                                      isHome: false,
-                                                      uploadFile: recordedFile,
-                                                    ),
-                                                  ),
-                                                );
-                                              },
-                                            );
-                                          },
-                                        );
-                                      }
-                                    } else {
-                                      debugPrint('녹화: 녹화된 영상이 없습니다.');
-                                    }
+                                    _stopRecording();
                                   },
                                   icon: const Icon(Icons.adjust_rounded,
                                       color: Colors.red),
@@ -227,6 +161,72 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     }
 
     super.dispose();
+  }
+
+  void _startRecording() async {
+    // 포그라운드 서비스 시작
+
+    await PoPoForegroundService.startService();
+
+    _isRecording = await FlutterScreenRecording.startRecordScreen(
+      "녹화: my_screen_recording",
+      titleNotification: "Recording Screen",
+      messageNotification: "Tap to stop recording",
+    );
+
+    if (_isRecording) {
+      debugPrint("녹화: 녹화가 시작되었습니다.");
+    } else {
+      debugPrint("녹화: 녹화 시작에 실패했습니다.");
+    }
+
+    setState(() {});
+  }
+
+  void _stopRecording() async {
+    _isRecording = false;
+
+    setState(() {});
+
+    // 포그라운드 서비스 종료
+    await PoPoForegroundService.stopService();
+    String recordedPath = await FlutterScreenRecording.stopRecordScreen;
+
+    if (recordedPath.isNotEmpty) {
+      File recordedFile = File(recordedPath);
+      if (await recordedFile.exists() == false) {
+        Fluttertoast.showToast(msg: "녹화 오류.. 다시 시도해주세요 🥲");
+      } else {
+        // 업로드 다이얼로그 생성
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return VideoUploadDialog(
+              title: '📸 업로드',
+              message: '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
+              file: recordedFile,
+              onCancel: () {
+                Navigator.pop(context);
+              },
+              onConfirm: () async {
+                // 업로드 스크린 생성
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => HomeUploadScreen(
+                      isHome: false,
+                      uploadFile: recordedFile,
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        );
+      }
+    } else {
+      debugPrint('녹화: 녹화된 영상이 없습니다.');
+    }
   }
 
   void _popoStageEnter() {

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -82,6 +82,93 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                               onGenerateRoute:
                                   _socketStageProvider.onGenerateRoute,
                             ),
+                            Positioned(
+                              top: 68,
+                              right: 2,
+                              child: Visibility(
+                                visible: _isRecording,
+                                replacement: IconButton(
+                                  onPressed: () async {
+                                    // 녹화 중이 아닐 때
+                                    // 포그라운드 서비스 시작
+                                    await PoPoForegroundService.startService();
+
+                                    _isRecording = await FlutterScreenRecording
+                                        .startRecordScreen(
+                                      "녹화: my_screen_recording",
+                                      titleNotification: "Recording Screen",
+                                      messageNotification:
+                                          "Tap to stop recording",
+                                    );
+
+                                    if (_isRecording) {
+                                      debugPrint("녹화: 녹화가 시작되었습니다.");
+                                    } else {
+                                      debugPrint("녹화: 녹화 시작에 실패했습니다.");
+                                    }
+
+                                    setState(() {});
+                                  },
+                                  icon: const Icon(Icons.adjust_rounded,
+                                      color: Colors.white),
+                                ),
+                                child: IconButton(
+                                  onPressed: () async {
+                                    _isRecording = false;
+
+                                    setState(() {});
+
+                                    // 포그라운드 서비스 종료
+                                    await PoPoForegroundService.stopService();
+                                    String recordedPath =
+                                        await FlutterScreenRecording
+                                            .stopRecordScreen;
+
+                                    if (recordedPath.isNotEmpty) {
+                                      File recordedFile = File(recordedPath);
+                                      if (await recordedFile.exists() ==
+                                          false) {
+                                        Fluttertoast.showToast(
+                                            msg: "녹화 오류.. 다시 시도해주세요 🥲");
+                                      } else {
+                                        // 업로드 다이얼로그 생성
+                                        showDialog(
+                                          context: context,
+                                          builder: (BuildContext context) {
+                                            return VideoUploadDialog(
+                                              title: '📸 업로드',
+                                              message:
+                                                  '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
+                                              file: recordedFile,
+                                              onCancel: () {
+                                                Navigator.pop(context);
+                                              },
+                                              onConfirm: () async {
+                                                // 업로드 스크린 생성
+                                                Navigator.push(
+                                                  context,
+                                                  MaterialPageRoute(
+                                                    builder: (context) =>
+                                                        HomeUploadScreen(
+                                                      isHome: false,
+                                                      uploadFile: recordedFile,
+                                                    ),
+                                                  ),
+                                                );
+                                              },
+                                            );
+                                          },
+                                        );
+                                      }
+                                    } else {
+                                      debugPrint('녹화: 녹화된 영상이 없습니다.');
+                                    }
+                                  },
+                                  icon: const Icon(Icons.adjust_rounded,
+                                      color: Colors.red),
+                                ),
+                              ),
+                            ),
                             const Positioned(
                               bottom: 68,
                               left: 0,
@@ -220,80 +307,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         ),
       ),
       actions: [
-        Visibility(
-          visible: _isRecording,
-          replacement: IconButton(
-            onPressed: () async {
-              // 녹화 중이 아닐 때
-              // 포그라운드 서비스 시작
-              await PoPoForegroundService.startService();
-
-              _isRecording = await FlutterScreenRecording.startRecordScreen(
-                "녹화: my_screen_recording",
-                titleNotification: "Recording Screen",
-                messageNotification: "Tap to stop recording",
-              );
-
-              if (_isRecording) {
-                debugPrint("녹화: 녹화가 시작되었습니다.");
-              } else {
-                debugPrint("녹화: 녹화 시작에 실패했습니다.");
-              }
-
-              setState(() {});
-            },
-            icon: const Icon(Icons.adjust_rounded, color: Colors.white),
-          ),
-          child: IconButton(
-            onPressed: () async {
-              _isRecording = false;
-
-              setState(() {});
-
-              // 포그라운드 서비스 종료
-              await PoPoForegroundService.stopService();
-              String recordedPath =
-                  await FlutterScreenRecording.stopRecordScreen;
-
-              if (recordedPath.isNotEmpty) {
-                File recordedFile = File(recordedPath);
-                if (await recordedFile.exists() == false) {
-                  Fluttertoast.showToast(msg: "녹화 오류.. 다시 시도해주세요 🥲");
-                } else {
-                  // 업로드 다이얼로그 생성
-                  showDialog(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return VideoUploadDialog(
-                        title: '📸 업로드',
-                        message: '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
-                        file: recordedFile,
-                        onCancel: () {
-                          Navigator.pop(context);
-                        },
-                        onConfirm: () async {
-                          // 업로드 스크린 생성
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => HomeUploadScreen(
-                                isHome: false,
-                                uploadFile: recordedFile,
-                              ),
-                            ),
-                          );
-                        },
-                      );
-                    },
-                  );
-                }
-              } else {
-                debugPrint('녹화: 녹화된 영상이 없습니다.');
-              }
-            },
-            icon: const Icon(Icons.adjust_rounded, color: Colors.red),
-          ),
-        ),
         _buildUserCountWidget(),
       ],
     );

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -184,9 +184,9 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     );
   }
 
-  AppBar _buildAppBar(BuildContext context) {
-    bool isRecording = false;
+  bool isRecording = false;
 
+  AppBar _buildAppBar(BuildContext context) {
     return AppBar(
       centerTitle: true,
       title: GestureDetector(
@@ -283,50 +283,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
             },
             icon: const Icon(Icons.adjust_rounded, color: Colors.red),
           ),
-        ),
-        IconButton(
-          onPressed: () async {
-            isRecording = false;
-
-            setState(() {});
-
-            // 포그라운드 서비스 종료
-            await PoPoForegroundService.stopService();
-            String recordedPath = await FlutterScreenRecording.stopRecordScreen;
-
-            if (recordedPath.isNotEmpty) {
-              File recordedFile = File(recordedPath);
-              // 업로드 다이얼로그 생성
-              showDialog(
-                context: context,
-                builder: (BuildContext context) {
-                  return VideoUploadDialog(
-                    title: '📸 업로드',
-                    message: '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
-                    file: recordedFile,
-                    onCancel: () {
-                      Navigator.pop(context);
-                    },
-                    onConfirm: () async {
-                      // 업로드 스크린 생성
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => HomeUploadScreen(
-                            isHome: false,
-                            uploadFile: recordedFile,
-                          ),
-                        ),
-                      );
-                    },
-                  );
-                },
-              );
-            } else {
-              debugPrint('녹화: 녹화된 영상이 없습니다.');
-            }
-          },
-          icon: const Icon(Icons.adjust_rounded, color: Colors.red),
         ),
         _buildUserCountWidget(),
       ],

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -6,6 +6,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_screen_recording/flutter_screen_recording.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pocket_pose/config/audio_player/audio_player_util.dart';
 import 'package:pocket_pose/data/entity/request/stage_enter_request.dart';
 import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
@@ -36,6 +37,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
   late MultiVideoPlayProvider _multiVideoPlayProvider;
   late StageProviderImpl _stageProvider;
   late SocketStageProviderImpl _socketStageProvider;
+  bool _isRecording = false;
 
   @override
   Widget build(BuildContext context) {
@@ -123,6 +125,12 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     if (_isEnter) {
       _socketStageProvider.exitStage();
       _isEnter = false;
+
+      // 녹화 해제
+      if (_isRecording) {
+        FlutterScreenRecording.stopRecordScreen;
+        Fluttertoast.showToast(msg: "녹화 중단");
+      }
     }
 
     super.dispose();
@@ -184,8 +192,6 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
     );
   }
 
-  bool isRecording = false;
-
   AppBar _buildAppBar(BuildContext context) {
     return AppBar(
       centerTitle: true,
@@ -215,20 +221,20 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       ),
       actions: [
         Visibility(
-          visible: isRecording,
+          visible: _isRecording,
           replacement: IconButton(
             onPressed: () async {
               // 녹화 중이 아닐 때
               // 포그라운드 서비스 시작
               await PoPoForegroundService.startService();
 
-              isRecording = await FlutterScreenRecording.startRecordScreen(
+              _isRecording = await FlutterScreenRecording.startRecordScreen(
                 "녹화: my_screen_recording",
                 titleNotification: "Recording Screen",
                 messageNotification: "Tap to stop recording",
               );
 
-              if (isRecording) {
+              if (_isRecording) {
                 debugPrint("녹화: 녹화가 시작되었습니다.");
               } else {
                 debugPrint("녹화: 녹화 시작에 실패했습니다.");
@@ -240,7 +246,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
           ),
           child: IconButton(
             onPressed: () async {
-              isRecording = false;
+              _isRecording = false;
 
               setState(() {});
 

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -129,7 +129,7 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
       // 녹화 해제
       if (_isRecording) {
         FlutterScreenRecording.stopRecordScreen;
-        Fluttertoast.showToast(msg: "녹화 중단");
+        Fluttertoast.showToast(msg: "녹화를 중단합니다.");
       }
     }
 
@@ -257,32 +257,36 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
 
               if (recordedPath.isNotEmpty) {
                 File recordedFile = File(recordedPath);
-                // 업로드 다이얼로그 생성
-                showDialog(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return VideoUploadDialog(
-                      title: '📸 업로드',
-                      message: '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
-                      file: recordedFile,
-                      onCancel: () {
-                        Navigator.pop(context);
-                      },
-                      onConfirm: () async {
-                        // 업로드 스크린 생성
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => HomeUploadScreen(
-                              isHome: false,
-                              uploadFile: recordedFile,
+                if (await recordedFile.exists() == false) {
+                  Fluttertoast.showToast(msg: "녹화 오류.. 다시 시도해주세요 🥲");
+                } else {
+                  // 업로드 다이얼로그 생성
+                  showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return VideoUploadDialog(
+                        title: '📸 업로드',
+                        message: '방금 진행한 ⭐ 포포 플레이 영상 ⭐을 커뮤니티에 업로드 하시겠습니까?',
+                        file: recordedFile,
+                        onCancel: () {
+                          Navigator.pop(context);
+                        },
+                        onConfirm: () async {
+                          // 업로드 스크린 생성
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => HomeUploadScreen(
+                                isHome: false,
+                                uploadFile: recordedFile,
+                              ),
                             ),
-                          ),
-                        );
-                      },
-                    );
-                  },
-                );
+                          );
+                        },
+                      );
+                    },
+                  );
+                }
               } else {
                 debugPrint('녹화: 녹화된 영상이 없습니다.');
               }

--- a/lib/ui/screen/stage/popo_stage_screen.dart
+++ b/lib/ui/screen/stage/popo_stage_screen.dart
@@ -169,18 +169,24 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
                                 ),
                               ),
                             ),
-                            const Positioned(
-                              bottom: 68,
-                              left: 0,
-                              right: 0,
-                              child: StageLiveTalkListWidget(),
+                            Visibility(
+                              visible: !_isRecording,
+                              child: const Positioned(
+                                bottom: 68,
+                                left: 0,
+                                right: 0,
+                                child: StageLiveTalkListWidget(),
+                              ),
                             ),
-                            Positioned(
-                              bottom: 0,
-                              left: 0,
-                              right: 0,
-                              child: StageLiveChatBarWidget(
-                                  nickName: widget.userData.nickname),
+                            Visibility(
+                              visible: !_isRecording,
+                              child: Positioned(
+                                bottom: 0,
+                                left: 0,
+                                right: 0,
+                                child: StageLiveChatBarWidget(
+                                    nickName: widget.userData.nickname),
+                              ),
                             ),
                           ],
                         )
@@ -286,28 +292,34 @@ class _PoPoStageScreenState extends State<PoPoStageScreen> {
         onTap: () {
           _stageProvider.getStageEnter(StageEnterRequest(page: 0, size: 10));
         },
-        child: const Text(
-          "PoPo 스테이지",
-          style: TextStyle(fontSize: 18),
+        child: Visibility(
+          visible: !_isRecording,
+          child: const Text(
+            "PoPo 스테이지",
+            style: TextStyle(fontSize: 18),
+          ),
         ),
       ),
       backgroundColor: Colors.transparent,
       elevation: 0.0,
-      leading: IconButton(
-        onPressed: () {
-          AudioPlayerUtil().stop();
-          if (widget.getIndex() == 0) {
-            Navigator.pop(context);
-          } else {
-            Navigator.pop(context);
-          }
-        },
-        icon: SvgPicture.asset(
-          'assets/icons/ic_stage_back_white.svg',
+      leading: Visibility(
+        visible: !_isRecording,
+        child: IconButton(
+          onPressed: () {
+            AudioPlayerUtil().stop();
+            if (widget.getIndex() == 0) {
+              Navigator.pop(context);
+            } else {
+              Navigator.pop(context);
+            }
+          },
+          icon: SvgPicture.asset(
+            'assets/icons/ic_stage_back_white.svg',
+          ),
         ),
       ),
       actions: [
-        _buildUserCountWidget(),
+        Visibility(visible: !_isRecording, child: _buildUserCountWidget()),
       ],
     );
   }

--- a/lib/ui/view/home/comment_button_view.dart
+++ b/lib/ui/view/home/comment_button_view.dart
@@ -8,8 +8,6 @@ import 'package:pocket_pose/data/remote/provider/comment_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/entity/comment_data.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
-import 'package:pocket_pose/ui/screen/profile/profile_screen.dart';
-import 'package:pocket_pose/ui/widget/page_route_with_animation.dart';
 import 'package:provider/provider.dart';
 
 class CommentButtonView extends StatefulWidget {

--- a/lib/ui/widget/video/video_upload_dialog.dart
+++ b/lib/ui/widget/video/video_upload_dialog.dart
@@ -70,8 +70,10 @@ class _VideoUploadDialogState extends State<VideoUploadDialog> {
                         aspectRatio: _videoController.value.aspectRatio,
                         child: CachedVideoPlayer(_videoController),
                       )
-                    : CircularProgressIndicator(
-                        color: AppColor.purpleColor,
+                    : Center(
+                        child: CircularProgressIndicator(
+                          color: AppColor.purpleColor,
+                        ),
                       ),
               ),
             ),

--- a/lib/ui/widget/video/video_upload_dialog.dart
+++ b/lib/ui/widget/video/video_upload_dialog.dart
@@ -20,6 +20,7 @@ class VideoUploadDialog extends StatefulWidget {
   }) : super(key: key);
 
   @override
+  // ignore: library_private_types_in_public_api
   _VideoUploadDialogState createState() => _VideoUploadDialogState();
 }
 


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/63f00ca0-8e95-46e0-8719-f4fe23442288

## 💬 작업 설명
#114 후 포포 스테이지의 녹화 기능을 보완했습니다.

## ✅ 한 일
1. 녹화 아이콘 하나로 변경(녹화 중이지 않을 때는 흰색, 녹화 중일 땐 빨간색으로 변경)
2. 스테이지 퇴장한 경우 녹화 중단 처리
3. 녹화 안된 경우 토스트 처리
4. 녹화 버튼 참여 인원수 위젯 아래로 이동
5. 녹화 중일 때 앱바, 채팅 목록, 채팅 입력창 안보이는 기능 개발
6. 포포 스테이지 녹화 기능 리팩토링

## ☝️ 참고 하세요~
1. 녹화 후 채팅 목록에 아무것도 안 나옵니다..! 제가 작성한 코드랑은 관련없이 setState랑 Visibility 과정에서 (?) 채팅 내용이 모두 삭제되는 것 같습니다.. 확인 부탁드립니다.
2. 녹화는 아주 길게도 찍어봤는데 잘 됩니다! 녹화가 안되는 경우는 아마 인터넷 문제일 것 같은데.. 토스트 처리는 해놨습니다! 만약에 또 발생한다면 어떤 상황인지 이야기 해주세요~

## 🤓 다음에 할 일
1. 팔로우 푸시 알림 리다이렉션
2. 좋아요 푸시 알림 리다이렉션