### PR TITLE
[feat] 팔로우, 좋아요 푸시 알림 기능 개발

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -108,7 +108,8 @@ void setNotificationHandler(Map<String, dynamic>? map) async {
         case "ADD_FOLLOW":
           Get.to(
               transition: Transition.rightToLeft,
-              () => ProfileScreen(userId: map['followerId']));
+              () => ProfileScreen(
+                  userId: map['followerId'], isNotification: true));
           break;
         case "ADD_LIKE":
           Get.to(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:pocket_pose/firebase_options.dart';
 import 'package:pocket_pose/ui/screen/chat/chat_detail_screen.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/screen/onboarding/on_boarding_screen.dart';
+import 'package:pocket_pose/ui/screen/profile/profile_screen.dart';
 import 'package:pocket_pose/ui/screen/share/share_screen.dart';
 import 'package:provider/provider.dart';
 
@@ -103,6 +104,11 @@ void setNotificationHandler(Map<String, dynamic>? map) async {
                     videoUuid: map['videoId'],
                     commentId: map['commentId'],
                   ));
+          break;
+        case "ADD_FOLLOW":
+          Get.to(
+              transition: Transition.rightToLeft,
+              () => ProfileScreen(userId: map['followerId']));
           break;
       }
     } catch (error) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -110,6 +110,13 @@ void setNotificationHandler(Map<String, dynamic>? map) async {
               transition: Transition.rightToLeft,
               () => ProfileScreen(userId: map['followerId']));
           break;
+        case "ADD_LIKE":
+          Get.to(
+              transition: Transition.rightToLeft,
+              () => ShareScreen(
+                    videoUuid: map['videoId'],
+                  ));
+          break;
       }
     } catch (error) {
       debugPrint('mmm Notification payload error $error');

--- a/lib/ui/screen/profile/profile_screen.dart
+++ b/lib/ui/screen/profile/profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/data/remote/provider/profile_provider.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
+import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/view/profile/profile_tab_videos_view.dart';
 import 'package:pocket_pose/ui/widget/profile/profile_tapbar_widget.dart';
 
@@ -14,11 +15,13 @@ class ProfileScreen extends StatefulWidget {
   const ProfileScreen({
     this.isNavigation,
     this.userId,
+    this.isNotification,
     Key? key,
   }) : super(key: key);
 
   final bool? isNavigation;
   final String? userId;
+  final bool? isNotification;
   @override
   State<ProfileScreen> createState() => _ProfileScreenState();
 }
@@ -99,7 +102,17 @@ class _ProfileScreenState extends State<ProfileScreen>
                     (widget.isNavigation == null || !widget.isNavigation!)) &&
             details.primaryDelta! > 10) {
           // 왼쪽에서 오른쪽으로 드래그했을 때 pop
-          Navigator.of(context).pop();
+          if (widget.isNotification != null && widget.isNotification!) {
+            _multiVideoPlayProvider.resetVideoPlayer(0);
+
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(builder: (context) => const MainScreen()),
+              (route) => false,
+            );
+          } else {
+            Navigator.of(context).pop();
+          }
         }
       },
       child: FutureBuilder(
@@ -118,6 +131,7 @@ class _ProfileScreenState extends State<ProfileScreen>
                                   profileResponse:
                                       _profileProvider.profileResponse!,
                                   isBottomNavi: widget.isNavigation ?? false,
+                                  isNotification: widget.isNotification,
                                 ),
                                 ProfileUserInfoWidget(
                                     profileResponse:

--- a/lib/ui/view/home/comment_button_view.dart
+++ b/lib/ui/view/home/comment_button_view.dart
@@ -8,8 +8,6 @@ import 'package:pocket_pose/data/remote/provider/comment_provider.dart';
 import 'package:pocket_pose/data/remote/provider/kakao_login_provider.dart';
 import 'package:pocket_pose/domain/entity/comment_data.dart';
 import 'package:pocket_pose/domain/entity/user_data.dart';
-import 'package:pocket_pose/ui/screen/profile/profile_screen.dart';
-import 'package:pocket_pose/ui/widget/page_route_with_animation.dart';
 import 'package:provider/provider.dart';
 
 class CommentButtonView extends StatefulWidget {

--- a/lib/ui/widget/profile/profile_tapbar_widget.dart
+++ b/lib/ui/widget/profile/profile_tapbar_widget.dart
@@ -2,22 +2,32 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/data/entity/response/profile_response.dart';
+import 'package:pocket_pose/data/local/provider/multi_video_play_provider.dart';
+import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/screen/profile/profile_edit_screen.dart';
 import 'package:pocket_pose/ui/screen/profile/profile_setting_screen.dart';
 import 'package:pocket_pose/ui/widget/page_route_with_animation.dart';
+import 'package:provider/provider.dart';
 
+// ignore: must_be_immutable
 class ProfileTapbarWidget extends StatelessWidget {
-  const ProfileTapbarWidget({
+  ProfileTapbarWidget({
     super.key,
     required this.profileResponse,
     required this.isBottomNavi,
+    required this.isNotification,
   });
 
   final ProfileResponse profileResponse;
   final bool isBottomNavi;
+  final bool? isNotification;
+  late MultiVideoPlayProvider _multiVideoPlayProvider;
 
   @override
   Widget build(BuildContext context) {
+    _multiVideoPlayProvider =
+        Provider.of<MultiVideoPlayProvider>(context, listen: false);
+
     return Container(
         color: AppColor.whiteColor,
         child: Row(
@@ -31,7 +41,18 @@ class ProfileTapbarWidget extends StatelessWidget {
                 children: [
                   InkWell(
                     onTap: () {
-                      Navigator.pop(context);
+                      if (isNotification != null && isNotification!) {
+                        _multiVideoPlayProvider.resetVideoPlayer(0);
+
+                        Navigator.pushAndRemoveUntil(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => const MainScreen()),
+                          (route) => false,
+                        );
+                      } else {
+                        Navigator.of(context).pop();
+                      }
                     },
                     child: Container(
                       margin: const EdgeInsets.fromLTRB(20, 40, 0, 0),

--- a/lib/ui/widget/video/video_upload_dialog.dart
+++ b/lib/ui/widget/video/video_upload_dialog.dart
@@ -20,6 +20,7 @@ class VideoUploadDialog extends StatefulWidget {
   }) : super(key: key);
 
   @override
+  // ignore: library_private_types_in_public_api
   _VideoUploadDialogState createState() => _VideoUploadDialogState();
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -1012,18 +1012,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -1425,10 +1425,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1481,10 +1481,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   textfield_tags:
     dependency: "direct main"
     description:
@@ -1661,6 +1661,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1702,5 +1710,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
## 📱 작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/f11081c1-b88c-4df8-a122-a41f0e4b5543

## 💬 작업 설명
팔로우, 좋아요 푸시 알림 기능을 개발했습니다.

## ✅ 한 일
1. 팔로우 푸시 알림 리다이렉션 기능 개발
2. 좋아요 푸시 알림 리다이렉션 기능 개발
3. 팔로우 리다이렉션에서 pop 하면 홈으로 가는 기능 개발

## ☝️ 참고 하세요~
1. 팔로우, 좋아요 모두 pop하면 홈으로 돌아갑니다.

## 🤓 다음에 할 일
1. 로그아웃 후 홈으로 돌아오면 노란 화면 나오는 버그 수정
