### PR TITLE
[feat] dotenv 환경변수 추가 (HH-450)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# dotenv
+*.env

--- a/lib/data/remote/provider/kakao_login_provider.dart
+++ b/lib/data/remote/provider/kakao_login_provider.dart
@@ -12,6 +12,7 @@ import 'package:pocket_pose/main.dart';
 import 'package:pocket_pose/ui/screen/main_screen.dart';
 import 'package:pocket_pose/ui/widget/login_modal_content_widget.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 const _storage = FlutterSecureStorage();
 const _accessTokenKey = 'kakaoAccessToken';
@@ -91,9 +92,8 @@ class KaKaoLoginProvider extends ChangeNotifier {
   // 카카오 서버 로그인
   Future<void> _login(String kakaoAccessToken) async {
     try {
-      var fcmToken = await FirebaseMessaging.instance.getToken(
-          vapidKey:
-              "BGIFfDEvFQXrQ9dyfyFDZZ0T1d-A-88SU-aTaS744Xigeu9NoNogwWjqHuY8hBFW5LGcMPmoQRrlnxzD");
+      var fcmToken = await FirebaseMessaging.instance
+          .getToken(vapidKey: dotenv.env['vapidKey']);
 
       if (fcmToken == null) {
         debugPrint('FCM: 토큰 얻기 실패!');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:pocket_pose/ui/screen/onboarding/on_boarding_screen.dart';
 import 'package:pocket_pose/ui/screen/profile/profile_screen.dart';
 import 'package:pocket_pose/ui/screen/share/share_screen.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 // 카메라 목록 변수
 List<CameraDescription> cameras = [];
@@ -47,6 +48,9 @@ Future<void> main() async {
   await notificationService.init();
   DynamicLink().setup();
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+
+  // .env 파일 읽어오기
+  await dotenv.load(fileName: 'assets/.env');
 
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (_) => MultiVideoPlayProvider()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,7 +34,10 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 List<CameraDescription> cameras = [];
 
 Future<void> main() async {
-  KakaoSdk.init(nativeAppKey: 'f03a21b3fa588715cb55730113dea1ab');
+  // .env 파일 읽어오기
+  await dotenv.load(fileName: 'assets/.env');
+
+  KakaoSdk.init(nativeAppKey: dotenv.env['nativeAppKey']);
   // 비동기 메서드를 사용함
   WidgetsFlutterBinding.ensureInitialized();
   // 사용 가능한 카메라 목록 받아옴
@@ -48,9 +51,6 @@ Future<void> main() async {
   await notificationService.init();
   DynamicLink().setup();
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
-
-  // .env 파일 읽어오기
-  await dotenv.load(fileName: 'assets/.env');
 
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (_) => MultiVideoPlayProvider()),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -502,6 +502,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_foreground_task:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_screen_recording: ^2.0.9
   video_thumbnail: ^0.5.3
   flutter_foreground_task: ^6.1.1 
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -76,6 +77,7 @@ flutter:
     - assets/images/
     - assets/fonts/
     - assets/audios/
+    - assets/.env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
## 📱 작업 사진
UI 변경 없습니다.

## 💬 작업 설명
dotenv 에 민감한 정보를 추가해 관리하도록 개발 했습니다.

## ✅ 한 일
1. dotenv 사용을 위한 환경 설정 
2. FCM vapidKey env에 등록
3. Kakao nativeAppKey env에 등록
4. .gitignore에 env 파일 등록

## ☝️ 참고 하세요~
1. .gitignore에 env 파일이 등록되어 있어서 민영님 로컬에서는 동작을 안할 거에요! 슬랙에 env 파일 보내놓을테니 assets 밑에 파일 넣어주세요~
2. 이 [참고 블로그](https://ejayjeon.tistory.com/3)가 아주 최신이고 친절하네요~

## 🤓 다음에 할 일
1. terminated 상태일 때 푸시 알림 처리
