### PR TITLE
[feat] terminated 상태일 때 push notification 처리 (HH-445)

### DIFF
--- a/lib/config/fcm/remote_notifications_ervice.dart
+++ b/lib/config/fcm/remote_notifications_ervice.dart
@@ -9,6 +9,7 @@ class RemoteNotificationService {
   }
 
   Future<void> initNotificationSettings(FirebaseMessaging messaging) async {
+    await FirebaseMessaging.instance.getInitialMessage();
     await FirebaseMessaging.instance.setAutoInitEnabled(true);
     await messaging.requestPermission(
       alert: true,

--- a/lib/ui/view/video/multi_video_play_view.dart
+++ b/lib/ui/view/video/multi_video_play_view.dart
@@ -150,10 +150,12 @@ class _MultiVideoPlayerViewState extends State<MultiVideoPlayerView>
                             .currentIndexs[widget.screenNum] <=
                         0) {
                       //모든 비디오 로드 전 처음 화면에 진입했을 경우
-                      return Container(color: Colors.yellow); // 비디오 로딩 중
+                      //return Container(color: Colors.yellow);
+                      return const MusicSpinner();
                     } else {
                       //마지막 페이지에 진입했을 경우
-                      return Container(color: Colors.pink);
+                      //return Container(color: Colors.pink);
+                      return const MusicSpinner();
                     }
                   }
                 }
@@ -245,10 +247,12 @@ class _MultiVideoPlayerViewState extends State<MultiVideoPlayerView>
                   if (_multiVideoPlayProvider.currentIndexs[widget.screenNum] <=
                       0) {
                     //모든 비디오 로드 전 처음 화면에 진입했을 경우
-                    return Container(color: Colors.yellow); // 비디오 로딩 중
+                    //return Container(color: Colors.yellow);
+                    return const MusicSpinner();
                   } else {
                     //마지막 페이지에 진입했을 경우
-                    return Container(color: Colors.pink);
+                    //return Container(color: Colors.pink);
+                    return const MusicSpinner();
                   }
                 }
               }


### PR DESCRIPTION
## 📱작업 사진 
https://github.com/2023-HATCH/hatch-flutter-app-2023/assets/86946928/337a1a14-81b5-4cef-8461-29127ac7bd17

## 💬 작업 설명
terminated 상태일 때 push notification을 처리하고
비디오 로딩 상황별 임시로 지정해놓은 분홍, 노랑 화면을 스피너로 변경 했습니다.

## ✅ 한 일
1. terminated 상태일 때 푸시 알림 기능 개발
2. 비디오 로딩 중에 나오는 분홍, 노랑 화면 스피너로 변경

## 💃 부탁 드립니다~
1. 생각보다 terminated 푸시 알림이 쉽게 해결되어 잘된게 맞나 싶네요..? 확인 부탁드립니다

## 🤓 다음에 할 일
1. 개발 끝입니다. 오류 발견되면 유지보수 하겠습니다.