### PR TITLE
[ui] 스테이지 중간 점수 + mvp 애니메이션 추가 (HH-451)

### DIFF
--- a/lib/data/remote/provider/socket_stage_provider_impl.dart
+++ b/lib/data/remote/provider/socket_stage_provider_impl.dart
@@ -89,6 +89,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   Map<PoseLandmarkType, PoseLandmark>? player1;
   Map<PoseLandmarkType, PoseLandmark>? player2;
   List<StagePlayerInfoListItem>? midScores;
+  int _midScoreKey = 0;
   Map<PoseLandmarkType, PoseLandmark>? mvpSkeleton;
 
   SocketType _socketType = SocketType.WAIT;
@@ -103,6 +104,7 @@ class SocketStageProviderImpl extends ChangeNotifier
   StageMusicData? get catchMusicData => _catchMusicData;
   int get userCount => _userCount;
   List<StagePlayerInfoListItem> get playerInfos => _playerInfos;
+  int get midScoreKey => _midScoreKey;
   StageTalkListItem? get talk => _talk;
 
   List<StagePlayerListItem> get players => _players;
@@ -331,6 +333,7 @@ class SocketStageProviderImpl extends ChangeNotifier
             jsonDecode(frame.body.toString()),
             StageMidScoreResponse.fromJson(
                 jsonDecode(frame.body.toString())['data']));
+        _midScoreKey++;
         midScores = socketResponse.data?.playerInfos ?? [];
         notifyListeners();
         break;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,6 +91,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
+@pragma('vm:entry-point')
 void setNotificationHandler(Map<String, dynamic>? map) async {
   if (map != null) {
     try {
@@ -131,8 +132,10 @@ void setNotificationHandler(Map<String, dynamic>? map) async {
   }
 }
 
+@pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  debugPrint("mmm ${message.data}");
-  await Firebase.initializeApp()
-      .then((_) => setNotificationHandler(message.data));
+  await Firebase.initializeApp();
+  setNotificationHandler(message.data);
+
+  return Future.value();
 }

--- a/lib/ui/screen/onboarding/on_boarding_screen.dart
+++ b/lib/ui/screen/onboarding/on_boarding_screen.dart
@@ -34,22 +34,23 @@ class _OnBoardingScreenState extends State<OnBoardingScreen> {
         setState(() {});
       },
       globalBackgroundColor: Colors.black,
-      globalHeader:
-          Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
-        Padding(
-          padding: const EdgeInsets.all(18.0),
-          child: TextButton(
-            onPressed: () {
-              _introKey.currentState?.skipToEnd();
-            },
-            child: Text(
-              _skipState ? "건너뛰기" : "",
-              style: const TextStyle(color: Colors.white, fontSize: 16),
-              textAlign: TextAlign.right,
+      globalHeader: SingleChildScrollView(
+        child: Column(crossAxisAlignment: CrossAxisAlignment.end, children: [
+          Padding(
+            padding: const EdgeInsets.all(18.0),
+            child: TextButton(
+              onPressed: () {
+                _introKey.currentState?.skipToEnd();
+              },
+              child: Text(
+                _skipState ? "건너뛰기" : "",
+                style: const TextStyle(color: Colors.white, fontSize: 16),
+                textAlign: TextAlign.right,
+              ),
             ),
-          ),
-        )
-      ]),
+          )
+        ]),
+      ),
       globalFooter: const SizedBox(
         height: 30.0,
       ),

--- a/lib/ui/view/stage/popo_play_view.dart
+++ b/lib/ui/view/stage/popo_play_view.dart
@@ -212,16 +212,16 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
 
     if (similarity == null) {
       scoreText = "";
-    } else if (similarity < -1) {
+    } else if (similarity < 0.3) {
       scoreText = "Bad";
       scoreNeonColor = Colors.red;
-    } else if (similarity < 0.4) {
+    } else if (similarity < 0.5) {
       scoreText = "Good";
       scoreNeonColor = AppColor.purpleColor2;
-    } else if (similarity < 0.6) {
+    } else if (similarity < 0.7) {
       scoreText = "Great";
       scoreNeonColor = AppColor.greenColor;
-    } else if (similarity < 0.8) {
+    } else if (similarity < 0.9) {
       scoreText = "Excellent";
       scoreNeonColor = AppColor.blueColor2;
     } else if (similarity <= 1.0) {
@@ -245,14 +245,14 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     )
         .animate(key: Key(key.toString()))
         .fadeIn()
+        .animate(key: Key(key.toString()), delay: 100.ms)
         .scale(
             duration: 200.ms,
             begin: const Offset(0.9, 0.9),
             end: const Offset(1, 1))
-        .animate(delay: 200.ms)
+        .animate(key: Key(key.toString()), delay: 300.ms)
         .shake(curve: Curves.bounceIn)
-        .fadeOut(
-          duration: 300.ms,
-        );
+        .animate(key: Key(key.toString()), delay: 900.ms)
+        .fadeOut();
   }
 }

--- a/lib/ui/view/stage/popo_play_view.dart
+++ b/lib/ui/view/stage/popo_play_view.dart
@@ -7,6 +7,7 @@ import 'package:pocket_pose/data/remote/provider/stage_provider_impl.dart';
 import 'package:pocket_pose/domain/entity/stage_player_list_item.dart';
 import 'package:pocket_pose/ui/view/stage/ml_kit_camera_play_view.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 // ml_kit_skeleton_custom_view
 class PoPoPlayView extends StatefulWidget {
@@ -90,7 +91,9 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
                   widget.players[0].profileImg,
                   widget.players[0].nickname,
                   context.select<SocketStageProviderImpl, double?>(
-                      (provider) => provider.midScores?[0].similarity)),
+                      (provider) => provider.midScores?[0].similarity),
+                  context.select<SocketStageProviderImpl, int>(
+                      (provider) => provider.midScoreKey)),
             ],
           ),
         );
@@ -107,12 +110,16 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
                   widget.players[1].profileImg,
                   widget.players[1].nickname,
                   context.select<SocketStageProviderImpl, double?>(
-                      (provider) => provider.midScores?[1].similarity)),
+                      (provider) => provider.midScores?[1].similarity),
+                  context.select<SocketStageProviderImpl, int>(
+                      (provider) => provider.midScoreKey)),
               getProfile(
                   widget.players[0].profileImg,
                   widget.players[0].nickname,
                   context.select<SocketStageProviderImpl, double?>(
-                      (provider) => provider.midScores?[0].similarity)),
+                      (provider) => provider.midScores?[0].similarity),
+                  context.select<SocketStageProviderImpl, int>(
+                      (provider) => provider.midScoreKey)),
             ],
           ),
         );
@@ -128,17 +135,23 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
                   widget.players[1].profileImg,
                   widget.players[1].nickname,
                   context.select<SocketStageProviderImpl, double?>(
-                      (provider) => provider.midScores?[1].similarity)),
+                      (provider) => provider.midScores?[1].similarity),
+                  context.select<SocketStageProviderImpl, int>(
+                      (provider) => provider.midScoreKey)),
               getProfile(
                   widget.players[0].profileImg,
                   widget.players[0].nickname,
                   context.select<SocketStageProviderImpl, double?>(
-                      (provider) => provider.midScores?[0].similarity)),
+                      (provider) => provider.midScores?[0].similarity),
+                  context.select<SocketStageProviderImpl, int>(
+                      (provider) => provider.midScoreKey)),
               getProfile(
                   widget.players[2].profileImg,
                   widget.players[2].nickname,
                   context.select<SocketStageProviderImpl, double?>(
-                      (provider) => provider.midScores?[2].similarity)),
+                      (provider) => provider.midScores?[2].similarity),
+                  context.select<SocketStageProviderImpl, int>(
+                      (provider) => provider.midScoreKey)),
             ],
           ),
         );
@@ -147,7 +160,8 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
     }
   }
 
-  Column getProfile(String? profileImg, String nickName, double? score) {
+  Widget getProfile(
+      String? profileImg, String nickName, double? score, int key) {
     return Column(
       children: [
         ClipRRect(
@@ -187,12 +201,12 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
         const SizedBox(
           height: 8,
         ),
-        getScoreNeonText(score),
+        getScoreNeonText(score, key),
       ],
     );
   }
 
-  Widget getScoreNeonText(double? similarity) {
+  Widget getScoreNeonText(double? similarity, int key) {
     String scoreText = "";
     Color scoreNeonColor = Colors.transparent;
 
@@ -228,6 +242,13 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
           ],
         ),
       ),
-    );
+    )
+        .animate(key: Key(key.toString()))
+        .scale(
+            duration: 200.ms,
+            begin: const Offset(0.9, 0.9),
+            end: const Offset(1, 1))
+        .animate(delay: 200.ms)
+        .shake(curve: Curves.bounceIn);
   }
 }

--- a/lib/ui/view/stage/popo_play_view.dart
+++ b/lib/ui/view/stage/popo_play_view.dart
@@ -244,11 +244,15 @@ class _PoPoPlayViewState extends State<PoPoPlayView> {
       ),
     )
         .animate(key: Key(key.toString()))
+        .fadeIn()
         .scale(
             duration: 200.ms,
             begin: const Offset(0.9, 0.9),
             end: const Offset(1, 1))
         .animate(delay: 200.ms)
-        .shake(curve: Curves.bounceIn);
+        .shake(curve: Curves.bounceIn)
+        .fadeOut(
+          duration: 300.ms,
+        );
   }
 }

--- a/lib/ui/view/stage/popo_result_view.dart
+++ b/lib/ui/view/stage/popo_result_view.dart
@@ -95,8 +95,10 @@ class _PoPoResultViewState extends State<PoPoResultView> {
                       index < _socketStageProvider.playerInfos.length;
                       index++)
                     StageResultPlayerInfoWidget(
-                        player: _socketStageProvider.playerInfos[index],
-                        index: index)
+                      player: _socketStageProvider.playerInfos[index],
+                      index: index,
+                      playerLength: _socketStageProvider.playerInfos.length,
+                    )
                 ],
               ),
             ],

--- a/lib/ui/view/stage/popo_wait_view.dart
+++ b/lib/ui/view/stage/popo_wait_view.dart
@@ -1,9 +1,6 @@
 import 'package:assets_audio_player/assets_audio_player.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:pocket_pose/data/entity/socket_request/send_skeleton_request.dart';
-import 'package:pocket_pose/data/remote/provider/socket_stage_provider_impl.dart';
-import 'package:provider/provider.dart';
 
 class PoPoWaitView extends StatefulWidget {
   const PoPoWaitView({Key? key}) : super(key: key);
@@ -14,7 +11,6 @@ class PoPoWaitView extends StatefulWidget {
 
 class _PoPoWaitViewState extends State<PoPoWaitView> {
   AssetsAudioPlayer? _assetsAudioPlayer;
-  late SocketStageProviderImpl _socketStageProvider;
 
   @override
   Widget build(BuildContext context) {
@@ -30,17 +26,10 @@ class _PoPoWaitViewState extends State<PoPoWaitView> {
             mainAxisSize: MainAxisSize.min,
             children: [
               const SizedBox(height: 80.0),
-              InkWell(
-                onTap: () {
-                  var resuest = SendSkeletonRequest(
-                      playerNum: 0, frameNum: 1, skeleton: {});
-                  _socketStageProvider.sendPlaySkeleton(resuest);
-                },
-                child: const Text(
-                  "대기중...",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 40, color: Colors.white),
-                ),
+              const Text(
+                "대기중...",
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 40, color: Colors.white),
               ),
               const SizedBox(height: 20.0),
               const Text(
@@ -70,8 +59,6 @@ class _PoPoWaitViewState extends State<PoPoWaitView> {
 
   @override
   void initState() {
-    _socketStageProvider =
-        Provider.of<SocketStageProviderImpl>(context, listen: false);
     _assetsAudioPlayer = AssetsAudioPlayer();
     _assetsAudioPlayer?.open(Audio("assets/audios/sound_stage_wait.mp3"));
     super.initState();

--- a/lib/ui/widget/stage/stage_result_player_info_widget.dart
+++ b/lib/ui/widget/stage/stage_result_player_info_widget.dart
@@ -21,21 +21,42 @@ class StageResultPlayerInfoWidget extends StatelessWidget {
       child: (index == 0)
           //  mvp면 테두리 네온 추가
           ? Container(
-              decoration: BoxDecoration(
-                  border: Border.all(
-                      color: Colors.white,
-                      width: 1.0,
-                      style: BorderStyle.solid),
-                  borderRadius: BorderRadius.circular(15),
-                  boxShadow: [
-                    for (double i = 1; i < 5; i++)
-                      BoxShadow(
-                          color: AppColor.yellowColor,
-                          blurStyle: BlurStyle.outer,
-                          blurRadius: 3 * i)
-                  ]),
-              child: _buildPlayerInfoWidget(player, index))
-          : _buildPlayerInfoWidget(player, index),
+                  decoration: BoxDecoration(
+                      border: Border.all(
+                          color: Colors.white,
+                          width: 1.0,
+                          style: BorderStyle.solid),
+                      borderRadius: BorderRadius.circular(15),
+                      boxShadow: [
+                        for (double i = 1; i < 5; i++)
+                          BoxShadow(
+                              color: AppColor.yellowColor,
+                              blurStyle: BlurStyle.outer,
+                              blurRadius: 3 * i)
+                      ]),
+                  child: _buildPlayerInfoWidget(player, index))
+              .animate(
+                  delay:
+                      (1000 * playerLength - 1000 * (playerLength - index + 1))
+                          .ms)
+              .shimmer(duration: 1200.ms, color: AppColor.grayColor2)
+              .animate(
+                  delay:
+                      (1000 * playerLength - 1000 * (playerLength - index + 1))
+                          .ms)
+              .scale(begin: const Offset(0.8, 0.8))
+          : _buildPlayerInfoWidget(player, index)
+              .animate(
+                  delay:
+                      (1000 * playerLength - 1000 * (playerLength - index + 1))
+                          .ms)
+              .shimmer(duration: 1200.ms, color: AppColor.grayColor2)
+              .animate(
+                  delay:
+                      (1000 * playerLength - 1000 * (playerLength - index + 1))
+                          .ms)
+              .fadeIn(duration: 1200.ms, curve: Curves.fastOutSlowIn)
+              .slide(),
     );
   }
 
@@ -145,11 +166,6 @@ class StageResultPlayerInfoWidget extends StatelessWidget {
           ),
         ),
       ),
-    )
-        .animate(delay: (1000 * playerLength - 1000 * (index + 1)).ms)
-        .shimmer(duration: 1200.ms, color: AppColor.grayColor2)
-        .animate(delay: (1000 * playerLength - 1000 * (index + 1)).ms)
-        .fadeIn(duration: 1200.ms, curve: Curves.fastOutSlowIn)
-        .slide();
+    );
   }
 }

--- a/lib/ui/widget/stage/stage_result_player_info_widget.dart
+++ b/lib/ui/widget/stage/stage_result_player_info_widget.dart
@@ -6,9 +6,13 @@ import 'package:flutter_animate/flutter_animate.dart';
 
 class StageResultPlayerInfoWidget extends StatelessWidget {
   const StageResultPlayerInfoWidget(
-      {super.key, required this.player, required this.index});
+      {super.key,
+      required this.player,
+      required this.index,
+      required this.playerLength});
   final StagePlayerInfoListItem player;
   final int index;
+  final int playerLength;
 
   @override
   Widget build(BuildContext context) {
@@ -142,9 +146,9 @@ class StageResultPlayerInfoWidget extends StatelessWidget {
         ),
       ),
     )
-        .animate()
+        .animate(delay: (1000 * playerLength - 1000 * (index + 1)).ms)
         .shimmer(duration: 1200.ms, color: AppColor.grayColor2)
-        .animate()
+        .animate(delay: (1000 * playerLength - 1000 * (index + 1)).ms)
         .fadeIn(duration: 1200.ms, curve: Curves.fastOutSlowIn)
         .slide();
   }

--- a/lib/ui/widget/stage/stage_result_player_info_widget.dart
+++ b/lib/ui/widget/stage/stage_result_player_info_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pocket_pose/config/app_color.dart';
 import 'package:pocket_pose/domain/entity/stage_player_info_list_item.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 class StageResultPlayerInfoWidget extends StatelessWidget {
   const StageResultPlayerInfoWidget(
@@ -140,6 +141,11 @@ class StageResultPlayerInfoWidget extends StatelessWidget {
           ),
         ),
       ),
-    );
+    )
+        .animate()
+        .shimmer(duration: 1200.ms, color: AppColor.grayColor2)
+        .animate()
+        .fadeIn(duration: 1200.ms, curve: Curves.fastOutSlowIn)
+        .slide();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -502,6 +502,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_animate:
+    dependency: "direct main"
+    description:
+      name: flutter_animate
+      sha256: "62f346340a96192070e31e3f2a1bd30a28530f1fe8be978821e06cd56b74d6d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0+1"
   flutter_dotenv:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,8 +57,9 @@ dependencies:
   flutter_local_notifications: ^15.1.1
   flutter_screen_recording: ^2.0.9
   video_thumbnail: ^0.5.3
-  flutter_foreground_task: ^6.1.1 
+  flutter_foreground_task: ^6.1.1
   flutter_dotenv: ^5.1.0
+  flutter_animate: ^4.2.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📱 작업 사진 
- 용량이 커서 [슬랙](https://hatch2023.slack.com/archives/C04GGGQ3DDM/p1696310749269929)에 올리겠습니다.

## 💬 작업 설명
- 스테이지 플레이 시 중간 점수 애니메이션을 추가했습니다.
- 스테이지 mvp화면의 사용자 정보 위젯에 애니메이션을 추가했습니다.

## ✅ 한 일
1. 스테이지 플레이: 중간 점수 애니메이션, 결과: 등수 애니메이션
2. 온보딩 화면별 대응

## ☝️ 참고 하세요~
1. 온보딩 화면 기기 크기별로 ui 만들게 한 건데도 오류 나는 거라 원래는 스크롤 안 되게 하려고 했는데 오류나는 경우 스크롤 되도록 했습니다. 특정 기기를 위해 ui를 줄이는 것보다 대부분 기기에서 ui가 예쁘게 보이는 게 좋을 거 같아서 이렇게 했습니다!

## 🤓 다음에 할 일
1. 리팩토링
