### PR TITLE
[refactor] 채팅 상세 사용자 프로필 에러 처리

### DIFF
--- a/lib/config/fcm/notification_service.dart
+++ b/lib/config/fcm/notification_service.dart
@@ -100,17 +100,6 @@ class NotificationService {
   }
 }
 
-void onDidReceiveBackgroundNotificationResponse(details) {
-  if (details.payload != null) {
-    try {
-      Map<String, dynamic> notificationPayload = jsonDecode(details.payload!);
-      setNotificationHandler(notificationPayload);
-    } catch (error) {
-      debugPrint('mmm Notification payload error $error');
-    }
-  }
-}
-
 void onDidReceiveNotificationResponse(details) async {
   if (details.payload != null) {
     try {

--- a/lib/ui/widget/chat/chat_detail_left_bubble_widget.dart
+++ b/lib/ui/widget/chat/chat_detail_left_bubble_widget.dart
@@ -65,8 +65,21 @@ class ChatDetailLeftBubbleWidget extends StatelessWidget {
                         : Image.network(
                             chatDetail.sender.profileImg!,
                             fit: BoxFit.cover,
-                            width: 45,
-                            height: 45,
+                            width: 40,
+                            height: 40,
+                            loadingBuilder: (context, child, loadingProgress) {
+                              if (loadingProgress == null) return child;
+                              return Center(
+                                child: CircularProgressIndicator(
+                                  color: AppColor.purpleColor,
+                                ),
+                              );
+                            },
+                            errorBuilder: (context, error, stackTrace) =>
+                                Image.asset(
+                              'assets/images/charactor_popo_default.png',
+                              fit: BoxFit.cover,
+                            ),
                           ),
                   ),
                 )


### PR DESCRIPTION
## 📱 작업 사진 
x

## 💬 작업 설명
- 채팅 상세 사용자 프로필 에러 처리만 했습니다~(분명히 전에 추가한 거 같은데 왜...)

## ✅ 한 일
1. 채팅 상세 사용자 프로필 에러 처리 

## 🔧 보완할 점
1. fcm terminated 상태일 때 redirection 처리: 코드는 추가했는데 동작을 안 하네요...🥲
2. 스테이지 대기-캐치-플레이-결과 화면 전환 시 키보드 포커스 유지: 원래는 안 좋은 방법이라 강제로 처리할 수 밖에 없나본데... 강제로 처리해봐도 화면 전환 시 키보드 사라지는 건 똑같아서(이후에 다시 올라오긴 함...) 원래대로 바꿨습니다.🥲

## ☝️ 참고 하세요~
1. 시연 때 곡 하나만 하려고 해서 어떤 곡을 정할지 현재 4곡(나문희의 첫사랑, 마카레나, 퀸카, 미투) 중에 고르고 있습니다. 따라서 스테이지도 이 4곡만 나오고 있습니다. 테스트 더 해보고 이 중 하나를 고를 예정입니다~
